### PR TITLE
fix: align import/export with v11 schema and add pre-import backup

### DIFF
--- a/docs/excel-import-guide.md
+++ b/docs/excel-import-guide.md
@@ -2,18 +2,19 @@
 
 > **Note**: This Excel import script is a **temporary migration tool** for users moving from Excel-based planning to the app's native system. Once you've imported your historical data, use the app's built-in export/import feature (DataManagement component) for all future backups and data transfers.
 
-## What's New in V10
+## What's New in V11
 
-The import script now generates v10 format backups with these improvements:
+The import script now generates v11 format backups with these improvements:
 
 - **Unified Areas System**: All beds, permanent plantings, and infrastructure are now represented as a single `Area` type with different kinds (rotation-bed, perennial-bed, tree, berry, herb, infrastructure)
 - **Grid Positions**: Each area includes grid position data for proper visual layout
 - **Season Structure**: Seasons now use `areas` array instead of legacy `beds` array
 - **Type Safety**: Stronger typing with AreaKind discriminator instead of separate types
+- **Singular Plant IDs**: Plant IDs now use singular form (pea not peas, broad-bean not broad-beans) for consistency
 
 ## Overview
 
-Convert your Excel planning workbook to the app's native v10 backup format with unified areas system, then import it through the existing import/export interface.
+Convert your Excel planning workbook to the app's native v11 backup format with unified areas system, then import it through the existing import/export interface.
 
 ## Prerequisites
 
@@ -73,7 +74,7 @@ This creates a JSON file in the same format as the app's export function, contai
 - Sowing, transplant, and harvest dates
 - Variety names linked to plantings
 
-### V10 Unified Areas System
+### V11 Unified Areas System
 - **Areas**: All beds converted to unified Area type with kind (rotation-bed, perennial-bed)
 - **Grid Positions**: Default layout positions included for proper display
 - **Rotation Groups**: Inferred from plant types in historical data
@@ -97,14 +98,14 @@ The script includes mappings for 50+ common plant names. If you see warnings abo
 2. Re-run the conversion
 3. Check plant IDs match those in `src/lib/vegetable-database.ts`
 
-## Backup Format (V10)
+## Backup Format (V11)
 
-The output matches the app's v10 export format exactly:
+The output matches the app's v11 export format exactly:
 
 ```json
 {
   "allotment": {
-    "version": 10,
+    "version": 11,
     "meta": {
       "name": "My Allotment",
       "location": "Scotland",
@@ -150,7 +151,7 @@ The output matches the app's v10 export format exactly:
     "meta": {...}
   },
   "exportedAt": "2026-01-11T12:00:00Z",
-  "exportVersion": 10
+  "exportVersion": 11
 }
 ```
 

--- a/docs/research/import-export-alignment-review.md
+++ b/docs/research/import-export-alignment-review.md
@@ -1,0 +1,224 @@
+# Import/Export Alignment Review
+
+**Date**: 2026-01-18
+**Status**: Completed
+
+## Executive Summary
+
+This document reviews the alignment between data structures and import/export functionality, identifies issues, documents fixes made, and analyzes the feasibility of partial migrations.
+
+## Current Architecture
+
+### Data Storage
+
+The app uses two localStorage keys for data:
+
+1. **`allotment-unified-data`** (STORAGE_KEY)
+   - Contains: `AllotmentData` (v11 schema)
+   - Includes: areas, seasons, plantings, varieties, events, tasks
+
+2. **`community-allotment-varieties`** (VARIETY_STORAGE_KEY)
+   - Contains: `VarietyData` (v2 schema)
+   - Used by: Seeds page, useVarieties hook
+   - Synchronized: Auto-sync when plantings added via `variety-allotment-sync.ts`
+
+### Export Format
+
+```typescript
+interface CompleteExport {
+  allotment: AllotmentData      // v11 schema
+  varieties: VarietyData        // v2 schema (separate for Seeds page)
+  exportedAt: string
+  exportVersion: number         // CURRENT_SCHEMA_VERSION (11)
+}
+```
+
+### Import Flow
+
+1. Parse JSON file
+2. **NEW**: Create pre-import backup (safety measure)
+3. Detect format (new vs old)
+4. Merge `varieties.varieties` into `allotmentData.varieties`
+5. Save to localStorage
+6. Trigger UI reload
+
+## Issues Identified & Fixed
+
+### Issue 1: Excel Script Generated v10, App is v11
+
+**Problem**: The `scripts/excel-to-backup.py` generated v10 format with plural plant IDs (peas, onions), but the app's v11 schema uses singular IDs (pea, onion).
+
+**Fix Applied**:
+- Updated PLANT_MAPPINGS to use singular plant IDs
+- Updated version numbers to 11
+- Updated infer_rotation_group() to use singular IDs
+- Updated documentation in `docs/excel-import-guide.md`
+
+### Issue 2: No Pre-Import Backup
+
+**Problem**: Documentation promised "automatic backup before import" but code didn't implement it.
+
+**Fix Applied**:
+- Added `createPreImportBackup()` function in DataManagement.tsx
+- Creates backup with key `allotment-unified-data-pre-import-{timestamp}`
+- Called before every import operation
+
+### Issue 3: Documentation Out of Date
+
+**Problem**: `excel-import-guide.md` referenced v10 format.
+
+**Fix Applied**: Updated all v10 references to v11 throughout the document.
+
+## Architecture Decision: Dual Variety Storage
+
+The current architecture maintains varieties in two places:
+1. Inside `AllotmentData.varieties` (exported/imported together)
+2. Separate `community-allotment-varieties` storage (for Seeds page)
+
+**Why keep both?**
+- Seeds page can work independently without loading full allotment data
+- Sync happens via `variety-allotment-sync.ts` when plantings added
+- Export combines both, import merges them back
+
+**Recommendation**: Keep current architecture. The separation provides good UX for the Seeds page while maintaining data consistency through the sync mechanism.
+
+## Partial Migration Feasibility Analysis
+
+The user asked about implementing partial imports for:
+1. Only seeds (varieties)
+2. Only plot structure (layout.areas)
+3. Only specific years (seasons)
+
+### Complexity Assessment
+
+| Feature | Complexity | Effort | Risk |
+|---------|------------|--------|------|
+| Seeds only | Low | 2-4 hours | Low |
+| Layout only | Medium | 4-8 hours | Medium |
+| Specific years | High | 8-16 hours | High |
+
+### 1. Seeds Only Import (Low Complexity)
+
+**Implementation**:
+```typescript
+interface PartialImportOptions {
+  importSeeds: true
+}
+```
+
+**Steps**:
+1. Parse backup file
+2. Extract `varieties.varieties` array
+3. Merge with existing varieties (by ID or plantId+name)
+4. Save to variety storage
+5. Optionally update AllotmentData.varieties
+
+**Considerations**:
+- Simple merge logic (replace or append)
+- No dependencies on other data
+- Can preserve existing variety customizations
+
+### 2. Layout Only Import (Medium Complexity)
+
+**Implementation**:
+```typescript
+interface PartialImportOptions {
+  importLayout: true
+  backfillSeasons?: boolean  // Create AreaSeason for new areas
+}
+```
+
+**Steps**:
+1. Parse backup file
+2. Extract `allotment.layout.areas` array
+3. Merge with existing areas (by ID)
+4. If backfillSeasons, create AreaSeason entries for existing years
+5. Handle area conflicts (same ID, different data)
+
+**Considerations**:
+- Grid positions may conflict with existing layout
+- New areas need AreaSeason entries for existing years
+- Removed areas may have orphaned season data
+
+### 3. Specific Years Import (High Complexity)
+
+**Implementation**:
+```typescript
+interface PartialImportOptions {
+  importSeasons: number[]  // e.g., [2024, 2025]
+  mergeMode: 'replace' | 'merge'
+}
+```
+
+**Steps**:
+1. Parse backup file
+2. Extract specified years from `allotment.seasons`
+3. For each year:
+   - Match AreaSeason to existing areas (by areaId)
+   - Handle missing areas (skip or warn)
+   - Merge or replace plantings
+4. Update timestamps
+
+**Considerations**:
+- Area IDs must match between import and existing data
+- Plantings may reference varieties that don't exist
+- Rotation groups may conflict
+- Historical data integrity concerns
+
+### Recommended Approach
+
+**Phase 1**: Implement Seeds-only import (low risk, high value)
+- Add checkbox in DataManagement: "Import seeds only"
+- Merge varieties without touching allotment data
+
+**Phase 2**: Implement selective year import (if needed)
+- Add year selector showing available years in backup
+- Warn about area mismatches
+- Default to merge mode with conflict detection
+
+**Phase 3**: Layout import (only if requested)
+- Most complex due to visual positioning
+- May require manual grid adjustment
+
+### UI Design for Partial Import
+
+```
+┌─────────────────────────────────────────┐
+│ Import Options                           │
+├─────────────────────────────────────────┤
+│ ○ Full restore (replace all data)       │
+│ ○ Partial import                         │
+│   ┌─────────────────────────────────┐   │
+│   │ ☐ Seed varieties                 │   │
+│   │ ☐ Plot layout                    │   │
+│   │ ☐ Seasons:                       │   │
+│   │   ☐ 2024  ☐ 2025  ☐ 2026        │   │
+│   └─────────────────────────────────┘   │
+│                                          │
+│ [Preview Changes] [Import]               │
+└─────────────────────────────────────────┘
+```
+
+## Files Modified
+
+1. `scripts/excel-to-backup.py` - Updated to v11 format with singular plant IDs
+2. `src/components/allotment/DataManagement.tsx` - Added pre-import backup
+3. `docs/excel-import-guide.md` - Updated v10 references to v11
+
+## Testing
+
+- All 238 unit tests pass
+- TypeScript type-check passes
+- No breaking changes to existing import/export flow
+
+## Recommendations
+
+1. **Keep current architecture**: The dual variety storage provides good separation of concerns
+
+2. **Implement seeds-only import**: Low effort, high value for users managing seed inventory separately
+
+3. **Add import preview**: Before importing, show what will change (areas added/removed, seasons affected)
+
+4. **Add backup management UI**: Allow users to see and restore pre-import backups
+
+5. **Consider selective export**: Export only specific years or just seeds for sharing

--- a/scripts/excel-to-backup.py
+++ b/scripts/excel-to-backup.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 """
-TEMPORARY MIGRATION TOOL - Convert Excel Workbook to App Backup Format (v10)
+TEMPORARY MIGRATION TOOL - Convert Excel Workbook to App Backup Format (v11)
 
 This script is a one-time migration tool for users moving from Excel-based
 planning to the app's native system. After migrating, use the app's built-in
 export/import feature (DataManagement component) for backups.
 
-Converts Allotment Planning Workbook to v10 backup format with unified areas.
+Converts Allotment Planning Workbook to v11 backup format with unified areas.
 Outputs the same format as the app's export function.
 
-Updated for v10 unified areas system:
-- Uses 'areas' array instead of separate beds/permanentPlantings/infrastructure
-- Seasons use 'areas' instead of 'beds'
-- Includes gridPosition for layout
-- All areas are AreaKind type (rotation-bed, perennial-bed, etc.)
+v11 format features:
+- Unified 'areas' array (rotation-bed, perennial-bed, tree, berry, herb, infrastructure)
+- Seasons use 'areas' array for per-year plantings
+- Includes gridPosition for visual layout
+- Singular plant IDs (pea not peas, broad-bean not broad-beans)
 
 Usage: python3 excel-to-backup.py <excel-file> <output-json>
 
@@ -27,14 +27,19 @@ import sys
 from datetime import datetime
 
 # Plant name mappings from Excel to database IDs
+# v11: Use singular form for plant IDs (pea not peas, bean not beans)
 PLANT_MAPPINGS = {
-    'peas': 'peas',
-    'pea': 'peas',
-    'beans': 'broad-beans',
-    'beans & peas': 'broad-beans',
-    'broad bean \'ratio\'': 'broad-beans',
-    'french beans': 'french-beans',
-    'french borlotti stokkievitsboon': 'french-beans',
+    'peas': 'pea',
+    'pea': 'pea',
+    'beans': 'broad-bean',
+    'beans & peas': 'broad-bean',
+    'broad bean \'ratio\'': 'broad-bean',
+    'broad beans': 'broad-bean',
+    'french beans': 'french-bean',
+    'french bean': 'french-bean',
+    'french borlotti stokkievitsboon': 'french-bean',
+    'runner beans': 'runner-bean',
+    'runner bean': 'runner-bean',
     'onions': 'onion',
     'onion': 'onion',
     'onion electric (red autumn)': 'onion',
@@ -42,9 +47,10 @@ PLANT_MAPPINGS = {
     'white senshyn': 'onion',
     'red electric': 'onion',
     'onion \'centurion\'': 'onion',
-    'spring onion \'lilia\'': 'spring-onions',
-    'spring onion parade (organic)': 'spring-onions',
-    'onion (spring) keravel pink': 'spring-onions',
+    'spring onion \'lilia\'': 'spring-onion',
+    'spring onion parade (organic)': 'spring-onion',
+    'spring onions': 'spring-onion',
+    'onion (spring) keravel pink': 'spring-onion',
     'potatoes': 'potato',
     'potato': 'potato',
     'potatoes (early)': 'potato',
@@ -287,18 +293,18 @@ def main():
 
     # Infer rotation groups
     def infer_rotation_group(plantings):
-        # Simple mapping based on plantId
+        # Simple mapping based on plantId (v11: uses singular form)
         group_counts = {}
         for p in plantings:
             pid = p['plantId']
             # Simplified rotation group inference
-            if pid in ['peas', 'broad-beans', 'french-beans', 'runner-beans']:
+            if pid in ['pea', 'broad-bean', 'french-bean', 'runner-bean']:
                 group = 'legumes'
-            elif pid in ['cabbage', 'kale', 'broccoli', 'cauliflower', 'brussels-sprouts']:
+            elif pid in ['cabbage', 'kale', 'broccoli', 'cauliflower', 'brussels-sprout']:
                 group = 'brassicas'
             elif pid in ['carrot', 'beetroot', 'parsnip', 'potato', 'turnip']:
                 group = 'roots'
-            elif pid in ['onion', 'garlic', 'leek', 'spring-onions', 'shallot']:
+            elif pid in ['onion', 'garlic', 'leek', 'spring-onion', 'shallot']:
                 group = 'alliums'
             elif pid in ['courgette', 'pumpkin', 'squash', 'cucumber', 'melon']:
                 group = 'cucurbits'
@@ -395,10 +401,10 @@ def main():
             'updatedAt': now
         })
 
-    # Build complete backup format (v10)
+    # Build complete backup format (v11)
     output = {
         'allotment': {
-            'version': 10,  # Updated to v10
+            'version': 11,  # Updated to v11 - uses singular plant IDs
             'meta': {
                 'name': 'My Allotment',
                 'location': 'Scotland',
@@ -423,7 +429,7 @@ def main():
             }
         },
         'exportedAt': now,
-        'exportVersion': 10  # Updated to v10
+        'exportVersion': 11  # Updated to v11 - uses singular plant IDs
     }
 
     with open(output_file, 'w') as f:


### PR DESCRIPTION
- Update excel-to-backup.py to generate v11 format with singular plant IDs
- Add createPreImportBackup() before import to prevent accidental data loss
- Update docs/excel-import-guide.md to reflect v11 changes
- Add comprehensive research doc on import/export alignment and partial migrations