### PR TITLE
fix: GitHub Pages deployment - add force-static manifest

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,12 +1,18 @@
 import type { MetadataRoute } from "next";
 
+// Required for static export (GitHub Pages)
+export const dynamic = "force-static";
+
 export default function manifest(): MetadataRoute.Manifest {
+  // Use basePath for GitHub Pages deployment
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
   return {
     name: "Bonnie Wee Plot",
     short_name: "Bonnie Plot",
     description:
       "Plan your Scottish garden, track plantings across seasons, and get AI-powered growing advice for our climate",
-    start_url: "/",
+    start_url: `${basePath}/`,
     display: "standalone",
     background_color: "#f9fafb",
     theme_color: "#5c6e49",
@@ -14,19 +20,19 @@ export default function manifest(): MetadataRoute.Manifest {
     categories: ["lifestyle", "productivity"],
     icons: [
       {
-        src: "/icons/icon-192x192.png",
+        src: `${basePath}/icons/icon-192x192.png`,
         sizes: "192x192",
         type: "image/png",
         purpose: "any",
       },
       {
-        src: "/icons/icon-512x512.png",
+        src: `${basePath}/icons/icon-512x512.png`,
         sizes: "512x512",
         type: "image/png",
         purpose: "any",
       },
       {
-        src: "/icons/icon-maskable-512x512.png",
+        src: `${basePath}/icons/icon-maskable-512x512.png`,
         sizes: "512x512",
         type: "image/png",
         purpose: "maskable",


### PR DESCRIPTION
## Summary
- Add `export const dynamic = "force-static"` to manifest.ts for static export compatibility
- Update manifest paths (start_url, icons) to include basePath for GitHub Pages

## Problem
GitHub Pages deployment was failing with:
```
Error: export const dynamic = "force-static"/export const revalidate not configured on route "/manifest.webmanifest" with "output: export"
```

## Test Plan
- [ ] CI build passes
- [ ] GitHub Pages deployment succeeds
- [ ] Site loads at https://ismaelmartinez.github.io/bonnie-wee-plot/

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>