### PR TITLE
Fix planting dialog accessibility and state management issues

### DIFF
--- a/src/components/allotment/PlantingCard.tsx
+++ b/src/components/allotment/PlantingCard.tsx
@@ -51,7 +51,7 @@ export default function PlantingCard({
   return (
     <div
       className={`rounded-zen p-3 ${bads.length > 0 ? 'bg-zen-kitsune-50 border border-zen-kitsune-200' : 'bg-zen-stone-50'} ${
-        onClick ? 'cursor-pointer hover:bg-zen-stone-100/50 focus-within:ring-2 focus-within:ring-zen-moss-500 focus-within:ring-offset-2 transition' : ''
+        onClick ? 'cursor-pointer hover:bg-zen-stone-100/50 focus:ring-2 focus:ring-zen-moss-500 focus:ring-offset-2 transition' : ''
       }`}
       onClick={handleCardClick}
       onKeyDown={onClick ? handleKeyDown : undefined}

--- a/src/components/allotment/PlantingDetailDialog.tsx
+++ b/src/components/allotment/PlantingDetailDialog.tsx
@@ -50,7 +50,7 @@ export default function PlantingDetailDialog({
     setLocalTransplantDate(formatDateForInput(planting?.transplantDate))
     setLocalHarvestStart(formatDateForInput(planting?.actualHarvestStart))
     setLocalHarvestEnd(formatDateForInput(planting?.actualHarvestEnd))
-  }, [planting?.notes, planting?.sowDate, planting?.transplantDate, planting?.actualHarvestStart, planting?.actualHarvestEnd])
+  }, [planting?.id, planting?.notes, planting?.sowDate, planting?.transplantDate, planting?.actualHarvestStart, planting?.actualHarvestEnd])
 
   const veg = planting ? getVegetableById(planting.plantId) : null
   const { goods, bads } = planting
@@ -300,8 +300,9 @@ export default function PlantingDetailDialog({
               {(['excellent', 'good', 'fair', 'poor'] as const).map((rating) => (
                 <button
                   key={rating}
+                  type="button"
                   onClick={() => handleSuccessChange(planting.success === rating ? undefined : rating)}
-                  className={`px-4 py-2.5 min-h-[44px] text-sm rounded-zen capitalize transition ${
+                  className={`px-4 py-2.5 min-h-[44px] min-w-[44px] text-sm rounded-zen capitalize transition ${
                     planting.success === rating
                       ? rating === 'excellent'
                         ? 'bg-zen-moss-600 text-white'
@@ -334,6 +335,7 @@ export default function PlantingDetailDialog({
 
           <section className="pt-4 border-t border-zen-stone-200">
             <button
+              type="button"
               onClick={() => setShowDeleteConfirm(true)}
               className="w-full flex items-center justify-center gap-2 px-4 py-3 min-h-[44px] text-zen-ume-600 border border-zen-ume-200 rounded-zen hover:bg-zen-ume-50 transition"
             >


### PR DESCRIPTION
## Summary

Address code review feedback from PR #68 to improve accessibility, touch target consistency, and state management reliability in the PlantingDetailDialog component.

## Changes

- **Button type attributes**: Add explicit `type="button"` to delete button and success rating buttons to prevent unintended form submissions if the dialog is ever wrapped in a form context
- **Touch target consistency**: Add `min-w-[44px]` to success rating buttons to ensure consistent square-ish touch targets alongside `min-h-[44px]`
- **Focus styling**: Fix focus ring styling by changing `focus-within:ring-2` to `focus:ring-2` in PlantingCard to only show focus when the card itself is focused, not when nested elements are focused (reduces confusing dual focus states)
- **State management**: Add `planting?.id` to useEffect dependency array to ensure local state syncs when switching between different plantings

## Test Plan

- [x] Production build passes
- [x] All 385 unit tests pass
- [x] Buttons properly typed as buttons
- [x] Focus ring styling improved for accessibility
- [x] Dialog state properly syncs when switching plantings

🤖 Generated with [Claude Code](https://claude.com/claude-code)