### PR TITLE
feat: add 'had' seed status and remove available checkbox

### DIFF
--- a/src/app/seeds/page.tsx
+++ b/src/app/seeds/page.tsx
@@ -9,6 +9,7 @@ import {
   ExternalLink,
   Package,
   Check,
+  CheckCheck,
   ShoppingCart,
   AlertTriangle,
   Plus,
@@ -38,7 +39,8 @@ function getNextStatus(current: SeedStatus): SeedStatus {
   const cycle: Record<SeedStatus, SeedStatus> = {
     'none': 'ordered',
     'ordered': 'have',
-    'have': 'none'
+    'have': 'had',
+    'had': 'none'
   }
   return cycle[current]
 }
@@ -59,6 +61,11 @@ const statusConfig: Record<SeedStatus, { label: string; icon: LucideIcon; classN
     label: 'Have',
     icon: Check,
     className: 'bg-zen-moss-100 text-zen-moss-700 hover:bg-zen-moss-200'
+  },
+  'had': {
+    label: 'Had',
+    icon: CheckCheck,
+    className: 'bg-zen-stone-200 text-zen-stone-600 hover:bg-zen-stone-300'
   }
 }
 

--- a/src/components/seeds/VarietyEditDialog.tsx
+++ b/src/components/seeds/VarietyEditDialog.tsx
@@ -5,7 +5,7 @@ import Dialog from '@/components/ui/Dialog'
 import PlantCombobox from '@/components/allotment/PlantCombobox'
 import { VegetableCategory } from '@/types/garden-planner'
 import { StoredVariety, NewVariety, VarietyUpdate, SeedStatus } from '@/types/variety-data'
-import { Check, Package, ShoppingCart } from 'lucide-react'
+import { Check, CheckCheck, Package, ShoppingCart } from 'lucide-react'
 
 interface VarietyEditDialogProps {
   isOpen: boolean
@@ -31,7 +31,6 @@ export default function VarietyEditDialog({
   const [supplier, setSupplier] = useState('')
   const [price, setPrice] = useState('')
   const [notes, setNotes] = useState('')
-  const [available, setAvailable] = useState(true)
   const [categoryFilter, setCategoryFilter] = useState<VegetableCategory | 'all'>('all')
   const [seedStatusForYear, setSeedStatusForYear] = useState<SeedStatus | null>(null)
 
@@ -46,7 +45,6 @@ export default function VarietyEditDialog({
       setSupplier(variety.supplier || '')
       setPrice(variety.price?.toString() || '')
       setNotes(variety.notes || '')
-      setAvailable(variety.available ?? true)
       // Load existing seed status for the selected year
       if (yearToTrack && variety.seedsByYear?.[yearToTrack]) {
         setSeedStatusForYear(variety.seedsByYear[yearToTrack])
@@ -64,7 +62,6 @@ export default function VarietyEditDialog({
     setSupplier('')
     setPrice('')
     setNotes('')
-    setAvailable(true)
     setSeedStatusForYear(null)
   }
 
@@ -106,7 +103,6 @@ export default function VarietyEditDialog({
         supplier: supplier.trim() || undefined,
         price: parsedPrice,
         notes: notes.trim() || undefined,
-        available,
         seedsByYear,
       }
       onSave(newVariety)
@@ -118,7 +114,6 @@ export default function VarietyEditDialog({
         supplier: supplier.trim() || undefined,
         price: parsedPrice,
         notes: notes.trim() || undefined,
-        available,
         seedsByYear,
       }
       onSave(update)
@@ -238,23 +233,6 @@ export default function VarietyEditDialog({
           />
         </div>
 
-        <div>
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={available}
-              onChange={(e) => setAvailable(e.target.checked)}
-              className="w-4 h-4 text-emerald-600 border-gray-300 rounded focus:ring-emerald-500 focus:ring-2"
-            />
-            <span className="text-sm font-medium text-gray-700">
-              Available for planting
-            </span>
-          </label>
-          <p className="text-xs text-gray-500 mt-1 ml-6">
-            When checked, this variety can be selected when adding plantings to any year
-          </p>
-        </div>
-
         {yearToTrack && (
           <div className="border-t border-gray-200 pt-4">
             <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -296,6 +274,18 @@ export default function VarietyEditDialog({
               >
                 <Check className="w-4 h-4" />
                 Have
+              </button>
+              <button
+                type="button"
+                onClick={() => setSeedStatusForYear(seedStatusForYear === 'had' ? null : 'had')}
+                className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition ${
+                  seedStatusForYear === 'had'
+                    ? 'bg-gray-200 text-gray-700 ring-2 ring-gray-500'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                <CheckCheck className="w-4 h-4" />
+                Had
               </button>
             </div>
             <p className="text-xs text-gray-500 mt-2">

--- a/src/services/allotment-storage.ts
+++ b/src/services/allotment-storage.ts
@@ -2652,7 +2652,7 @@ export function togglePlannedYear(
 
 /**
  * Cycle seed status for a variety in a specific year
- * Cycles: none → ordered → have → none
+ * Cycles: none → ordered → have → had → none
  */
 export function toggleHaveSeedsForYear(
   data: AllotmentData,
@@ -2668,7 +2668,8 @@ export function toggleHaveSeedsForYear(
       const next: Record<SeedStatus, SeedStatus> = {
         'none': 'ordered',
         'ordered': 'have',
-        'have': 'none'
+        'have': 'had',
+        'had': 'none'
       }
       const nextState = next[current]
 

--- a/src/types/unified-allotment.ts
+++ b/src/types/unified-allotment.ts
@@ -396,8 +396,12 @@ export type NewGardenEvent = Omit<GardenEvent, 'id' | 'createdAt'>
 
 /**
  * Seed inventory status for a specific year
+ * - none: Need to order seeds
+ * - ordered: Seeds have been ordered
+ * - have: Currently have seeds
+ * - had: Had seeds but used/expired (no longer available)
  */
-export type SeedStatus = 'none' | 'ordered' | 'have'
+export type SeedStatus = 'none' | 'ordered' | 'have' | 'had'
 
 /**
  * A stored seed variety with year tracking
@@ -410,7 +414,6 @@ export interface StoredVariety {
   price?: number
   notes?: string
   plannedYears: number[]             // @deprecated - inferred from plantings in allotment
-  available?: boolean                // If true, available for selection in any year
   seedsByYear: Record<number, SeedStatus>  // Per-year inventory status
   isArchived?: boolean               // Soft delete - hides from UI without breaking planting references
   perenualId?: string                // Future: external API integration
@@ -426,7 +429,6 @@ export interface NewVariety {
   supplier?: string
   price?: number
   notes?: string
-  available?: boolean                // If true, available for selection in any year
   plannedYears?: number[]            // @deprecated - kept for backward compatibility
   seedsByYear?: Record<number, SeedStatus>
 }


### PR DESCRIPTION
## Summary

- Add new 'had' seed status for seeds we had but no longer have (used/expired)
- Remove non-functional 'Available for planting' checkbox from variety edit dialog
- Update status cycle: none → ordered → have → had → none

## Test plan

- [ ] Navigate to Seeds page
- [ ] Select a year and click on a variety's status button
- [ ] Verify cycling through: Need → Ordered → Have → Had → Need
- [ ] Edit a variety and verify 'Had' button appears in seed status section
- [ ] Verify 'Available for planting' checkbox is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)