### PR TITLE
docs: sync documentation with recent changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Bonnie Wee Plot is a Next.js 15 application for garden planning and AI-powered gardening advice, built with React 19 and TypeScript. Users can plan their allotment plots, track plantings across seasons, and get advice from "Aitor" - an AI gardening assistant powered by OpenAI (BYO API key).
+Bonnie Wee Plot is a Next.js 16 application for garden planning and AI-powered gardening advice, built with React 19 and TypeScript. Users can plan their allotment plots, track plantings across seasons, and get advice from "Aitor" - an AI gardening assistant powered by OpenAI (BYO API key).
 
 ## Commands
 
@@ -59,7 +59,7 @@ Seed varieties are stored exclusively in `AllotmentData.varieties` with computed
 - **Single Source of Truth**: All variety data lives in `AllotmentData.varieties`
 - **Computed Queries**: Year usage computed dynamically from plantings via `getVarietyUsedYears()`
 - **Soft Delete**: Varieties use `isArchived` flag to preserve references to historical plantings
-- **Inventory Tracking**: Per-year seed status (`none`/`ordered`/`have`) via `seedsByYear`
+- **Inventory Tracking**: Per-year seed status (`none`/`ordered`/`have`/`had`) via `seedsByYear`
 
 Query functions in `src/lib/variety-queries.ts`:
 - `getVarietyUsedYears(varietyId, data)` - Returns all years a variety was planted

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Welcome to your personal digital garden assistant, specifically tuned for those brave souls who garden where horizontal rain is a lifestyle choice. Plan your plot, get AI-powered advice, and learn proven techniques for growing in Scotland's "interesting" climate—all in one place.
 
-**Try it now:** [Bonnie Wee Plot on GitHub Pages](https://ismaelmartinez.github.io/bonnie-wee-plot)
+**Try it now:** [Bonnie Wee Plot](https://bonnie-wee-plot.vercel.app) (primary) | [GitHub Pages mirror](https://ismaelmartinez.github.io/bonnie-wee-plot) (static fallback)
 
 ## 🤖 AI-Generated Code Disclaimer
 
@@ -30,6 +30,7 @@ Design and track your growing space with year-by-year planning:
 ### 🌱 Seeds & Tracking
 Comprehensive seed and plant management for our shorter growing season:
 - **Seed Catalog**: Browse and search vegetables by category, focusing on what actually grows here
+- **Seed Inventory**: Track seed status per year (need/ordered/have/had) to manage your collection
 - **Planting Calendar**: View detailed planting windows adjusted for Scottish conditions
 - **Crop Rotation**: Smart rotation suggestions based on plant families
 
@@ -48,7 +49,7 @@ Turn garden waste into black gold:
 
 ## 🛠️ Built With Love (And Probably Too Much Coffee)
 
-- **Next.js 15**: The latest and greatest from the Next.js team
+- **Next.js 16**: The latest and greatest from the Next.js team
 - **React 19**: Cutting-edge React with all the new features
 - **TypeScript**: For when JavaScript just isn't confusing enough
 - **Tailwind CSS**: Making things pretty without the existential CSS crisis
@@ -69,7 +70,7 @@ Turn garden waste into black gold:
 2. **Feed it dependencies** (like fertilizer, but for code):
 
    ```bash
-   npm install --legacy-peer-deps
+   npm install
    ```
 
 3. **Wake up the development server** (it's not a morning person):
@@ -137,7 +138,7 @@ Your homepage command center showing seasonal phase (adjusted for Scottish latit
 The heart of the app - manage your growing space with physical bed layouts, yearly planting plans, rotation tracking, and bed notes.
 
 ### Seeds Catalog (`/seeds`)
-Browse vegetables by category, view detailed planting calendars, and learn about crop rotation families.
+Browse vegetables by category, track your seed inventory with per-year status (need/ordered/have/had), view detailed planting calendars, and learn about crop rotation families.
 
 ### Compost Tracker (`/compost`)
 Track multiple compost piles with material logging, C:N ratio tracking, event history, and status management.

--- a/docs/adrs/021-planting-detail-dialog.md
+++ b/docs/adrs/021-planting-detail-dialog.md
@@ -1,4 +1,4 @@
-# ADR 020: Planting Detail Dialog
+# ADR 021: Planting Detail Dialog
 
 **Date:** 2026-01-26
 **Status:** Accepted

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -26,3 +26,4 @@ This directory contains Architecture Decision Records documenting significant te
 | [018](018-variety-refactor.md) | Variety Management Refactor | Accepted |
 | [019](019-per-year-grid-positions.md) | Per-Year Grid Positions | Accepted |
 | [020](020-vercel-deployment-security.md) | Vercel Deployment with Security Scanning | Accepted |
+| [021](021-planting-detail-dialog.md) | Planting Detail Dialog | Accepted |


### PR DESCRIPTION
## Summary
Syncing documentation to reflect recent PRs (#78-#81):

- Update Next.js version from 15 to 16 (upgraded in PR #78)
- Add Vercel as primary deployment URL, GitHub Pages as fallback
- Remove `--legacy-peer-deps` from install instructions (no longer needed)
- Document seed inventory status tracking with 'had' status (PR #79)
- Fix duplicate ADR numbering: rename planting-detail-dialog from 020 to 021
- Add ADR 021 entry to the ADR index

🤖 Generated with [Claude Code](https://claude.com/claude-code)