### PR TITLE
Add AI tool calling for garden data modifications

### DIFF
--- a/src/__tests__/services/ai-tool-executor.test.ts
+++ b/src/__tests__/services/ai-tool-executor.test.ts
@@ -1,0 +1,479 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  executeToolCall,
+  executeToolCalls,
+  formatResultsForAI,
+} from '@/services/ai-tool-executor'
+import type { AllotmentData } from '@/types/unified-allotment'
+import type { ToolCall } from '@/lib/ai-tools-schema'
+
+// Mock allotment data for testing
+function createMockAllotmentData(): AllotmentData {
+  return {
+    version: 16,
+    currentYear: 2026,
+    meta: {
+      name: 'Test Allotment',
+      location: 'Edinburgh, Scotland',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    layout: {
+      areas: [
+        {
+          id: 'bed-a',
+          name: 'Bed A',
+          kind: 'rotation-bed',
+          canHavePlantings: true,
+        },
+        {
+          id: 'bed-b',
+          name: 'Bed B',
+          kind: 'rotation-bed',
+          canHavePlantings: true,
+        },
+        {
+          id: 'shed',
+          name: 'Garden Shed',
+          kind: 'infrastructure',
+          canHavePlantings: false,
+        },
+      ],
+    },
+    seasons: [
+      {
+        year: 2026,
+        status: 'current',
+        areas: [
+          {
+            areaId: 'bed-a',
+            plantings: [
+              {
+                id: 'planting-1',
+                plantId: 'tomato',
+                varietyName: 'San Marzano',
+                sowDate: '2026-03-15',
+                status: 'active',
+              },
+            ],
+          },
+          {
+            areaId: 'bed-b',
+            plantings: [],
+          },
+        ],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    varieties: [],
+  }
+}
+
+function createToolCall(
+  name: string,
+  args: Record<string, unknown>,
+  id?: string
+): ToolCall {
+  return {
+    id: id || `call_${Math.random().toString(36).substr(2, 9)}`,
+    type: 'function',
+    function: {
+      name,
+      arguments: JSON.stringify(args),
+    },
+  }
+}
+
+describe('executeToolCall', () => {
+  let mockData: AllotmentData
+
+  beforeEach(() => {
+    mockData = createMockAllotmentData()
+  })
+
+  describe('add_planting', () => {
+    it('should add a planting to a valid area', () => {
+      const toolCall = createToolCall('add_planting', {
+        areaId: 'bed-b',
+        plantId: 'carrot',
+        varietyName: 'Nantes 2',
+        sowDate: '2026-04-01',
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(true)
+      expect(result.result).toBeDefined()
+      expect((result.result as { message: string }).message).toContain('Carrot') // Plant name is capitalized
+      expect((result.result as { message: string }).message).toContain('Bed B')
+
+      // Check the planting was added
+      const bedB = updatedData.seasons[0].areas.find(a => a.areaId === 'bed-b')
+      expect(bedB?.plantings).toHaveLength(1)
+      expect(bedB?.plantings[0].plantId).toBe('carrot')
+      expect(bedB?.plantings[0].varietyName).toBe('Nantes 2')
+    })
+
+    it('should reject planting to non-existent area', () => {
+      const toolCall = createToolCall('add_planting', {
+        areaId: 'bed-z',
+        plantId: 'tomato',
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('not found')
+      // Data should be unchanged
+      expect(updatedData).toEqual(mockData)
+    })
+
+    it('should reject planting to area that cannot have plantings', () => {
+      const toolCall = createToolCall('add_planting', {
+        areaId: 'shed',
+        plantId: 'tomato',
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('cannot have plantings')
+      expect(updatedData).toEqual(mockData)
+    })
+
+    it('should reject invalid plant ID', () => {
+      const toolCall = createToolCall('add_planting', {
+        areaId: 'bed-b',
+        plantId: 'nonexistent-plant-xyz',
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('not found in the vegetable database')
+      expect(updatedData).toEqual(mockData)
+    })
+
+    it('should set status to active when sowDate is provided', () => {
+      const toolCall = createToolCall('add_planting', {
+        areaId: 'bed-b',
+        plantId: 'lettuce',
+        sowDate: '2026-04-15',
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(true)
+      const bedB = updatedData.seasons[0].areas.find(a => a.areaId === 'bed-b')
+      expect(bedB?.plantings[0].status).toBe('active')
+    })
+
+    it('should set status to planned when no sowDate', () => {
+      const toolCall = createToolCall('add_planting', {
+        areaId: 'bed-b',
+        plantId: 'lettuce',
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(true)
+      const bedB = updatedData.seasons[0].areas.find(a => a.areaId === 'bed-b')
+      expect(bedB?.plantings[0].status).toBe('planned')
+    })
+  })
+
+  describe('update_planting', () => {
+    it('should update an existing planting', () => {
+      const toolCall = createToolCall('update_planting', {
+        areaId: 'bed-a',
+        plantId: 'tomato',
+        updates: {
+          notes: 'Growing well!',
+          success: 'good',
+        },
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(true)
+      const bedA = updatedData.seasons[0].areas.find(a => a.areaId === 'bed-a')
+      expect(bedA?.plantings[0].notes).toBe('Growing well!')
+      expect(bedA?.plantings[0].success).toBe('good')
+    })
+
+    it('should reject update for non-existent planting', () => {
+      const toolCall = createToolCall('update_planting', {
+        areaId: 'bed-a',
+        plantId: 'carrot', // Not in bed-a
+        updates: { notes: 'test' },
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/not found|No planting/i)
+      expect(updatedData).toEqual(mockData)
+    })
+
+    it('should reject update for non-existent area', () => {
+      const toolCall = createToolCall('update_planting', {
+        areaId: 'bed-z',
+        plantId: 'tomato',
+        updates: { notes: 'test' },
+      })
+
+      const { result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('not found')
+    })
+  })
+
+  describe('remove_planting', () => {
+    it('should remove an existing planting', () => {
+      const toolCall = createToolCall('remove_planting', {
+        areaId: 'bed-a',
+        plantId: 'tomato',
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(true)
+      const bedA = updatedData.seasons[0].areas.find(a => a.areaId === 'bed-a')
+      expect(bedA?.plantings).toHaveLength(0)
+    })
+
+    it('should reject removal of non-existent planting', () => {
+      const toolCall = createToolCall('remove_planting', {
+        areaId: 'bed-b',
+        plantId: 'tomato', // Not in bed-b
+      })
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/not found|No planting/i)
+      expect(updatedData).toEqual(mockData)
+    })
+  })
+
+  describe('list_areas', () => {
+    it('should list all areas', () => {
+      const toolCall = createToolCall('list_areas', {})
+
+      const { updatedData, result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(true)
+      const areas = (result.result as { areas: unknown[] }).areas
+      expect(areas).toHaveLength(3)
+      // Data should be unchanged
+      expect(updatedData).toEqual(mockData)
+    })
+
+    it('should filter areas by kind', () => {
+      const toolCall = createToolCall('list_areas', {
+        kind: 'rotation-bed',
+      })
+
+      const { result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(true)
+      const areas = (result.result as { areas: unknown[] }).areas
+      expect(areas).toHaveLength(2)
+    })
+
+    it('should exclude archived areas', () => {
+      // Add an archived area
+      const dataWithArchived = {
+        ...mockData,
+        layout: {
+          areas: [
+            ...mockData.layout.areas,
+            {
+              id: 'bed-c',
+              name: 'Bed C (Archived)',
+              kind: 'rotation-bed' as const,
+              canHavePlantings: true,
+              isArchived: true,
+            },
+          ],
+        },
+      }
+
+      const toolCall = createToolCall('list_areas', {})
+
+      const { result } = executeToolCall(toolCall, dataWithArchived, 2026)
+
+      expect(result.success).toBe(true)
+      const areas = (result.result as { areas: { id: string }[] }).areas
+      expect(areas).toHaveLength(3) // Should not include archived
+      expect(areas.find(a => a.id === 'bed-c')).toBeUndefined()
+    })
+  })
+
+  describe('invalid arguments', () => {
+    it('should reject invalid JSON arguments', () => {
+      const toolCall: ToolCall = {
+        id: 'test-call',
+        type: 'function',
+        function: {
+          name: 'add_planting',
+          arguments: 'not valid json',
+        },
+      }
+
+      const { result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Invalid')
+    })
+
+    it('should reject missing required fields', () => {
+      const toolCall = createToolCall('add_planting', {
+        // Missing areaId and plantId
+      })
+
+      const { result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Invalid arguments')
+    })
+  })
+
+  describe('unknown function', () => {
+    it('should reject unknown function names', () => {
+      const toolCall = createToolCall('unknown_function', {})
+
+      const { result } = executeToolCall(toolCall, mockData, 2026)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Unknown function')
+    })
+  })
+})
+
+describe('executeToolCalls', () => {
+  let mockData: AllotmentData
+
+  beforeEach(() => {
+    mockData = createMockAllotmentData()
+  })
+
+  it('should execute multiple tool calls in sequence', () => {
+    const toolCalls = [
+      createToolCall('add_planting', {
+        areaId: 'bed-b',
+        plantId: 'carrot',
+      }),
+      createToolCall('add_planting', {
+        areaId: 'bed-b',
+        plantId: 'lettuce',
+      }),
+    ]
+
+    const { updatedData, results } = executeToolCalls(toolCalls, mockData, 2026)
+
+    expect(results).toHaveLength(2)
+    expect(results[0].success).toBe(true)
+    expect(results[1].success).toBe(true)
+
+    const bedB = updatedData.seasons[0].areas.find(a => a.areaId === 'bed-b')
+    expect(bedB?.plantings).toHaveLength(2)
+  })
+
+  it('should accumulate changes across calls', () => {
+    const toolCalls = [
+      createToolCall('add_planting', {
+        areaId: 'bed-b',
+        plantId: 'carrot',
+      }),
+      createToolCall('update_planting', {
+        areaId: 'bed-b',
+        plantId: 'carrot',
+        updates: { notes: 'Added via batch' },
+      }),
+    ]
+
+    const { updatedData, results } = executeToolCalls(toolCalls, mockData, 2026)
+
+    expect(results[0].success).toBe(true)
+    expect(results[1].success).toBe(true)
+
+    const bedB = updatedData.seasons[0].areas.find(a => a.areaId === 'bed-b')
+    expect(bedB?.plantings[0].notes).toBe('Added via batch')
+  })
+
+  it('should continue after failures', () => {
+    const toolCalls = [
+      createToolCall('add_planting', {
+        areaId: 'bed-z', // Invalid
+        plantId: 'carrot',
+      }),
+      createToolCall('add_planting', {
+        areaId: 'bed-b', // Valid
+        plantId: 'lettuce',
+      }),
+    ]
+
+    const { updatedData, results } = executeToolCalls(toolCalls, mockData, 2026)
+
+    expect(results[0].success).toBe(false)
+    expect(results[1].success).toBe(true)
+
+    const bedB = updatedData.seasons[0].areas.find(a => a.areaId === 'bed-b')
+    expect(bedB?.plantings).toHaveLength(1)
+  })
+})
+
+describe('formatResultsForAI', () => {
+  it('should format successful results', () => {
+    const results = [
+      {
+        tool_call_id: 'call-1',
+        success: true,
+        result: { message: 'Added tomato to Bed A' },
+      },
+    ]
+
+    const formatted = formatResultsForAI(results)
+
+    expect(formatted).toContain('Successfully completed 1 operation')
+    expect(formatted).toContain('Added tomato to Bed A')
+  })
+
+  it('should format failed results', () => {
+    const results = [
+      {
+        tool_call_id: 'call-1',
+        success: false,
+        error: 'Area not found',
+      },
+    ]
+
+    const formatted = formatResultsForAI(results)
+
+    expect(formatted).toContain('Failed 1 operation')
+    expect(formatted).toContain('Area not found')
+  })
+
+  it('should format mixed results', () => {
+    const results = [
+      {
+        tool_call_id: 'call-1',
+        success: true,
+        result: { message: 'Added tomato' },
+      },
+      {
+        tool_call_id: 'call-2',
+        success: false,
+        error: 'Area not found',
+      },
+    ]
+
+    const formatted = formatResultsForAI(results)
+
+    expect(formatted).toContain('Successfully completed 1 operation')
+    expect(formatted).toContain('Failed 1 operation')
+  })
+})

--- a/src/components/ai-advisor/ToolCallConfirmation.tsx
+++ b/src/components/ai-advisor/ToolCallConfirmation.tsx
@@ -1,0 +1,252 @@
+/**
+ * ToolCallConfirmation Component
+ *
+ * Displays pending AI tool calls and allows the user to approve or decline them.
+ * Shows a preview of what changes the AI wants to make to the garden data.
+ */
+
+'use client'
+
+import { AlertCircle, Check, X, Loader2 } from 'lucide-react'
+import { ToolCall, formatToolCallForUser, requiresConfirmation } from '@/lib/ai-tools-schema'
+import { getVegetableById } from '@/lib/vegetable-database'
+
+interface ToolCallConfirmationProps {
+  /** The tool calls pending confirmation */
+  toolCalls: ToolCall[]
+  /** Called when user approves or declines */
+  onConfirm: (approved: boolean) => void
+  /** Whether the tool calls are currently being executed */
+  isExecuting?: boolean
+}
+
+/**
+ * Main confirmation dialog for AI tool calls
+ */
+export function ToolCallConfirmation({
+  toolCalls,
+  onConfirm,
+  isExecuting = false,
+}: ToolCallConfirmationProps) {
+  // Filter to only tool calls that require confirmation
+  const confirmableCalls = toolCalls.filter(tc =>
+    requiresConfirmation(tc.function.name)
+  )
+
+  if (confirmableCalls.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className="bg-amber-50 border border-amber-200 rounded-lg p-4 my-3"
+      role="alertdialog"
+      aria-labelledby="tool-confirm-title"
+      aria-describedby="tool-confirm-desc"
+    >
+      <div className="flex items-start gap-3 mb-3">
+        <AlertCircle
+          className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5"
+          aria-hidden="true"
+        />
+        <div className="flex-1">
+          <h3
+            id="tool-confirm-title"
+            className="font-medium text-gray-800 mb-2"
+          >
+            Confirm Changes
+          </h3>
+          <p
+            id="tool-confirm-desc"
+            className="text-sm text-gray-600 mb-3"
+          >
+            Aitor would like to make the following changes to your garden:
+          </p>
+          <div className="space-y-2" role="list" aria-label="Proposed changes">
+            {confirmableCalls.map((call) => (
+              <ToolCallItem key={call.id} toolCall={call} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-2 justify-end mt-4">
+        <button
+          onClick={() => onConfirm(false)}
+          disabled={isExecuting}
+          className="flex items-center gap-2 px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg transition disabled:opacity-50"
+          aria-label="Decline changes"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+          Cancel
+        </button>
+        <button
+          onClick={() => onConfirm(true)}
+          disabled={isExecuting}
+          className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white hover:bg-green-700 rounded-lg transition disabled:opacity-50"
+          aria-label="Approve changes"
+        >
+          {isExecuting ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+              Applying...
+            </>
+          ) : (
+            <>
+              <Check className="w-4 h-4" aria-hidden="true" />
+              Confirm Changes
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Individual tool call item in the confirmation list
+ */
+function ToolCallItem({ toolCall }: { toolCall: ToolCall }) {
+  const details = getToolCallDetails(toolCall)
+
+  return (
+    <div
+      className="flex items-start gap-2 text-sm text-gray-700 bg-white p-2 rounded border border-amber-100"
+      role="listitem"
+    >
+      <span className="text-amber-500 flex-shrink-0">{details.icon}</span>
+      <div>
+        <span className="font-medium">{details.action}</span>
+        {details.extra && (
+          <span className="text-gray-500 ml-1">{details.extra}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface ToolCallDetails {
+  icon: string
+  action: string
+  extra?: string
+}
+
+/**
+ * Get human-readable details for a tool call
+ */
+function getToolCallDetails(toolCall: ToolCall): ToolCallDetails {
+  try {
+    const args = JSON.parse(toolCall.function.arguments)
+
+    switch (toolCall.function.name) {
+      case 'add_planting': {
+        const plant = getVegetableById(args.plantId)
+        const plantName = args.varietyName
+          ? `${args.varietyName} (${plant?.name || args.plantId})`
+          : (plant?.name || args.plantId)
+        return {
+          icon: '+',
+          action: `Add ${plantName} to ${args.areaId}`,
+          extra: args.sowDate ? `sowing ${args.sowDate}` : undefined,
+        }
+      }
+
+      case 'update_planting': {
+        const plant = getVegetableById(args.plantId)
+        const updateFields = Object.keys(args.updates || {}).join(', ')
+        return {
+          icon: '~',
+          action: `Update ${plant?.name || args.plantId} in ${args.areaId}`,
+          extra: updateFields ? `(${updateFields})` : undefined,
+        }
+      }
+
+      case 'remove_planting': {
+        const plant = getVegetableById(args.plantId)
+        return {
+          icon: '-',
+          action: `Remove ${plant?.name || args.plantId} from ${args.areaId}`,
+        }
+      }
+
+      default:
+        return {
+          icon: '?',
+          action: formatToolCallForUser(toolCall),
+        }
+    }
+  } catch {
+    return {
+      icon: '?',
+      action: formatToolCallForUser(toolCall),
+    }
+  }
+}
+
+/**
+ * Message shown after successful tool execution
+ */
+export function ToolExecutionSuccess({
+  message,
+  onDismiss,
+}: {
+  message: string
+  onDismiss?: () => void
+}) {
+  return (
+    <div
+      className="bg-green-50 border border-green-200 rounded-lg p-3 my-3 flex items-start gap-3"
+      role="status"
+      aria-live="polite"
+    >
+      <Check className="w-5 h-5 text-green-600 flex-shrink-0" aria-hidden="true" />
+      <div className="flex-1 text-sm text-green-800">
+        {message}
+      </div>
+      {onDismiss && (
+        <button
+          onClick={onDismiss}
+          className="text-green-600 hover:text-green-800"
+          aria-label="Dismiss"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Message shown after tool execution failure
+ */
+export function ToolExecutionError({
+  message,
+  onDismiss,
+}: {
+  message: string
+  onDismiss?: () => void
+}) {
+  return (
+    <div
+      className="bg-red-50 border border-red-200 rounded-lg p-3 my-3 flex items-start gap-3"
+      role="alert"
+      aria-live="assertive"
+    >
+      <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0" aria-hidden="true" />
+      <div className="flex-1 text-sm text-red-800">
+        {message}
+      </div>
+      {onDismiss && (
+        <button
+          onClick={onDismiss}
+          className="text-red-600 hover:text-red-800"
+          aria-label="Dismiss"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default ToolCallConfirmation

--- a/src/lib/ai-tools-schema.ts
+++ b/src/lib/ai-tools-schema.ts
@@ -151,7 +151,7 @@ export const PLANTING_TOOLS: OpenAITool[] = [
               },
               success: {
                 type: 'string',
-                enum: ['excellent', 'good', 'fair', 'poor', 'failed'],
+                enum: ['excellent', 'good', 'fair', 'poor'],
                 description: 'How well the planting performed',
               },
               notes: {
@@ -273,7 +273,7 @@ export const updatePlantingArgsSchema = z.object({
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/, 'actualHarvestEnd must be in YYYY-MM-DD format')
       .optional(),
-    success: z.enum(['excellent', 'good', 'fair', 'poor', 'failed']).optional(),
+    success: z.enum(['excellent', 'good', 'fair', 'poor']).optional(),
     notes: z.string().optional(),
     quantity: z.number().positive().optional(),
     status: z.enum(['planned', 'active', 'harvested', 'removed']).optional(),

--- a/src/lib/openai-client.ts
+++ b/src/lib/openai-client.ts
@@ -28,6 +28,36 @@ interface IncomingMessage {
   content: string
 }
 
+/**
+ * OpenAI Tool type for function calling
+ */
+export interface OpenAITool {
+  type: 'function'
+  function: {
+    name: string
+    description: string
+    parameters: {
+      type: 'object'
+      properties: Record<string, unknown>
+      required?: string[]
+      additionalProperties?: boolean
+    }
+    strict?: boolean
+  }
+}
+
+/**
+ * Tool call from OpenAI response
+ */
+export interface OpenAIToolCall {
+  id: string
+  type: 'function'
+  function: {
+    name: string
+    arguments: string // JSON string
+  }
+}
+
 export interface OpenAIClientOptions {
   apiToken: string
   message: string
@@ -35,10 +65,19 @@ export interface OpenAIClientOptions {
   image?: { type: string; data: string }
   allotmentContext?: string
   onFallbackToDirectAPI?: (reason: string) => void
+  /** Enable AI tool calling (function calling) for modifying garden data */
+  enableTools?: boolean
+  /** Tools to make available to the AI */
+  tools?: OpenAITool[]
 }
 
 export interface OpenAIResponse {
+  /** Type of response: 'text' for normal response, 'tool_calls' for function calls */
+  type: 'text' | 'tool_calls'
+  /** Text response (when type is 'text') */
   response: string
+  /** Tool calls (when type is 'tool_calls') */
+  tool_calls?: OpenAIToolCall[]
   usage?: {
     prompt_tokens: number
     completion_tokens: number
@@ -181,12 +220,34 @@ export async function callOpenAI(options: OpenAIClientOptions): Promise<OpenAIRe
   return await callOpenAIDirect(options)
 }
 
+// Tool usage instructions appended to system prompt when tools are enabled
+const TOOL_INSTRUCTIONS = `
+
+🔧 GARDEN MANAGEMENT TOOLS:
+You have access to tools that can modify the user's garden data. Use these tools when:
+- The user explicitly asks to add, update, or remove plantings
+- The user confirms they want to record something in their garden plan
+- You need to look up their available beds/areas
+
+IMPORTANT GUIDELINES:
+- ALWAYS confirm with the user before making changes
+- Use the user's bed/area IDs exactly as shown in their allotment data
+- When adding plantings, include variety name and sowing date if mentioned
+- Never make assumptions - ask for clarification if needed
+- If a user mentions planting something, offer to add it to their records
+
+Available tools:
+- add_planting: Add a new plant to a bed
+- update_planting: Update an existing planting's details
+- remove_planting: Remove a plant from a bed
+- list_areas: Get available beds and areas`
+
 /**
  * Direct OpenAI API call (used on GitHub Pages)
  * Bypasses Next.js API route and calls OpenAI directly from browser
  */
 async function callOpenAIDirect(options: OpenAIClientOptions): Promise<OpenAIResponse> {
-  const { apiToken, message, messages = [], image, allotmentContext } = options
+  const { apiToken, message, messages = [], image, allotmentContext, enableTools, tools } = options
 
   // Validate token format
   const tokenPattern = /^[a-zA-Z0-9\-_]{20,}$/
@@ -199,6 +260,11 @@ async function callOpenAIDirect(options: OpenAIClientOptions): Promise<OpenAIRes
 
   if (allotmentContext && typeof allotmentContext === 'string' && allotmentContext.trim()) {
     systemPrompt += `\n\n📊 USER'S ALLOTMENT DATA:\n${allotmentContext}\n\nUse this context to provide personalized advice. When relevant, reference the user's specific beds, plantings, and any noted problem areas. Consider their planting history when making rotation and succession suggestions.`
+  }
+
+  // Add tool instructions if tools are enabled
+  if (enableTools && tools && tools.length > 0) {
+    systemPrompt += TOOL_INSTRUCTIONS
   }
 
   // Prepare messages for OpenAI API
@@ -238,21 +304,30 @@ async function callOpenAIDirect(options: OpenAIClientOptions): Promise<OpenAIRes
   // Call OpenAI API directly
   const apiUrl = 'https://api.openai.com/v1/chat/completions'
 
+  // Build request body
+  const requestBody: Record<string, unknown> = {
+    model,
+    messages: apiMessages,
+    max_tokens: 1500,
+    temperature: 0.7,
+    presence_penalty: 0.6,
+    frequency_penalty: 0.3,
+    stream: false
+  }
+
+  // Add tools if enabled
+  if (enableTools && tools && tools.length > 0) {
+    requestBody.tools = tools
+    requestBody.tool_choice = 'auto'
+  }
+
   const response = await fetch(apiUrl, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${apiToken}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({
-      model,
-      messages: apiMessages,
-      max_tokens: 1500,
-      temperature: 0.7,
-      presence_penalty: 0.6,
-      frequency_penalty: 0.3,
-      stream: false
-    }),
+    body: JSON.stringify(requestBody),
   })
 
   if (!response.ok) {
@@ -275,13 +350,34 @@ async function callOpenAIDirect(options: OpenAIClientOptions): Promise<OpenAIRes
   }
 
   const data = await response.json()
-  const aiResponse = data.choices[0]?.message?.content
+  const aiMessage = data.choices[0]?.message
+
+  // Check if response contains tool calls
+  if (aiMessage?.tool_calls && aiMessage.tool_calls.length > 0) {
+    return {
+      type: 'tool_calls',
+      response: aiMessage.content || '',
+      tool_calls: aiMessage.tool_calls.map((tc: { id: string; type: string; function: { name: string; arguments: string } }) => ({
+        id: tc.id,
+        type: tc.type,
+        function: {
+          name: tc.function.name,
+          arguments: tc.function.arguments
+        }
+      })),
+      usage: data.usage
+    }
+  }
+
+  // Regular text response
+  const aiResponse = aiMessage?.content
 
   if (!aiResponse) {
     throw new Error('No response from AI')
   }
 
   return {
+    type: 'text',
     response: aiResponse,
     usage: data.usage
   }

--- a/src/services/ai-tool-executor.ts
+++ b/src/services/ai-tool-executor.ts
@@ -1,0 +1,469 @@
+/**
+ * AI Tool Executor Service
+ *
+ * Executes AI tool calls (function calling) against AllotmentData.
+ * Tool calls come from OpenAI's function calling API and modify garden data.
+ *
+ * All operations are immutable - they return new AllotmentData objects.
+ * The caller is responsible for persisting the updated data.
+ *
+ * @see docs/research/ai-inventory-management.md
+ * @see src/lib/ai-tools-schema.ts
+ */
+
+import {
+  AllotmentData,
+  NewPlanting,
+  PlantingUpdate,
+  Area,
+  Planting,
+} from '@/types/unified-allotment'
+import {
+  addPlanting as storageAddPlanting,
+  updatePlanting as storageUpdatePlanting,
+  removePlanting as storageRemovePlanting,
+  getAreaById,
+  getPlantingsForArea,
+  getAllAreas,
+  getAreasByKind,
+} from '@/services/allotment-storage'
+import {
+  ToolCall,
+  ToolResult,
+  parseToolCallArgs,
+  AddPlantingArgs,
+  UpdatePlantingArgs,
+  RemovePlantingArgs,
+  ListAreasArgs,
+} from '@/lib/ai-tools-schema'
+import { getVegetableById } from '@/lib/vegetable-database'
+
+/**
+ * Result of executing a tool call
+ */
+export interface ToolExecutionResult {
+  /** Updated allotment data (may be unchanged for read-only operations) */
+  updatedData: AllotmentData
+  /** Result to return to the AI for follow-up response */
+  result: ToolResult
+}
+
+/**
+ * Execute a single tool call against allotment data
+ *
+ * @param toolCall - The tool call from OpenAI
+ * @param allotmentData - Current allotment data
+ * @param currentYear - The currently selected year
+ * @returns Updated data and result for the AI
+ */
+export function executeToolCall(
+  toolCall: ToolCall,
+  allotmentData: AllotmentData,
+  currentYear: number
+): ToolExecutionResult {
+  const { id, function: func } = toolCall
+
+  // Parse and validate arguments
+  const parseResult = parseToolCallArgs(func.name, func.arguments)
+  if (!parseResult.valid) {
+    return {
+      updatedData: allotmentData,
+      result: {
+        tool_call_id: id,
+        success: false,
+        error: `Invalid arguments: ${parseResult.error}`,
+      },
+    }
+  }
+
+  try {
+    switch (func.name) {
+      case 'add_planting':
+        return executeAddPlanting(
+          id,
+          parseResult.data as AddPlantingArgs,
+          allotmentData,
+          currentYear
+        )
+
+      case 'update_planting':
+        return executeUpdatePlanting(
+          id,
+          parseResult.data as UpdatePlantingArgs,
+          allotmentData,
+          currentYear
+        )
+
+      case 'remove_planting':
+        return executeRemovePlanting(
+          id,
+          parseResult.data as RemovePlantingArgs,
+          allotmentData,
+          currentYear
+        )
+
+      case 'list_areas':
+        return executeListAreas(
+          id,
+          parseResult.data as ListAreasArgs,
+          allotmentData
+        )
+
+      default:
+        return {
+          updatedData: allotmentData,
+          result: {
+            tool_call_id: id,
+            success: false,
+            error: `Unknown function: ${func.name}`,
+          },
+        }
+    }
+  } catch (error) {
+    return {
+      updatedData: allotmentData,
+      result: {
+        tool_call_id: id,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+      },
+    }
+  }
+}
+
+/**
+ * Execute multiple tool calls in sequence
+ *
+ * Each call receives the updated data from the previous call,
+ * ensuring changes accumulate correctly.
+ */
+export function executeToolCalls(
+  toolCalls: ToolCall[],
+  allotmentData: AllotmentData,
+  currentYear: number
+): { updatedData: AllotmentData; results: ToolResult[] } {
+  let currentData = allotmentData
+  const results: ToolResult[] = []
+
+  for (const toolCall of toolCalls) {
+    const { updatedData, result } = executeToolCall(
+      toolCall,
+      currentData,
+      currentYear
+    )
+    currentData = updatedData
+    results.push(result)
+  }
+
+  return { updatedData: currentData, results }
+}
+
+// ============ INDIVIDUAL OPERATION HANDLERS ============
+
+function executeAddPlanting(
+  toolCallId: string,
+  args: AddPlantingArgs,
+  data: AllotmentData,
+  year: number
+): ToolExecutionResult {
+  // Validate area exists
+  const area = getAreaById(data, args.areaId)
+  if (!area) {
+    return {
+      updatedData: data,
+      result: {
+        tool_call_id: toolCallId,
+        success: false,
+        error: `Area '${args.areaId}' not found. Available areas: ${getAllAreas(data).map(a => a.id).join(', ')}`,
+      },
+    }
+  }
+
+  // Check if area can have plantings
+  if (!area.canHavePlantings) {
+    return {
+      updatedData: data,
+      result: {
+        tool_call_id: toolCallId,
+        success: false,
+        error: `Area '${args.areaId}' (${area.name}) cannot have plantings. Try a different bed.`,
+      },
+    }
+  }
+
+  // Validate plant exists in database
+  const plant = getVegetableById(args.plantId)
+  if (!plant) {
+    return {
+      updatedData: data,
+      result: {
+        tool_call_id: toolCallId,
+        success: false,
+        error: `Plant '${args.plantId}' not found in the vegetable database. Please check the plant name.`,
+      },
+    }
+  }
+
+  // Create the new planting
+  const newPlanting: NewPlanting = {
+    plantId: args.plantId,
+    varietyName: args.varietyName,
+    sowDate: args.sowDate,
+    sowMethod: args.sowMethod,
+    quantity: args.quantity,
+    notes: args.notes,
+    status: args.sowDate ? 'active' : 'planned',
+  }
+
+  const updatedData = storageAddPlanting(data, year, args.areaId, newPlanting)
+
+  const displayName = args.varietyName
+    ? `${args.varietyName} (${plant.name})`
+    : plant.name
+
+  return {
+    updatedData,
+    result: {
+      tool_call_id: toolCallId,
+      success: true,
+      result: {
+        message: `Added ${displayName} to ${area.name}${args.sowDate ? ` with sowing date ${args.sowDate}` : ''}`,
+        areaId: args.areaId,
+        areaName: area.name,
+        plantId: args.plantId,
+        plantName: plant.name,
+        varietyName: args.varietyName,
+        sowDate: args.sowDate,
+      },
+    },
+  }
+}
+
+function executeUpdatePlanting(
+  toolCallId: string,
+  args: UpdatePlantingArgs,
+  data: AllotmentData,
+  year: number
+): ToolExecutionResult {
+  // Validate area exists
+  const area = getAreaById(data, args.areaId)
+  if (!area) {
+    return {
+      updatedData: data,
+      result: {
+        tool_call_id: toolCallId,
+        success: false,
+        error: `Area '${args.areaId}' not found`,
+      },
+    }
+  }
+
+  // Find the planting to update
+  const plantings = getPlantingsForArea(data, year, args.areaId)
+  const planting = findPlantingByPlantId(plantings, args.plantId)
+
+  if (!planting) {
+    const availablePlants = plantings.map(p => p.plantId).join(', ')
+    return {
+      updatedData: data,
+      result: {
+        tool_call_id: toolCallId,
+        success: false,
+        error: `No planting of '${args.plantId}' found in ${area.name} for ${year}.${availablePlants ? ` Available: ${availablePlants}` : ' The bed is empty.'}`,
+      },
+    }
+  }
+
+  // Build the update object
+  const updates: PlantingUpdate = {}
+  if (args.updates.varietyName !== undefined) updates.varietyName = args.updates.varietyName
+  if (args.updates.sowDate !== undefined) updates.sowDate = args.updates.sowDate
+  if (args.updates.sowMethod !== undefined) updates.sowMethod = args.updates.sowMethod
+  if (args.updates.transplantDate !== undefined) updates.transplantDate = args.updates.transplantDate
+  if (args.updates.actualHarvestStart !== undefined) updates.actualHarvestStart = args.updates.actualHarvestStart
+  if (args.updates.actualHarvestEnd !== undefined) updates.actualHarvestEnd = args.updates.actualHarvestEnd
+  if (args.updates.success !== undefined) updates.success = args.updates.success
+  if (args.updates.notes !== undefined) updates.notes = args.updates.notes
+  if (args.updates.quantity !== undefined) updates.quantity = args.updates.quantity
+  if (args.updates.status !== undefined) updates.status = args.updates.status
+
+  const updatedData = storageUpdatePlanting(
+    data,
+    year,
+    args.areaId,
+    planting.id,
+    updates
+  )
+
+  const plant = getVegetableById(args.plantId)
+  const plantName = plant?.name || args.plantId
+
+  return {
+    updatedData,
+    result: {
+      tool_call_id: toolCallId,
+      success: true,
+      result: {
+        message: `Updated ${plantName} in ${area.name}`,
+        areaId: args.areaId,
+        areaName: area.name,
+        plantingId: planting.id,
+        updates: args.updates,
+      },
+    },
+  }
+}
+
+function executeRemovePlanting(
+  toolCallId: string,
+  args: RemovePlantingArgs,
+  data: AllotmentData,
+  year: number
+): ToolExecutionResult {
+  // Validate area exists
+  const area = getAreaById(data, args.areaId)
+  if (!area) {
+    return {
+      updatedData: data,
+      result: {
+        tool_call_id: toolCallId,
+        success: false,
+        error: `Area '${args.areaId}' not found`,
+      },
+    }
+  }
+
+  // Find the planting to remove
+  const plantings = getPlantingsForArea(data, year, args.areaId)
+  const planting = findPlantingByPlantId(plantings, args.plantId)
+
+  if (!planting) {
+    const availablePlants = plantings.map(p => p.plantId).join(', ')
+    return {
+      updatedData: data,
+      result: {
+        tool_call_id: toolCallId,
+        success: false,
+        error: `No planting of '${args.plantId}' found in ${area.name} for ${year}.${availablePlants ? ` Available: ${availablePlants}` : ' The bed is empty.'}`,
+      },
+    }
+  }
+
+  const updatedData = storageRemovePlanting(
+    data,
+    year,
+    args.areaId,
+    planting.id
+  )
+
+  const plant = getVegetableById(args.plantId)
+  const plantName = plant?.name || args.plantId
+
+  return {
+    updatedData,
+    result: {
+      tool_call_id: toolCallId,
+      success: true,
+      result: {
+        message: `Removed ${plantName} from ${area.name}`,
+        areaId: args.areaId,
+        areaName: area.name,
+        plantingId: planting.id,
+      },
+    },
+  }
+}
+
+function executeListAreas(
+  toolCallId: string,
+  args: ListAreasArgs,
+  data: AllotmentData
+): ToolExecutionResult {
+  // Get areas, optionally filtered by kind
+  const areas = args.kind
+    ? getAreasByKind(data, args.kind)
+    : getAllAreas(data)
+
+  // Filter to only active (non-archived) areas
+  const activeAreas = areas.filter(a => !a.isArchived)
+
+  // Format for AI response
+  const formattedAreas = activeAreas.map((area: Area) => ({
+    id: area.id,
+    name: area.name,
+    kind: area.kind,
+    canHavePlantings: area.canHavePlantings,
+    description: area.description,
+  }))
+
+  return {
+    updatedData: data, // No changes for list operation
+    result: {
+      tool_call_id: toolCallId,
+      success: true,
+      result: {
+        message: args.kind
+          ? `Found ${formattedAreas.length} ${args.kind} areas`
+          : `Found ${formattedAreas.length} areas total`,
+        areas: formattedAreas,
+        count: formattedAreas.length,
+      },
+    },
+  }
+}
+
+// ============ HELPER FUNCTIONS ============
+
+/**
+ * Find a planting by plant ID (not planting ID)
+ * The AI uses plant type (e.g., "tomato") not the internal UUID
+ */
+function findPlantingByPlantId(
+  plantings: Planting[],
+  plantId: string
+): Planting | undefined {
+  // Try exact match first
+  let planting = plantings.find(p => p.plantId === plantId)
+  if (planting) return planting
+
+  // Try case-insensitive match
+  const lowerPlantId = plantId.toLowerCase()
+  planting = plantings.find(p => p.plantId.toLowerCase() === lowerPlantId)
+  if (planting) return planting
+
+  // Try partial match (e.g., "tomatoes" -> "tomato")
+  const singularPlantId = plantId.replace(/s$/, '').toLowerCase()
+  planting = plantings.find(
+    p => p.plantId.toLowerCase() === singularPlantId ||
+         p.plantId.toLowerCase().replace(/s$/, '') === singularPlantId
+  )
+
+  return planting
+}
+
+/**
+ * Format tool execution results for AI follow-up message
+ */
+export function formatResultsForAI(results: ToolResult[]): string {
+  const successful = results.filter(r => r.success)
+  const failed = results.filter(r => !r.success)
+
+  const lines: string[] = []
+
+  if (successful.length > 0) {
+    lines.push(`Successfully completed ${successful.length} operation(s):`)
+    successful.forEach(r => {
+      const msg = (r.result as { message?: string })?.message
+      if (msg) lines.push(`- ${msg}`)
+    })
+  }
+
+  if (failed.length > 0) {
+    lines.push(`\nFailed ${failed.length} operation(s):`)
+    failed.forEach(r => {
+      lines.push(`- ${r.error}`)
+    })
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary
Implement OpenAI function calling (tool use) to allow the AI advisor to propose and execute modifications to garden data. Users can now approve or decline suggested changes like adding/updating/removing plantings.

## Key Changes

### Core Tool Execution
- **New service**: `src/services/ai-tool-executor.ts` - Executes AI tool calls against allotment data with full validation
  - `executeToolCall()` - Execute single tool call with error handling
  - `executeToolCalls()` - Execute multiple calls in sequence with state accumulation
  - `formatResultsForAI()` - Format results for AI follow-up messages
  - Handlers for `add_planting`, `update_planting`, `remove_planting`, `list_areas`

### UI Components
- **New component**: `src/components/ai-advisor/ToolCallConfirmation.tsx` - User confirmation dialog
  - Displays pending tool calls with human-readable descriptions
  - Approve/decline buttons with loading state
  - Shows what changes the AI wants to make before execution

### OpenAI Integration
- **Updated**: `src/lib/openai-client.ts`
  - Added `OpenAITool` and `OpenAIToolCall` types for function calling
  - Extended `OpenAIClientOptions` with `enableTools` and `tools` parameters
  - Modified response handling to detect and return tool calls separately from text
  - Added tool instructions to system prompt when tools are enabled
  - Support for `tool_choice: 'auto'` in API requests

### AI Advisor Page
- **Updated**: `src/app/ai-advisor/page.tsx`
  - Added state management for pending tool calls (`pendingToolCalls`, `isExecutingTools`)
  - Pass tools to OpenAI when allotment data is available
  - Handle tool call responses and show confirmation dialog
  - Execute approved tools and persist updated data to localStorage
  - Format and display results to user

### Schema Updates
- **Updated**: `src/lib/ai-tools-schema.ts`
  - Removed 'failed' from success enum (now: excellent, good, fair, poor)
  - Maintains existing tool definitions for add/update/remove/list operations

### Testing
- **New test suite**: `src/__tests__/services/ai-tool-executor.test.ts` (479 lines)
  - Comprehensive tests for all tool operations
  - Validation and error handling tests
  - Batch execution and state accumulation tests
  - Result formatting tests

## Implementation Details

- **Immutable operations**: All tool executions return new AllotmentData objects; caller handles persistence
- **Validation**: Comprehensive checks for area existence, planting permissions, plant database validity
- **User confirmation**: Tool calls require explicit user approval before execution
- **Error recovery**: Failed operations don't prevent subsequent operations in batch
- **Plant matching**: Flexible plant ID matching (exact, case-insensitive, singular/plural)
- **Data persistence**: Updated data saved to localStorage and reloaded via `useAllotment` hook

## Testing Coverage
- Add/update/remove planting operations
- Area validation and filtering
- Invalid arguments and unknown functions
- Batch execution with state accumulation
- Result formatting for AI responses

https://claude.ai/code/session_014NooxY16QmiyvETiY5rhFr