### PR TITLE
fix: pass enableTools to API route for function calling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # OpenAI API Key (optional - users can provide their own via BYOK)
 # OPENAI_API_KEY=sk-...
 
+# AI Tools Feature Flag - enables Aitor to modify garden data via function calling
+# Set to 'true' to enable AI inventory management (add/update/remove plantings)
+AI_TOOLS_ENABLED=true
+
 # Sentry Error Tracking (optional)
 # Get your DSN from https://sentry.io/settings/projects/[project]/keys/
 SENTRY_DSN=

--- a/src/lib/openai-client.ts
+++ b/src/lib/openai-client.ts
@@ -178,7 +178,8 @@ export async function callOpenAI(options: OpenAIClientOptions): Promise<OpenAIRe
         message: options.message,
         messages: options.messages,
         image: options.image,
-        allotmentContext: options.allotmentContext
+        allotmentContext: options.allotmentContext,
+        enableTools: options.enableTools
       })
     })
 


### PR DESCRIPTION
## Summary
Fixed AI tool calling not triggering via the API route.

## Problem
The client code wasn't passing `enableTools` to the API route, so even with `AI_TOOLS_ENABLED=true` on the server, tools were never activated.

## Changes
- Pass `enableTools` in the request body to `/api/ai-advisor`
- Document `AI_TOOLS_ENABLED` env var in `.env.example`

## How to Enable
Add to your `.env.local`:
```
AI_TOOLS_ENABLED=true
```

Then ask Aitor to add a planting, e.g., "Add tomatoes to bed A"

🤖 Generated with [Claude Code](https://claude.com/claude-code)