### PR TITLE
fix: add back buttons to QR code pairing views

### DIFF
--- a/src/components/sync/PairingModal.tsx
+++ b/src/components/sync/PairingModal.tsx
@@ -88,9 +88,32 @@ export function PairingModal({ open, onClose, onPaired }: PairingModalProps) {
           </div>
         )}
 
-        {step === 'show-qr' && payload && <QRCodeDisplay payload={payload} />}
+        {step === 'show-qr' && payload && (
+          <div className="flex flex-col gap-4">
+            <QRCodeDisplay payload={payload} />
+            <p className="text-xs text-gray-500 text-center">
+              Open Settings → Add Device → Scan QR Code on your other device
+            </p>
+            <button
+              onClick={() => setStep('choose')}
+              className="px-4 py-2 border rounded hover:bg-gray-50"
+            >
+              Back
+            </button>
+          </div>
+        )}
 
-        {step === 'scan-qr' && <QRCodeScanner onScan={handleScan} onError={setError} />}
+        {step === 'scan-qr' && (
+          <div className="flex flex-col gap-4">
+            <QRCodeScanner onScan={handleScan} onError={setError} />
+            <button
+              onClick={() => setStep('choose')}
+              className="px-4 py-2 border rounded hover:bg-gray-50"
+            >
+              Back
+            </button>
+          </div>
+        )}
 
         {step === 'confirm' && scannedPayload && (
           <div className="text-center">


### PR DESCRIPTION
## Summary

- Add Back button to QR code display step
- Add Back button to QR code scanner step
- Add instructional text explaining how to scan from other device

## Problem

User couldn't exit the QR code view once opened - there was no way to go back or close the modal from that screen.

## Test plan

- [x] E2E tests pass (12/12)
- [x] TypeScript compiles cleanly
- [x] Manually verify Back button appears and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)