### PR TITLE
fix: add error handling to DeviceSettings to prevent blank screen

### DIFF
--- a/src/components/sync/DeviceSettings.tsx
+++ b/src/components/sync/DeviceSettings.tsx
@@ -17,10 +17,21 @@ export function DeviceSettings() {
   const [editingName, setEditingName] = useState(false)
   const [newName, setNewName] = useState('')
   const [showPairing, setShowPairing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    setIdentity(getOrCreateIdentity())
-    setDevices(getPairedDevices())
+    try {
+      const id = getOrCreateIdentity()
+      setIdentity(id)
+      setDevices(getPairedDevices())
+      setError(null)
+    } catch (err) {
+      console.error('Failed to initialize device identity:', err)
+      setError(err instanceof Error ? err.message : 'Failed to initialize device identity')
+    } finally {
+      setIsLoading(false)
+    }
   }, [])
 
   const handleSaveName = () => {
@@ -41,7 +52,33 @@ export function DeviceSettings() {
     setShowPairing(false)
   }
 
-  if (!identity) return null
+  if (isLoading) {
+    return (
+      <div className="text-center py-8 text-gray-500">
+        Loading device settings...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <p className="text-red-700 font-medium">Unable to initialize device sync</p>
+        <p className="text-red-600 text-sm mt-1">{error}</p>
+        <p className="text-gray-600 text-sm mt-2">
+          This may be a browser compatibility issue. Try using Chrome or Safari.
+        </p>
+      </div>
+    )
+  }
+
+  if (!identity) {
+    return (
+      <div className="text-center py-8 text-gray-500">
+        Unable to create device identity
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary

Adds proper error handling and loading states to the DeviceSettings component to prevent a blank screen when device identity initialization fails.

## Problem

When `getOrCreateIdentity()` fails (e.g., due to crypto library compatibility issues on certain mobile browsers), the component was returning `null` and showing nothing - just a blank settings page.

## Changes

- Add loading state with "Loading device settings..." message
- Catch errors during identity initialization and display them
- Show helpful error message suggesting Chrome or Safari if it fails
- Add fallback message if identity is null without error

## Test plan

- [x] TypeScript compiles
- [x] Unit tests pass (545/545)
- [ ] Test on mobile - should now show error message instead of blank screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)