### PR TITLE
fix: use html5-qrcode for cross-browser QR scanning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@sentry/nextjs": "^10.34.0",
         "@serwist/next": "^9.5.0",
         "@yudiel/react-qr-scanner": "^2.5.1",
+        "html5-qrcode": "^2.3.8",
         "lucide-react": "^0.518.0",
         "next": "^16.1.6",
         "qrcode.react": "^4.2.0",
@@ -7403,6 +7404,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/html5-qrcode": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@sentry/nextjs": "^10.34.0",
     "@serwist/next": "^9.5.0",
     "@yudiel/react-qr-scanner": "^2.5.1",
+    "html5-qrcode": "^2.3.8",
     "lucide-react": "^0.518.0",
     "next": "^16.1.6",
     "qrcode.react": "^4.2.0",

--- a/src/components/sync/QRCodeScanner.tsx
+++ b/src/components/sync/QRCodeScanner.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Scanner } from '@yudiel/react-qr-scanner'
+import { useState, useEffect, useRef } from 'react'
+import { Html5Qrcode } from 'html5-qrcode'
 import type { PairingPayload } from '@/types/sync'
 
 interface QRCodeScannerProps {
@@ -10,63 +10,86 @@ interface QRCodeScannerProps {
 }
 
 export function QRCodeScanner({ onScan, onError }: QRCodeScannerProps) {
-  const [hasPermission, setHasPermission] = useState(true)
   const [isScanning, setIsScanning] = useState(false)
-  const [scanStatus, setScanStatus] = useState<string>('Initializing camera...')
+  const [scanStatus, setScanStatus] = useState('Initializing camera...')
+  const [hasPermission, setHasPermission] = useState(true)
+  const scannerRef = useRef<Html5Qrcode | null>(null)
+  const hasProcessedRef = useRef(false)
 
   useEffect(() => {
-    // Check if BarcodeDetector API is available
-    if (!('BarcodeDetector' in window)) {
-      setScanStatus('QR scanning may not work in this browser. Try Chrome or Safari.')
-    } else {
-      setScanStatus('Point camera at QR code')
-    }
-  }, [])
+    const scannerId = 'qr-scanner-container'
 
-  const handleScan = (result: { rawValue: string }[]) => {
-    if (result.length === 0) return
-    if (isScanning) return // Prevent double scans
+    const startScanner = async () => {
+      try {
+        const scanner = new Html5Qrcode(scannerId)
+        scannerRef.current = scanner
 
-    setIsScanning(true)
-    setScanStatus('QR code detected!')
+        await scanner.start(
+          { facingMode: 'environment' },
+          {
+            fps: 10,
+            qrbox: { width: 250, height: 250 },
+          },
+          (decodedText) => {
+            if (hasProcessedRef.current) return
+            hasProcessedRef.current = true
 
-    try {
-      const rawValue = result[0].rawValue
-      console.log('QR Scanned:', rawValue) // Debug log
+            setScanStatus('QR code detected!')
+            console.log('QR Scanned:', decodedText)
 
-      const payload = JSON.parse(rawValue) as PairingPayload
-      if (payload.v !== 1 || !payload.pk || !payload.code || !payload.name) {
-        onError('Invalid QR code - not a Bonnie Wee Plot pairing code')
-        setIsScanning(false)
+            try {
+              const payload = JSON.parse(decodedText) as PairingPayload
+              if (payload.v !== 1 || !payload.pk || !payload.code || !payload.name) {
+                onError('Invalid QR code - not a Bonnie Wee Plot pairing code')
+                hasProcessedRef.current = false
+                setScanStatus('Point camera at QR code')
+                return
+              }
+
+              // Stop scanner before calling onScan
+              scanner.stop().catch(console.error)
+              onScan(payload)
+            } catch {
+              onError('Could not read QR code - invalid format')
+              hasProcessedRef.current = false
+              setScanStatus('Point camera at QR code')
+            }
+          },
+          () => {
+            // Ignore scan failures (no QR found in frame)
+          }
+        )
+
+        setIsScanning(true)
         setScanStatus('Point camera at QR code')
-        return
+      } catch (err) {
+        console.error('Scanner error:', err)
+        if (err instanceof Error) {
+          if (err.message.includes('NotAllowedError') || err.message.includes('Permission')) {
+            setHasPermission(false)
+            return
+          }
+          setScanStatus(`Error: ${err.message}`)
+        }
+        onError('Failed to start camera')
       }
-      onScan(payload)
-    } catch {
-      onError('Could not read QR code - invalid format')
-      setIsScanning(false)
-      setScanStatus('Point camera at QR code')
     }
-  }
 
-  const handleError = (error: unknown) => {
-    console.error('Scanner error:', error) // Debug log
-    if (error instanceof Error) {
-      if (error.name === 'NotAllowedError') {
-        setHasPermission(false)
-        return
+    startScanner()
+
+    return () => {
+      if (scannerRef.current?.isScanning) {
+        scannerRef.current.stop().catch(console.error)
       }
-      setScanStatus(`Error: ${error.message}`)
     }
-    onError('Camera error - please try again')
-  }
+  }, [onScan, onError])
 
   if (!hasPermission) {
     return (
       <div className="text-center p-8">
         <p className="text-red-600 mb-2">Camera access denied</p>
         <p className="text-sm text-gray-500">
-          Please enable camera access in your browser settings.
+          Please enable camera access in your browser settings and reload the page.
         </p>
       </div>
     )
@@ -74,18 +97,16 @@ export function QRCodeScanner({ onScan, onError }: QRCodeScannerProps) {
 
   return (
     <div className="w-full max-w-sm mx-auto">
-      <Scanner
-        onScan={handleScan}
-        onError={handleError}
-        constraints={{ facingMode: 'environment' }}
-        styles={{ container: { borderRadius: '8px', overflow: 'hidden' } }}
-        formats={['qr_code']}
+      <div
+        id="qr-scanner-container"
+        className="rounded-lg overflow-hidden"
+        style={{ minHeight: '300px' }}
       />
       <p className="text-sm text-gray-500 text-center mt-4">
         {scanStatus}
       </p>
       <p className="text-xs text-gray-400 text-center mt-2">
-        Make sure the QR code is well-lit and fully visible
+        {isScanning ? 'Position the QR code within the frame' : 'Starting camera...'}
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary
- Replace @yudiel/react-qr-scanner with html5-qrcode library
- Fixes QR code scanning on iOS Safari (BarcodeDetector API not supported)
- Uses JavaScript-based QR decoding that works across all browsers

## Root Cause
The previous library (@yudiel/react-qr-scanner) relies on the BarcodeDetector API which is only supported on Chrome Android, not iOS Safari. Users reported the scanner showing camera feed but never detecting QR codes.

## Test plan
- [x] Unit tests pass
- [x] E2E tests pass (12 sync tests)
- [ ] Test on iOS Safari to verify QR scanning works

🤖 Generated with [Claude Code](https://claude.com/claude-code)