### PR TITLE
feat: add close button to pairing dialog

### DIFF
--- a/src/components/sync/PairingModal.tsx
+++ b/src/components/sync/PairingModal.tsx
@@ -64,7 +64,7 @@ export function PairingModal({ open, onClose, onPaired }: PairingModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" onClose={handleClose}>
         <DialogHeader>
           <DialogTitle>
             {step === 'choose' && 'Add Device'}

--- a/src/components/ui/shadcn-dialog.tsx
+++ b/src/components/ui/shadcn-dialog.tsx
@@ -42,9 +42,10 @@ export function Dialog({ open, onOpenChange, children }: DialogProps) {
 interface DialogContentProps {
   children: ReactNode
   className?: string
+  onClose?: () => void
 }
 
-export function DialogContent({ children, className = '' }: DialogContentProps) {
+export function DialogContent({ children, className = '', onClose }: DialogContentProps) {
   return (
     <div
       role="dialog"
@@ -52,6 +53,18 @@ export function DialogContent({ children, className = '' }: DialogContentProps) 
       className={`relative z-[102] bg-white rounded-xl shadow-xl w-full max-w-md p-6 ${className}`}
       onClick={(e) => e.stopPropagation()}
     >
+      {onClose && (
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
+          aria-label="Close"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+      )}
       {children}
     </div>
   )


### PR DESCRIPTION
## Summary
- Add X close button to top-right of pairing dialog
- Allows users to dismiss the dialog without clicking the backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)