### PR TITLE
fix: add PeerJS to CSP connect-src for P2P sync

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ const cspDirectives = {
   'default-src': ["'self'"],
   'script-src': ["'self'", "'unsafe-eval'", "'unsafe-inline'"],  // Next.js requires eval in dev
   'style-src': ["'self'", "'unsafe-inline'"],  // Tailwind CSS requirement
-  'connect-src': ["'self'", 'https://api.openai.com'],
+  'connect-src': ["'self'", 'https://api.openai.com', 'wss://0.peerjs.com', 'https://0.peerjs.com'],
   'img-src': ["'self'", 'data:', 'blob:', 'https://images.unsplash.com'],
   'font-src': ["'self'"],
   'frame-ancestors': ["'none'"],


### PR DESCRIPTION
## Summary
Add PeerJS signaling server to Content Security Policy's connect-src directive.

## Problem
CSP was blocking WebSocket connections to `wss://0.peerjs.com`, preventing P2P sync from working.

## Solution
Added `wss://0.peerjs.com` and `https://0.peerjs.com` to the allowed connect sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)