### PR TITLE
fix: use html5-qrcode for cross-browser QR scanning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@sentry/nextjs": "^10.34.0",
         "@serwist/next": "^9.5.0",
         "@upstash/redis": "^1.36.1",
-        "@yudiel/react-qr-scanner": "^2.5.1",
         "html5-qrcode": "^2.3.8",
         "lucide-react": "^0.518.0",
         "next": "^16.1.6",
@@ -3605,12 +3604,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/emscripten": {
-      "version": "1.41.5",
-      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
-      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -4629,20 +4622,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@yudiel/react-qr-scanner": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@yudiel/react-qr-scanner/-/react-qr-scanner-2.5.1.tgz",
-      "integrity": "sha512-FWzHaCneu30mQpE80VNWx4IPtBjXFEiTzhwWunZy3afvvAy/x0aVIgYijJKEbROoaAeDfcJ/gIyUCqPBP7bMOw==",
-      "license": "MIT",
-      "dependencies": {
-        "barcode-detector": "3.0.8",
-        "webrtc-adapter": "9.0.3"
-      },
-      "peerDependencies": {
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5154,15 +5133,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/barcode-detector": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.0.8.tgz",
-      "integrity": "sha512-Z9jzzE8ngEDyN9EU7lWdGgV07mcnEQnrX8W9WecXDqD2v+5CcVjt9+a134a5zb+kICvpsrDx6NYA6ay4LGFs8A==",
-      "license": "MIT",
-      "dependencies": {
-        "zxing-wasm": "2.2.4"
-      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
@@ -11244,12 +11214,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/sdp": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
-      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -12021,18 +11985,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
@@ -13030,19 +12982,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/webrtc-adapter": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
-      "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "sdp": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.10.0"
-      }
-    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -13398,34 +13337,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/zxing-wasm": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-2.2.4.tgz",
-      "integrity": "sha512-1gq5zs4wuNTs5umWLypzNNeuJoluFvwmvjiiT3L9z/TMlVveeJRWy7h90xyUqCe+Qq0zL0w7o5zkdDMWDr9aZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/emscripten": "^1.41.5",
-        "type-fest": "^5.2.0"
-      },
-      "peerDependencies": {
-        "@types/emscripten": ">=1.39.6"
-      }
-    },
-    "node_modules/zxing-wasm/node_modules/type-fest": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
-      "integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@sentry/nextjs": "^10.34.0",
     "@serwist/next": "^9.5.0",
     "@upstash/redis": "^1.36.1",
-    "@yudiel/react-qr-scanner": "^2.5.1",
     "html5-qrcode": "^2.3.8",
     "lucide-react": "^0.518.0",
     "next": "^16.1.6",


### PR DESCRIPTION
## Summary

Replace @yudiel/react-qr-scanner with html5-qrcode for the receive page QR scanner.

The previous library used BarcodeDetector API which is not supported on iOS Safari. html5-qrcode uses JavaScript-based decoding that works across all browsers.

## Test plan

- [ ] Test QR scanning on iOS Safari
- [ ] Test QR scanning on Android Chrome
- [ ] Test QR scanning on desktop browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)