### PR TITLE
fix(deps): update vite to resolve GHSA-p9ff-h696-f583

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13397,9 +13397,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Updates vite to resolve three high-severity vulnerabilities including GHSA-p9ff-h696-f583 (arbitrary file read via dev server WebSocket), GHSA-v2wj-q39q-566r (server.fs.deny bypass with queries), and GHSA-4w7w-66w2-5vf9 (path traversal in optimized deps .map handling).

Before: 1 high severity vulnerability (vite 7.0.0-7.3.1)
After: 0 vulnerabilities

## Test plan

- Build verified locally (next build succeeds)
- npm audit shows 0 vulnerabilities after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)