### PR TITLE
chore: finish dependabot/compost tech-debt cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Query functions in `src/lib/variety-queries.ts`:
 - `area-mutations.ts` — area CRUD, care logs, harvest tracking
 - `variety-operations.ts` — variety CRUD, seed inventory, supplier queries
 - `task-operations.ts` — custom tasks and maintenance tasks
+- `compost-operations.ts` — compost pile CRUD, inputs, events, and queries over `AllotmentData.compost`
 - `generic-storage.ts` — raw localStorage utilities
 
 All existing imports from `@/services/allotment-storage` continue to work unchanged via the barrel file. Immutable update patterns, Promise-based `flushSave()`, and automatic backup creation before imports are preserved.

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,6 @@
 # Current Plan
 
-Last updated: 2026-04-14
+Last updated: 2026-04-16
 
 ## What's Been Completed
 
@@ -194,6 +194,11 @@ After the page-by-page review, a batch of smaller fixes and housekeeping work la
 - **PR #267** Added `.github/dependabot.yml` as the single source of dependency automation (the earlier `renovate.json` was retired in favour of the GitHub-native tool).
 - **PRs #268–#277, #290** Grouped dependency bumps (react, nextjs, sentry, serwist, playwright, vitest, type-definitions, upstash, etc.) plus removal of the deprecated `@types/react-grid-layout`.
 - **PR #282** Removed the redundant Snyk workflow; the Snyk App handles security scanning.
+
+### Tech Debt Cleanup (April 2026)
+
+- Confirmed `renovate.json` is gone; Dependabot (`.github/dependabot.yml`) is the sole dependency automation.
+- Retired `compost-storage.ts`: the pure mutation/query helpers live in `src/services/compost-operations.ts` and are now re-exported from the `allotment-storage` barrel. `useCompost` imports through the unified barrel and stale `compost-storage` comments were updated.
 
 ### Remaining Backlog
 

--- a/docs/research/repo-analysis-and-improvements.md
+++ b/docs/research/repo-analysis-and-improvements.md
@@ -15,26 +15,9 @@ This analysis identifies **no critical blockers** but surfaces actionable improv
 
 ## 1. Code Structure Improvements
 
-### 1.1 Split `allotment-storage.ts` (3,356 lines)
+### 1.1 Split `allotment-storage.ts` — ✅ Done (March 2026 Tech Debt Sprint)
 
-This is the single largest maintainability concern. The file contains schema validation, repair logic, 16 migration versions, and all CRUD operations in one place. This was already identified in `pre-production-strategic-plan.md` but not yet actioned.
-
-**Proposed split:**
-```
-src/services/allotment/
-├── index.ts              # Re-exports public API
-├── storage.ts            # Core load/save/flush operations
-├── validation.ts         # validateAllotmentData, repairAllotmentData
-├── migrations.ts         # migrateSchema (v1→v16) + migration helpers
-├── crud-areas.ts         # addArea, updateArea, removeArea
-├── crud-plantings.ts     # addPlanting, updatePlanting, removePlanting
-├── crud-seasons.ts       # addSeason, updateSeason helpers
-├── crud-varieties.ts     # addVariety, updateVariety, archiveVariety
-├── crud-maintenance.ts   # maintenance task operations
-└── stats.ts              # getStorageStats, diagnostic functions
-```
-
-**Impact:** Smaller files are easier to review, test, and maintain. Migration code (which rarely changes) stops cluttering the CRUD functions (which change often). Each module can have focused unit tests.
+Originally flagged as the largest maintainability concern (3,356 lines with schema validation, repair logic, migrations, and all CRUD in one file). Now split into focused modules under `src/services/` — `storage-core.ts`, `storage-validation.ts`, `storage-migrations.ts`, `season-operations.ts`, `planting-operations.ts`, `area-queries.ts`, `area-mutations.ts`, `variety-operations.ts`, `task-operations.ts`, `compost-operations.ts`, and `generic-storage.ts`. The original path re-exports everything via a barrel so existing imports continue to work. Current schema version is v18 (not v16).
 
 ### 1.2 Replace `console.log` with structured logger in storage service
 

--- a/docs/research/repo-analysis-and-improvements.md
+++ b/docs/research/repo-analysis-and-improvements.md
@@ -253,11 +253,9 @@ Data lives exclusively in localStorage. If a user clears browser data, everythin
 ### 6.3 Compost section integration
 
 The compost feature feels somewhat isolated from the rest of the app:
-- Dashboard has `CompostAlerts` but the compost data model (`compost-storage.ts`) is completely separate from `AllotmentData`
+- Schema v18 folded compost data into `AllotmentData.compost`, and the former `compost-storage.ts` service was replaced by pure helpers in `compost-operations.ts` (re-exported via the `allotment-storage` barrel). Export/import consistency is therefore resolved.
 - No integration with the AI Advisor (Aitor can't answer compost questions with context)
 - No link between compost piles and specific beds/areas
-
-This may be intentional (keep sections focused per "Simplicity First"), but it's worth considering whether compost data should be part of `AllotmentData` for export/import consistency.
 
 ### 6.4 Search/filter capabilities
 

--- a/src/hooks/useCompost.ts
+++ b/src/hooks/useCompost.ts
@@ -15,16 +15,16 @@ import {
   NewCompostEvent,
 } from '@/types/compost'
 import {
-  addPile as storageAddPile,
-  updatePile as storageUpdatePile,
-  removePile as storageRemovePile,
-  addInput as storageAddInput,
-  removeInput as storageRemoveInput,
-  addEvent as storageAddEvent,
-  removeEvent as storageRemoveEvent,
-  getPileById,
-  getPilesByStatus,
-  getActivePiles,
+  addCompostPile as storageAddPile,
+  updateCompostPile as storageUpdatePile,
+  removeCompostPile as storageRemovePile,
+  addCompostInput as storageAddInput,
+  removeCompostInput as storageRemoveInput,
+  addCompostEvent as storageAddEvent,
+  removeCompostEvent as storageRemoveEvent,
+  getCompostPileById,
+  getCompostPilesByStatus,
+  getActiveCompostPiles,
 } from '@/services/allotment-storage'
 import type { CompostData } from '@/types/compost'
 import type { AllotmentData } from '@/types/unified-allotment'
@@ -135,17 +135,17 @@ export function useCompost(): UseCompostReturn {
 
   const getPile = useCallback((pileId: string) => {
     if (!compostData) return undefined
-    return getPileById(compostData, pileId)
+    return getCompostPileById(compostData, pileId)
   }, [compostData])
 
   const getPilesByStatusData = useCallback((status: CompostPile['status']) => {
     if (!compostData) return []
-    return getPilesByStatus(compostData, status)
+    return getCompostPilesByStatus(compostData, status)
   }, [compostData])
 
   const getActivePilesData = useCallback(() => {
     if (!compostData) return []
-    return getActivePiles(compostData)
+    return getActiveCompostPiles(compostData)
   }, [compostData])
 
   // ============ INPUT OPERATIONS ============

--- a/src/hooks/useCompost.ts
+++ b/src/hooks/useCompost.ts
@@ -25,7 +25,7 @@ import {
   getPileById,
   getPilesByStatus,
   getActivePiles,
-} from '@/services/compost-operations'
+} from '@/services/allotment-storage'
 import type { CompostData } from '@/types/compost'
 import type { AllotmentData } from '@/types/unified-allotment'
 import { useAllotmentData } from './allotment/useAllotmentData'
@@ -71,8 +71,8 @@ export interface UseCompostActions {
 export type UseCompostReturn = UseCompostState & UseCompostActions
 
 /**
- * Build a CompostData wrapper from AllotmentData for use with the existing
- * compost-storage pure functions (which operate on CompostData).
+ * Build a CompostData wrapper from AllotmentData for use with the
+ * compost-operations pure functions (which operate on CompostData).
  */
 function toCompostData(allotmentData: AllotmentData): CompostData {
   return {
@@ -105,7 +105,7 @@ export function useCompost(): UseCompostReturn {
     return toCompostData(allotmentData)
   }, [allotmentData])
 
-  // Helper: apply a compost-storage mutation and write back to AllotmentData
+  // Helper: apply a compost-operations mutation and write back to AllotmentData
   const applyCompostMutation = useCallback(
     (mutate: (cd: CompostData) => CompostData) => {
       if (!allotmentData) return

--- a/src/services/allotment-storage.ts
+++ b/src/services/allotment-storage.ts
@@ -161,16 +161,16 @@ export {
 
 // Compost operations (pure mutations + queries over AllotmentData.compost)
 export {
-  addPile,
-  updatePile,
-  removePile,
-  addInput,
-  removeInput,
-  addEvent,
-  removeEvent,
-  getPileById,
-  getPilesByStatus,
-  getActivePiles,
+  addCompostPile,
+  updateCompostPile,
+  removeCompostPile,
+  addCompostInput,
+  removeCompostInput,
+  addCompostEvent,
+  removeCompostEvent,
+  getCompostPileById,
+  getCompostPilesByStatus,
+  getActiveCompostPiles,
 } from './compost-operations'
 
 // Generic localStorage utilities

--- a/src/services/allotment-storage.ts
+++ b/src/services/allotment-storage.ts
@@ -159,6 +159,20 @@ export {
   removeMaintenanceTask,
 } from './task-operations'
 
+// Compost operations (pure mutations + queries over AllotmentData.compost)
+export {
+  addPile,
+  updatePile,
+  removePile,
+  addInput,
+  removeInput,
+  addEvent,
+  removeEvent,
+  getPileById,
+  getPilesByStatus,
+  getActivePiles,
+} from './compost-operations'
+
 // Generic localStorage utilities
 export {
   getStorageItem,

--- a/src/services/compost-operations.ts
+++ b/src/services/compost-operations.ts
@@ -24,7 +24,7 @@ import { generateId } from '@/lib/utils/id'
 /**
  * Add a new compost pile
  */
-export function addPile(data: CompostData, pile: NewCompostPile): CompostData {
+export function addCompostPile(data: CompostData, pile: NewCompostPile): CompostData {
   const now = new Date().toISOString()
   const newPile: CompostPile = {
     ...pile,
@@ -45,7 +45,7 @@ export function addPile(data: CompostData, pile: NewCompostPile): CompostData {
 /**
  * Update a compost pile
  */
-export function updatePile(
+export function updateCompostPile(
   data: CompostData,
   pileId: string,
   updates: Partial<Omit<CompostPile, 'id' | 'inputs' | 'events' | 'createdAt'>>
@@ -66,7 +66,7 @@ export function updatePile(
 /**
  * Remove a compost pile
  */
-export function removePile(data: CompostData, pileId: string): CompostData {
+export function removeCompostPile(data: CompostData, pileId: string): CompostData {
   return {
     ...data,
     piles: data.piles.filter(pile => pile.id !== pileId),
@@ -79,7 +79,7 @@ export function removePile(data: CompostData, pileId: string): CompostData {
 /**
  * Add an input to a compost pile
  */
-export function addInput(
+export function addCompostInput(
   data: CompostData,
   pileId: string,
   input: NewCompostInput
@@ -104,7 +104,7 @@ export function addInput(
 /**
  * Remove an input from a compost pile
  */
-export function removeInput(
+export function removeCompostInput(
   data: CompostData,
   pileId: string,
   inputId: string
@@ -127,7 +127,7 @@ export function removeInput(
 /**
  * Add an event to a compost pile
  */
-export function addEvent(
+export function addCompostEvent(
   data: CompostData,
   pileId: string,
   event: NewCompostEvent
@@ -152,7 +152,7 @@ export function addEvent(
 /**
  * Remove an event from a compost pile
  */
-export function removeEvent(
+export function removeCompostEvent(
   data: CompostData,
   pileId: string,
   eventId: string
@@ -175,20 +175,20 @@ export function removeEvent(
 /**
  * Get a pile by ID
  */
-export function getPileById(data: CompostData, pileId: string): CompostPile | undefined {
+export function getCompostPileById(data: CompostData, pileId: string): CompostPile | undefined {
   return data.piles.find(pile => pile.id === pileId)
 }
 
 /**
  * Get piles by status
  */
-export function getPilesByStatus(data: CompostData, status: CompostPile['status']): CompostPile[] {
+export function getCompostPilesByStatus(data: CompostData, status: CompostPile['status']): CompostPile[] {
   return data.piles.filter(pile => pile.status === status)
 }
 
 /**
  * Get active piles (not yet applied)
  */
-export function getActivePiles(data: CompostData): CompostPile[] {
+export function getActiveCompostPiles(data: CompostData): CompostPile[] {
   return data.piles.filter(pile => pile.status !== 'applied')
 }


### PR DESCRIPTION
- Re-export compost-operations helpers from the allotment-storage barrel
  so compost lives in the unified storage layer (useCompost now imports
  through the barrel).
- Drop stale `compost-storage` comment references in useCompost.
- Record in current-plan.md that renovate.json is gone and
  compost-storage.ts has been retired (Dependabot is the sole dep bot).
- Add compost-operations to the storage barrel list in CLAUDE.md.
- Refresh the compost note in repo-analysis-and-improvements.md to
  reflect the v18 AllotmentData integration.

No behaviour change. Lint clean, type-check clean, 830 unit tests pass.

https://claude.ai/code/session_015KswRBURPwtsLkgQwygRJM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and plans to reflect compost now integrated into allotment data, new compost operation coverage, and recent planning/tech-debt notes.

* **Chores**
  * Reorganized internal compost service/export surface and renamed compost operation identifiers for clarity. No user-facing behavior or APIs were removed; functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->