### PR TITLE
fix(plant-edit): reflect edits in UI and recalc harvest on edit

### DIFF
--- a/src/components/allotment/MobileAreaBottomSheet.tsx
+++ b/src/components/allotment/MobileAreaBottomSheet.tsx
@@ -94,13 +94,16 @@ export default function MobileAreaBottomSheet({
   onArchiveArea,
   onClose,
 }: MobileAreaBottomSheetProps) {
-  const [selectedPlanting, setSelectedPlanting] = useState<Planting | null>(null)
+  const [selectedPlantingId, setSelectedPlantingId] = useState<string | null>(null)
   const [showArchiveConfirm, setShowArchiveConfirm] = useState(false)
   const [summaryPlantId, setSummaryPlantId] = useState<string | null>(null)
 
   const area = selectedItemRef ? getArea(selectedItemRef.id) : undefined
   const areaSeason = area ? getAreaSeason(area.id) : null
   const plantings = area ? getPlantings(area.id) : []
+  const selectedPlanting = selectedPlantingId
+    ? plantings.find(p => p.id === selectedPlantingId) || null
+    : null
   const notes = area ? getAreaNotes(area.id) : []
   const previousYearRotation = area ? getPreviousYearRotation(area.id) : null
 
@@ -283,7 +286,7 @@ export default function MobileAreaBottomSheet({
                         planting={p}
                         onUpdate={(updates) => onUpdatePlanting(p.id, updates)}
                         otherPlantings={plantings}
-                        onClick={() => setSelectedPlanting(p)}
+                        onClick={() => setSelectedPlantingId(p.id)}
                         onPlantInfo={setSummaryPlantId}
                       />
                     ))}
@@ -347,16 +350,16 @@ export default function MobileAreaBottomSheet({
       <PlantingDetailDialog
         planting={selectedPlanting}
         isOpen={!!selectedPlanting}
-        onClose={() => setSelectedPlanting(null)}
+        onClose={() => setSelectedPlantingId(null)}
         onUpdate={(updates) => {
-          if (selectedPlanting) {
-            onUpdatePlanting(selectedPlanting.id, updates)
+          if (selectedPlantingId) {
+            onUpdatePlanting(selectedPlantingId, updates)
           }
         }}
         onDelete={() => {
-          if (selectedPlanting) {
-            onDeletePlanting(selectedPlanting.id)
-            setSelectedPlanting(null)
+          if (selectedPlantingId) {
+            onDeletePlanting(selectedPlantingId)
+            setSelectedPlantingId(null)
           }
         }}
         otherPlantings={plantings}

--- a/src/components/allotment/PlantingDetailDialog.tsx
+++ b/src/components/allotment/PlantingDetailDialog.tsx
@@ -80,7 +80,7 @@ export default function PlantingDetailDialog({
   const PhaseIcon = phaseInfo ? getPhaseIcon(phaseInfo.phase) : Leaf
 
   const handleNotesBlur = useCallback(() => {
-    if (planting && localNotes !== planting.notes) {
+    if (planting && localNotes !== (planting.notes || '')) {
       emitUpdate({ notes: localNotes || undefined })
     }
   }, [planting, localNotes, emitUpdate])
@@ -91,24 +91,28 @@ export default function PlantingDetailDialog({
    */
   const handleUpdateAndRecalculate = useCallback(
     (updates: PlantingUpdate) => {
-      // Gate on the post-update sow date so recalculation still fires when
-      // the user is adding a sow date to a planting that didn't have one.
+      // Key-presence check (not value check) so clearing a field still triggers
+      // recalc — handleDateChange passes `undefined` for empty strings.
+      const touchesHarvestInputs =
+        'sowDate' in updates || 'transplantDate' in updates || 'sowMethod' in updates
       const merged = planting ? { ...planting, ...updates } : null
-      const needsRecalculation =
-        !!merged &&
-        !!veg &&
-        !!merged.sowDate &&
-        (updates.sowDate !== undefined ||
-          updates.transplantDate !== undefined ||
-          updates.sowMethod !== undefined)
 
-      if (needsRecalculation && merged && veg) {
-        const updatedPlanting = populateExpectedHarvest(merged, veg)
-        emitUpdate({
-          ...updates,
-          expectedHarvestStart: updatedPlanting.expectedHarvestStart,
-          expectedHarvestEnd: updatedPlanting.expectedHarvestEnd,
-        })
+      if (merged && veg && touchesHarvestInputs) {
+        if (!merged.sowDate) {
+          // Sow date gone — drop the stale expected harvest window.
+          emitUpdate({
+            ...updates,
+            expectedHarvestStart: undefined,
+            expectedHarvestEnd: undefined,
+          })
+        } else {
+          const updatedPlanting = populateExpectedHarvest(merged, veg)
+          emitUpdate({
+            ...updates,
+            expectedHarvestStart: updatedPlanting.expectedHarvestStart,
+            expectedHarvestEnd: updatedPlanting.expectedHarvestEnd,
+          })
+        }
       } else {
         emitUpdate(updates)
       }

--- a/src/components/allotment/PlantingDetailDialog.tsx
+++ b/src/components/allotment/PlantingDetailDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import {
   Droplets,
   Sun,
@@ -13,6 +13,7 @@ import {
   Info,
   Leaf,
   Star,
+  CheckCircle2,
 } from 'lucide-react'
 import Dialog, { ConfirmDialog } from '@/components/ui/Dialog'
 import Tabs, { Tab } from '@/components/ui/Tabs'
@@ -44,6 +45,8 @@ export default function PlantingDetailDialog({
   const [localSowDate, setLocalSowDate] = useState(formatDateForInput(planting?.sowDate))
   const [localTransplantDate, setLocalTransplantDate] = useState(formatDateForInput(planting?.transplantDate))
   const [localHarvestDate, setLocalHarvestDate] = useState(formatDateForInput(planting?.actualHarvestStart))
+  const [savedFlash, setSavedFlash] = useState(false)
+  const savedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     setLocalNotes(planting?.notes || '')
@@ -51,6 +54,22 @@ export default function PlantingDetailDialog({
     setLocalTransplantDate(formatDateForInput(planting?.transplantDate))
     setLocalHarvestDate(formatDateForInput(planting?.actualHarvestStart))
   }, [planting?.id, planting?.notes, planting?.sowDate, planting?.transplantDate, planting?.actualHarvestStart])
+
+  useEffect(() => {
+    return () => {
+      if (savedTimeoutRef.current) clearTimeout(savedTimeoutRef.current)
+    }
+  }, [])
+
+  const emitUpdate = useCallback(
+    (updates: PlantingUpdate) => {
+      onUpdate(updates)
+      setSavedFlash(true)
+      if (savedTimeoutRef.current) clearTimeout(savedTimeoutRef.current)
+      savedTimeoutRef.current = setTimeout(() => setSavedFlash(false), 1800)
+    },
+    [onUpdate]
+  )
 
   const veg = planting ? getVegetableById(planting.plantId) : null
   const { goods, bads } = planting
@@ -62,9 +81,9 @@ export default function PlantingDetailDialog({
 
   const handleNotesBlur = useCallback(() => {
     if (planting && localNotes !== planting.notes) {
-      onUpdate({ notes: localNotes || undefined })
+      emitUpdate({ notes: localNotes || undefined })
     }
-  }, [planting, localNotes, onUpdate])
+  }, [planting, localNotes, emitUpdate])
 
   /**
    * Helper to update planting fields and recalculate harvest dates when needed
@@ -72,30 +91,29 @@ export default function PlantingDetailDialog({
    */
   const handleUpdateAndRecalculate = useCallback(
     (updates: PlantingUpdate) => {
-      // Check if we need to recalculate harvest dates
+      // Gate on the post-update sow date so recalculation still fires when
+      // the user is adding a sow date to a planting that didn't have one.
+      const merged = planting ? { ...planting, ...updates } : null
       const needsRecalculation =
-        planting &&
-        veg &&
-        planting.sowDate &&
+        !!merged &&
+        !!veg &&
+        !!merged.sowDate &&
         (updates.sowDate !== undefined ||
           updates.transplantDate !== undefined ||
           updates.sowMethod !== undefined)
 
-      if (needsRecalculation) {
-        const updatedPlanting = populateExpectedHarvest(
-          { ...planting, ...updates },
-          veg
-        )
-        onUpdate({
+      if (needsRecalculation && merged && veg) {
+        const updatedPlanting = populateExpectedHarvest(merged, veg)
+        emitUpdate({
           ...updates,
           expectedHarvestStart: updatedPlanting.expectedHarvestStart,
           expectedHarvestEnd: updatedPlanting.expectedHarvestEnd,
         })
       } else {
-        onUpdate(updates)
+        emitUpdate(updates)
       }
     },
-    [onUpdate, planting, veg]
+    [emitUpdate, planting, veg]
   )
 
   const handleDateChange = useCallback(
@@ -118,9 +136,9 @@ export default function PlantingDetailDialog({
 
   const handleSuccessChange = useCallback(
     (success: Planting['success']) => {
-      onUpdate({ success: success || undefined })
+      emitUpdate({ success: success || undefined })
     },
-    [onUpdate]
+    [emitUpdate]
   )
 
   const handleDelete = useCallback(() => {
@@ -362,7 +380,18 @@ export default function PlantingDetailDialog({
                 {crossYearInfo.label}
               </span>
             )}
+            <span
+              className={`ml-auto inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full bg-zen-moss-50 text-zen-moss-700 transition-opacity ${savedFlash ? 'opacity-100' : 'opacity-0'}`}
+              aria-live="polite"
+              role="status"
+            >
+              <CheckCircle2 className="w-3.5 h-3.5" />
+              Saved
+            </span>
           </div>
+          <p className="text-xs text-zen-stone-500 mb-3">
+            Changes save automatically as you edit.
+          </p>
 
           {/* Tabs */}
           <div className="flex-1">

--- a/src/components/allotment/details/BedDetailPanel.tsx
+++ b/src/components/allotment/details/BedDetailPanel.tsx
@@ -53,9 +53,12 @@ export default function BedDetailPanel({
   onArchiveArea,
 }: BedDetailPanelProps) {
   const [isEditMode, setIsEditMode] = useState(false)
-  const [selectedPlanting, setSelectedPlanting] = useState<Planting | null>(null)
+  const [selectedPlantingId, setSelectedPlantingId] = useState<string | null>(null)
   const [showArchiveConfirm, setShowArchiveConfirm] = useState(false)
   const [summaryPlantId, setSummaryPlantId] = useState<string | null>(null)
+  const selectedPlanting = selectedPlantingId
+    ? plantings.find(p => p.id === selectedPlantingId) || null
+    : null
   // Determine if this is a rotation bed (vs perennial bed)
   const isRotationBed = area.kind === 'rotation-bed'
 
@@ -220,7 +223,7 @@ export default function BedDetailPanel({
                 planting={p}
                 onUpdate={(updates) => onUpdatePlanting(p.id, updates)}
                 otherPlantings={plantings}
-                onClick={() => setSelectedPlanting(p)}
+                onClick={() => setSelectedPlantingId(p.id)}
                 onPlantInfo={setSummaryPlantId}
               />
             ))}
@@ -263,16 +266,16 @@ export default function BedDetailPanel({
     <PlantingDetailDialog
       planting={selectedPlanting}
       isOpen={!!selectedPlanting}
-      onClose={() => setSelectedPlanting(null)}
+      onClose={() => setSelectedPlantingId(null)}
       onUpdate={(updates) => {
-        if (selectedPlanting) {
-          onUpdatePlanting(selectedPlanting.id, updates)
+        if (selectedPlantingId) {
+          onUpdatePlanting(selectedPlantingId, updates)
         }
       }}
       onDelete={() => {
-        if (selectedPlanting) {
-          onDeletePlanting(selectedPlanting.id)
-          setSelectedPlanting(null)
+        if (selectedPlantingId) {
+          onDeletePlanting(selectedPlantingId)
+          setSelectedPlantingId(null)
         }
       }}
       otherPlantings={plantings}

--- a/tests/allotment.spec.ts
+++ b/tests/allotment.spec.ts
@@ -1084,14 +1084,22 @@ test.describe('Planting Detail Dialog - Editing', () => {
   }
 
   async function openPlantingDetailDialog(page: import('@playwright/test').Page) {
-    await selectRotationBed(page)
-    // Click the planting card to open the detail dialog
+    // Seeded data guarantees Test Bed A exists — select it directly rather than
+    // routing through selectRotationBed, whose ensureRotationBedExists helper
+    // can race hydration and create a second empty bed under a slow dev server.
+    const gridItem = page.locator('[class*="react-grid-item"]').filter({ hasText: 'Test Bed A' }).first()
+    const mobileItem = page.getByRole('button').filter({ hasText: 'Test Bed A' }).first()
+    const bedTarget = (await gridItem.isVisible({ timeout: 5000 }).catch(() => false))
+      ? gridItem
+      : mobileItem
+    await expect(bedTarget).toBeVisible({ timeout: 10000 })
+    await bedTarget.click()
+
     const plantingCard = page.getByRole('button', { name: /View details for Carrot/i }).first()
-    await expect(plantingCard).toBeVisible({ timeout: 5000 })
+    await expect(plantingCard).toBeVisible({ timeout: 10000 })
     await plantingCard.click()
     const dialog = page.getByRole('dialog').filter({ hasText: /Carrot/i })
     await expect(dialog).toBeVisible({ timeout: 5000 })
-    // Switch to the Dates tab
     await dialog.getByRole('tab', { name: /Dates/i }).click()
     return dialog
   }

--- a/tests/allotment.spec.ts
+++ b/tests/allotment.spec.ts
@@ -1019,6 +1019,159 @@ test.describe('Allotment Infrastructure Areas', () => {
   })
 })
 
+test.describe('Planting Detail Dialog - Editing', () => {
+  // Seeds a rotation bed containing a single planting with no sow date / method
+  // so the edit flow can be exercised without going through the Add dialog.
+  async function seedBedWithPlanting(page: import('@playwright/test').Page) {
+    await page.evaluate(() => {
+      const now = new Date().toISOString()
+      const currentYear = new Date().getFullYear()
+      const testData = {
+        version: 18,
+        meta: {
+          name: 'My Allotment',
+          location: 'Edinburgh, Scotland',
+          createdAt: now,
+          updatedAt: now,
+        },
+        layout: {
+          areas: [
+            {
+              id: 'test-bed-a',
+              name: 'Test Bed A',
+              kind: 'rotation-bed',
+              position: { x: 0, y: 0, w: 2, h: 2 },
+            },
+          ],
+        },
+        seasons: [
+          {
+            year: currentYear,
+            status: 'current',
+            areas: [
+              {
+                areaId: 'test-bed-a',
+                rotationGroup: 'roots',
+                plantings: [
+                  {
+                    id: 'planting-carrot-1',
+                    plantId: 'carrot',
+                    status: 'planned',
+                  },
+                ],
+                notes: [],
+              },
+            ],
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+        currentYear,
+        maintenanceTasks: [],
+        varieties: [],
+        gardenEvents: [],
+      }
+      localStorage.setItem('allotment-unified-data', JSON.stringify(testData))
+      localStorage.setItem(
+        'bonnie-wee-plot-tours',
+        JSON.stringify({ disabled: true, completed: [], dismissed: [], pageVisits: {} })
+      )
+    })
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await page.locator('.animate-spin').waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {})
+    await page.locator('h1').filter({ hasText: /Plot Layout/i }).waitFor({ state: 'visible', timeout: 30000 })
+  }
+
+  async function openPlantingDetailDialog(page: import('@playwright/test').Page) {
+    await selectRotationBed(page)
+    // Click the planting card to open the detail dialog
+    const plantingCard = page.getByRole('button', { name: /View details for Carrot/i }).first()
+    await expect(plantingCard).toBeVisible({ timeout: 5000 })
+    await plantingCard.click()
+    const dialog = page.getByRole('dialog').filter({ hasText: /Carrot/i })
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+    // Switch to the Dates tab
+    await dialog.getByRole('tab', { name: /Dates/i }).click()
+    return dialog
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/allotment')
+    await seedBedWithPlanting(page)
+  })
+
+  test('sow method dropdown reflects selection immediately', async ({ page }) => {
+    const dialog = await openPlantingDetailDialog(page)
+
+    const sowMethod = dialog.locator('#sow-method')
+    await expect(sowMethod).toHaveValue('')
+
+    // Select "outdoor" — before the id-based lookup fix this would persist to
+    // storage but the dropdown value stayed empty.
+    await sowMethod.selectOption('outdoor')
+    await expect(sowMethod).toHaveValue('outdoor')
+
+    // Change again to make sure subsequent edits also reflect.
+    await sowMethod.selectOption('indoor')
+    await expect(sowMethod).toHaveValue('indoor')
+
+    // And the storage layer got the update too.
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const raw = localStorage.getItem('allotment-unified-data')
+          if (!raw) return null
+          const data = JSON.parse(raw)
+          return data.seasons?.[0]?.areas?.[0]?.plantings?.[0]?.sowMethod ?? null
+        })
+      )
+      .toBe('indoor')
+  })
+
+  test('adding a sow date on edit calculates expected harvest', async ({ page }) => {
+    const dialog = await openPlantingDetailDialog(page)
+
+    // No expected-harvest block yet since there's no sow date.
+    await expect(dialog.getByText('Expected Harvest')).toHaveCount(0)
+
+    // Pick outdoor sowing so the calculator has a method to work with.
+    await dialog.locator('#sow-method').selectOption('outdoor')
+
+    // Set a sow date — before the recalc gate fix this did NOT trigger
+    // populateExpectedHarvest because planting.sowDate (pre-update) was empty.
+    await dialog.locator('#sow-date').fill('2026-04-15')
+
+    await expect(dialog.getByText('Expected Harvest')).toBeVisible({ timeout: 3000 })
+
+    // Storage should contain populated expected-harvest fields too.
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const raw = localStorage.getItem('allotment-unified-data')
+          if (!raw) return null
+          const p = JSON.parse(raw).seasons?.[0]?.areas?.[0]?.plantings?.[0]
+          return p?.expectedHarvestStart ?? null
+        })
+      )
+      .not.toBeNull()
+  })
+
+  test('shows Saved indicator after an edit', async ({ page }) => {
+    const dialog = await openPlantingDetailDialog(page)
+
+    // The indicator is always in the DOM but fades in via opacity-100 /
+    // opacity-0, so we assert on the class toggling.
+    const savedBadge = dialog.getByRole('status').filter({ hasText: 'Saved' })
+
+    await expect(savedBadge).toHaveClass(/opacity-0/)
+
+    await dialog.locator('#sow-method').selectOption('outdoor')
+
+    await expect(savedBadge).toHaveClass(/opacity-100/, { timeout: 2000 })
+  })
+})
+
 test.describe('Plant Database - New Scottish Plants', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/allotment')


### PR DESCRIPTION
## Summary

Three issues in the planting detail dialog:

- **UI didn't update after dropdown/date changes.** `MobileAreaBottomSheet` and `BedDetailPanel` snapshotted the whole `Planting` into local state when the user opened the dialog. Updates persisted to storage, but the dialog kept receiving the stale snapshot as its `planting` prop, so fields like sow method wouldn't repaint. Switched both panels to hold `selectedPlantingId` and look up the current planting from the live `plantings` array on each render.

- **Expected-harvest recalc didn't fire when editing.** `PlantingDetailDialog.handleUpdateAndRecalculate` gated on `planting.sowDate` (pre-update). If a planting had no sow date and the user added one via edit, the recalc branch was skipped. Now it merges `updates` onto `planting` first and gates on the effective sow date.

- **No feedback that changes are saved.** Added a subtle "Saved" pill that flashes on each update and a small hint near the top of the dialog saying "Changes save automatically as you edit."

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 830 passed
- [ ] Manual: open a planting, change sow method — dropdown reflects the new value immediately
- [ ] Manual: create a planting with no sow date, then edit to add one — expected harvest dates populate
- [ ] Manual: any edit flashes the "Saved" indicator

https://claude.ai/code/session_012k3rDvbamgmvca4LAZw2Dd