### PR TITLE
feat: research-driven UI improvements (weather strip, crop progress, boost this bed, Aitor re-enable)

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -204,6 +204,16 @@ After the page-by-page review, a batch of smaller fixes and housekeeping work la
 
 - Automatic backup prompts
 
+### Competitor Learnings: Vercro (https://vercro.com)
+
+Reviewed Vercro, a UK/Ireland gardening task app with overlapping scope. Postcode/rainfall integration (their #1 differentiator) is already shipped here via Open-Meteo + schema v19. Remaining ideas worth considering:
+
+- **Plant Check — focused photo diagnosis.** Vercro's AI is a single-purpose "snap a sick plant → diagnosis" tool, not an open chat. Easier to explain and avoids the cold-start problem that contributed to hiding Aitor (`SHOW_AI_ADVISOR = false`). Could ship as a narrow feature alongside or instead of re-enabling the chat.
+- **Crop timeline visualisation.** Per-plant growth-stage strip showing where each planting sits between sow → expected harvest → actual harvest. We already store all the dates on `Planting`; this is purely a new view over existing data.
+- **"Boost this bed" affordance.** Per-bed positive-framing button surfacing concrete companion suggestions ("add marigolds to deter pests", "add broad beans to fix nitrogen"). We have `enhancedCompanions` data and a hidden `SHOW_ROTATION_SUGGESTIONS` flag — same data, friendlier framing than rotation constraints.
+- **Daily-plan positioning.** Their tagline ("Not a calendar. A plan.") leads users straight to today's tasks. Our Today dashboard already exists; mostly a marketing/landing-surface decision rather than a build.
+- **Social login.** Google/Apple one-tap via Clerk — config change, not a build.
+
 ### Future Phases (Contingent on User Adoption)
 
 These are from the pre-production strategic plan (`docs/research/pre-production-strategic-plan.md`):

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -235,11 +235,22 @@ Vercro frames companion planting as a positive next action ("add marigolds to de
 - Cross-reference `data.varieties[*].seedsByYear` to prefer companions the user already has seed for. Click → `AddPlantingForm` pre-filled with that variety.
 - Independent from the existing `SHOW_ROTATION_SUGGESTIONS` flag — this is positive-framed and shippable on day one; rotation suggestions can stay hidden.
 
-#### 4. Social login
+#### 4. Weather strip on Today (today / tomorrow / +1)
+
+Small forecast tiles above the existing rainfall line — icon, max/min temp, precipitation. Reuses everything that already exists: `fetchRainfall()` plumbing in `src/lib/weather/open-meteo.ts`, the localStorage cache, the coordinate gate, and `LocationPromptBanner`. Only changes:
+
+- Extend the Open-Meteo query with `weathercode`, `temperature_2m_max`, `temperature_2m_min` and bump `forecast_days` to 2 or 3.
+- Widen `RainfallSummary` (or split it) into a `WeatherSummary` with a `daily` array.
+- Map WMO weather codes to `lucide-react` icons (`Sun`, `Cloud`, `CloudRain`, `CloudSnow`, `CloudLightning`, `CloudDrizzle`).
+- New `<WeatherStrip>` component on `TodayDashboard.tsx`, ~3 tiles, hidden when `hasCoordinates` is false.
+
+Effort: ~1–2 hours; all infrastructure is already in place.
+
+#### 5. Social login
 
 Verify Google/Apple are enabled in the Clerk Dashboard for this project. Pure config; no code change. Worth doing alongside the Aitor re-enable since it lifts the friction on the auth gate that's about to do real work.
 
-#### 5. Drop: daily-plan positioning
+#### 6. Drop: daily-plan positioning
 
 Today is already the landing route, the onboarding wizard already covers the "open, follow, done" framing, and the marketing surface is small. No build to do.
 

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -206,13 +206,42 @@ After the page-by-page review, a batch of smaller fixes and housekeeping work la
 
 ### Competitor Learnings: Vercro (https://vercro.com)
 
-Reviewed Vercro, a UK/Ireland gardening task app with overlapping scope. Postcode/rainfall integration (their #1 differentiator) is already shipped here via Open-Meteo + schema v19. Remaining ideas worth considering:
+Reviewed Vercro, a UK/Ireland gardening task app with overlapping scope. Postcode/rainfall integration (their headline differentiator) is already shipped here via Open-Meteo + schema v19, `LocationPromptBanner`, and `generateWateringTasks`. Remaining ideas, ordered by leverage:
 
-- **Plant Check — focused photo diagnosis.** Vercro's AI is a single-purpose "snap a sick plant → diagnosis" tool, not an open chat. Easier to explain and avoids the cold-start problem that contributed to hiding Aitor (`SHOW_AI_ADVISOR = false`). Could ship as a narrow feature alongside or instead of re-enabling the chat.
-- **Crop timeline visualisation.** Per-plant growth-stage strip showing where each planting sits between sow → expected harvest → actual harvest. We already store all the dates on `Planting`; this is purely a new view over existing data.
-- **"Boost this bed" affordance.** Per-bed positive-framing button surfacing concrete companion suggestions ("add marigolds to deter pests", "add broad beans to fix nitrogen"). We have `enhancedCompanions` data and a hidden `SHOW_ROTATION_SUGGESTIONS` flag — same data, friendlier framing than rotation constraints.
-- **Daily-plan positioning.** Their tagline ("Not a calendar. A plan.") leads users straight to today's tasks. Our Today dashboard already exists; mostly a marketing/landing-surface decision rather than a build.
-- **Social login.** Google/Apple one-tap via Clerk — config change, not a build.
+#### 1. Aitor as a signed-in, opt-in companion (re-enable, do not narrow)
+
+Vercro's AI is a single-purpose "snap a sick plant → diagnosis" tool. We already have richer infrastructure: tool-calling for data modifications (`ai-tool-executor.ts`), photo upload (`route.ts` accepts plant images, gpt-4o vision), BYO API key, and a global chat modal. Re-enable rather than re-scope, but constrain who sees it and how it's introduced:
+
+- **Replace the global flag with per-user gating.** `SHOW_AI_ADVISOR = false` is binary; swap it for `SignedIn` (Clerk) plus a per-user opt-in preference (`AllotmentData.meta.aiAdvisorEnabled`, default false). Anonymous users never see it; signed-in users see a one-time "Try Aitor?" banner on Today.
+- **Surface photo diagnosis as the lead use case.** Add a "Diagnose a plant" button next to the chat-launcher that opens `AitorChatModal` pre-seeded with an image picker and a system prompt focused on diagnosis — closes the cold-start gap that drove hiding the chat in the first place.
+- **Add prompt suggestions in `QuickTopics.tsx`.** "What can I plant in May?" / "Diagnose this leaf" / "Plan my next rotation" / "Why is my chard bolting?" — concrete entries beat a blank input.
+- **Files:** `src/config/release-visibility.ts` (remove `SHOW_AI_ADVISOR`), `src/app/layout.tsx` (gate `AitorChatButton`/`AitorChatModal` on `SignedIn` + preference), `src/app/settings/page.tsx` (move AI tab out from behind the flag, gate on `SignedIn`), `src/components/dashboard/TodayDashboard.tsx` (one-time invite banner), `src/types/unified-allotment.ts` (`meta.aiAdvisorEnabled`).
+- **Risk to weigh:** server-side fallback (`OPENAI_API_KEY`) becomes a real cost line once auth-gated users opt in en masse — keep BYO key as the default and only allow server-side for a future paid/free-tier when ready.
+
+#### 2. Crop timeline visualisation
+
+Per-plant growth-stage strip (sow → emergence → growing → expected harvest window → actual harvests). All data already lives on `Planting`. Two surface options, low cost either way:
+
+- Add a `<PlantingTimeline>` strip at the top of `PlantingDetailDialog` (the tabbed dialog already exists).
+- Add a compact sparkline to each item in Today's "Growing" section so users see at-a-glance where each plant sits in its arc.
+
+Lifecycle stage derives from `sowDate`, `expectedHarvestStart/End`, and `actualHarvestDates`; perennials can reuse `calculatePerennialStatus()`.
+
+#### 3. "Boost this bed" — companion suggestions in area panel
+
+Vercro frames companion planting as a positive next action ("add marigolds to deter pests"). We have richer data already: `EnhancedCompanion` carries `mechanism` (`pest_repellent`, `nitrogen_fixation`, `disease_suppression`, …) and `confidence` — perfect for the "why" copy.
+
+- Add a "Boost this bed" section to `BedDetailPanel.tsx` and `MobileAreaBottomSheet.tsx`. For each current planting in the bed, surface up to 3 high-confidence companions with mechanism-derived copy, deduped across the bed.
+- Cross-reference `data.varieties[*].seedsByYear` to prefer companions the user already has seed for. Click → `AddPlantingForm` pre-filled with that variety.
+- Independent from the existing `SHOW_ROTATION_SUGGESTIONS` flag — this is positive-framed and shippable on day one; rotation suggestions can stay hidden.
+
+#### 4. Social login
+
+Verify Google/Apple are enabled in the Clerk Dashboard for this project. Pure config; no code change. Worth doing alongside the Aitor re-enable since it lifts the friction on the auth gate that's about to do real work.
+
+#### 5. Drop: daily-plan positioning
+
+Today is already the landing route, the onboarding wizard already covers the "open, follow, done" framing, and the marketing surface is small. No build to do.
 
 ### Future Phases (Contingent on User Adoption)
 

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -204,6 +204,21 @@ After the page-by-page review, a batch of smaller fixes and housekeeping work la
 
 - Automatic backup prompts
 
+### Vercro Learnings: Shipped
+
+Four of the five Vercro learnings landed on `claude/analyze-vercro-app-A6inL`:
+
+- **Today weather strip** (commit 865c986) — 3-tile today/tomorrow/+1 forecast on the Today dashboard. Open-Meteo query extended with `weathercode` + temps; `RainfallSummary.forecast` carries the daily tiles; WMO codes mapped to lucide icons in `src/lib/weather/wmo-icons.ts`.
+- **Crop progress strip** (commit e6bc285) — `<PlantingProgress>` rendered in `PlantingDetailDialog` showing sow → expected harvest window with actual harvest overlaid and a "today" line. Pure UI over existing `Planting` fields.
+- **Boost this bed** (commit f3897f8) — companion suggestions in `BedDetailPanel` for rotation beds with at least one planting. Ranked by seed availability → confidence → name; click pre-fills the Add Planting dialog with the suggested variety. Logic in `src/lib/boost-suggestions.ts` with full unit coverage.
+- **Aitor re-enable** (commit e744f33) — replaced `SHOW_AI_ADVISOR` flag with Clerk `isSignedIn` gate via `AitorAuthGate`. Settings "AI & Location" tab gated the same way. Anonymous users see no AI surfaces; signed-in users get the chat back.
+
+Follow-ups still on the roadmap:
+
+- **Aitor polish** — per-user `meta.aiAdvisorEnabled` opt-in (schema v20), photo-diagnosis pre-seed entry-point, refreshed prompt suggestions in `QuickTopics.tsx`.
+- **Boost this bed on mobile** — port to `MobileAreaBottomSheet` (skipped for tightness in the first PR).
+- **Social login** — verify Google/Apple are enabled in the Clerk Dashboard. Pure config.
+
 ### Competitor Learnings: Vercro (https://vercro.com)
 
 Reviewed Vercro, a UK/Ireland gardening task app with overlapping scope. Postcode/rainfall integration (their headline differentiator) is already shipped here via Open-Meteo + schema v19, `LocationPromptBanner`, and `generateWateringTasks`. Remaining ideas, ordered by leverage:

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -204,70 +204,40 @@ After the page-by-page review, a batch of smaller fixes and housekeeping work la
 
 - Automatic backup prompts
 
-### Vercro Learnings: Shipped
+### Research-Driven Improvements: Shipped
 
-Four of the five Vercro learnings landed on `claude/analyze-vercro-app-A6inL`:
+A round of research into adjacent gardening apps surfaced four small UI bets, all landed on `claude/analyze-vercro-app-A6inL`:
 
-- **Today weather strip** (commit 865c986) — 3-tile today/tomorrow/+1 forecast on the Today dashboard. Open-Meteo query extended with `weathercode` + temps; `RainfallSummary.forecast` carries the daily tiles; WMO codes mapped to lucide icons in `src/lib/weather/wmo-icons.ts`.
-- **Crop progress strip** (commit e6bc285) — `<PlantingProgress>` rendered in `PlantingDetailDialog` showing sow → expected harvest window with actual harvest overlaid and a "today" line. Pure UI over existing `Planting` fields.
-- **Boost this bed** (commit f3897f8) — companion suggestions in `BedDetailPanel` for rotation beds with at least one planting. Ranked by seed availability → confidence → name; click pre-fills the Add Planting dialog with the suggested variety. Logic in `src/lib/boost-suggestions.ts` with full unit coverage.
-- **Aitor re-enable** (commit e744f33) — replaced `SHOW_AI_ADVISOR` flag with Clerk `isSignedIn` gate via `AitorAuthGate`. Settings "AI & Location" tab gated the same way. Anonymous users see no AI surfaces; signed-in users get the chat back.
+- **Today weather strip** (commit 76ff0ef) — 3-tile today/tomorrow/+1 forecast on the Today dashboard. Open-Meteo query extended with `weathercode` + temps; `RainfallSummary.forecast` carries the daily tiles; WMO codes mapped to lucide icons in `src/lib/weather/wmo-icons.ts`.
+- **Crop progress strip** (commit a197ad4) — `<PlantingProgress>` rendered in `PlantingDetailDialog` showing sow → expected harvest window with actual harvest overlaid and a "today" line. Pure UI over existing `Planting` fields.
+- **Boost this bed** (commit 2ba4c67) — companion suggestions in `BedDetailPanel` for rotation beds with at least one planting. Ranked by seed availability → confidence → name; click pre-fills the Add Planting dialog with the suggested variety. Logic in `src/lib/boost-suggestions.ts` with full unit coverage.
+- **Aitor re-enable** (commit 5255f4c) — replaced `SHOW_AI_ADVISOR` flag with Clerk `isSignedIn` gate via `AitorAuthGate`. Settings "AI & Location" tab gated the same way. Anonymous users see no AI surfaces; signed-in users get the chat back.
 
-Follow-ups still on the roadmap:
+### Frost & Climate Data (research)
 
-- **Aitor polish** — per-user `meta.aiAdvisorEnabled` opt-in (schema v20), photo-diagnosis pre-seed entry-point, refreshed prompt suggestions in `QuickTopics.tsx`.
-- **Boost this bed on mobile** — port to `MobileAreaBottomSheet` (skipped for tightness in the first PR).
-- **Social login** — verify Google/Apple are enabled in the Clerk Dashboard. Pure config.
+`docs/research/frost-and-climate-data.md` — fresh research into what we could do with frost and broader climate data on top of the existing Open-Meteo plumbing. Recommended track: frost dot on the WeatherStrip → `hardiness` field on `Vegetable` → last/first-frost dates cached on `meta.frostDates` from the Open-Meteo Climate API → frost-aware sow-date validation. ~12–18 hours total, very high leverage on UK/Scotland sowing decisions.
 
-### Competitor Learnings: Vercro (https://vercro.com)
+### Research-Driven Improvements: Backlog
 
-Reviewed Vercro, a UK/Ireland gardening task app with overlapping scope. Postcode/rainfall integration (their headline differentiator) is already shipped here via Open-Meteo + schema v19, `LocationPromptBanner`, and `generateWateringTasks`. Remaining ideas, ordered by leverage:
+Follow-ups from the same research round, in order of leverage:
 
-#### 1. Aitor as a signed-in, opt-in companion (re-enable, do not narrow)
+#### 1. Aitor as a signed-in, opt-in companion (polish on top of the re-enable)
 
-Vercro's AI is a single-purpose "snap a sick plant → diagnosis" tool. We already have richer infrastructure: tool-calling for data modifications (`ai-tool-executor.ts`), photo upload (`route.ts` accepts plant images, gpt-4o vision), BYO API key, and a global chat modal. Re-enable rather than re-scope, but constrain who sees it and how it's introduced:
+The chat is back for signed-in users via `AitorAuthGate`. Remaining polish:
 
-- **Replace the global flag with per-user gating.** `SHOW_AI_ADVISOR = false` is binary; swap it for `SignedIn` (Clerk) plus a per-user opt-in preference (`AllotmentData.meta.aiAdvisorEnabled`, default false). Anonymous users never see it; signed-in users see a one-time "Try Aitor?" banner on Today.
-- **Surface photo diagnosis as the lead use case.** Add a "Diagnose a plant" button next to the chat-launcher that opens `AitorChatModal` pre-seeded with an image picker and a system prompt focused on diagnosis — closes the cold-start gap that drove hiding the chat in the first place.
-- **Add prompt suggestions in `QuickTopics.tsx`.** "What can I plant in May?" / "Diagnose this leaf" / "Plan my next rotation" / "Why is my chard bolting?" — concrete entries beat a blank input.
-- **Files:** `src/config/release-visibility.ts` (remove `SHOW_AI_ADVISOR`), `src/app/layout.tsx` (gate `AitorChatButton`/`AitorChatModal` on `SignedIn` + preference), `src/app/settings/page.tsx` (move AI tab out from behind the flag, gate on `SignedIn`), `src/components/dashboard/TodayDashboard.tsx` (one-time invite banner), `src/types/unified-allotment.ts` (`meta.aiAdvisorEnabled`).
+- **Per-user opt-in.** Add `meta.aiAdvisorEnabled` (schema migration v20, default false). Show a one-time "Try Aitor?" banner on Today that flips it on. Replaces the implicit "signed-in == opted-in" with an explicit choice.
+- **Photo-diagnosis lead path.** Add a "Diagnose a plant" entry-point next to the chat launcher that opens `AitorChatModal` pre-seeded with an image picker and a system prompt focused on diagnosis — closes the cold-start gap that drove hiding the chat in the first place. The API route already accepts plant images via gpt-4o vision.
+- **Refresh `QuickTopics.tsx` prompts.** "What can I plant in May?" / "Diagnose this leaf" / "Plan my next rotation" / "Why is my chard bolting?" — concrete entries beat a blank input.
+- **Files:** `src/types/unified-allotment.ts` (`meta.aiAdvisorEnabled`), `src/services/storage-migrations.ts` (v20), `src/components/ai-advisor/AitorAuthGate.tsx`, `src/components/dashboard/TodayDashboard.tsx` (one-time banner), `src/components/ai-advisor/QuickTopics.tsx`, `src/components/ai-advisor/AitorChatButton.tsx`.
 - **Risk to weigh:** server-side fallback (`OPENAI_API_KEY`) becomes a real cost line once auth-gated users opt in en masse — keep BYO key as the default and only allow server-side for a future paid/free-tier when ready.
 
-#### 2. Crop timeline visualisation
+#### 2. "Boost this bed" on mobile
 
-Per-plant growth-stage strip (sow → emergence → growing → expected harvest window → actual harvests). All data already lives on `Planting`. Two surface options, low cost either way:
+Port the `<BoostThisBed>` section from `BedDetailPanel.tsx` to `MobileAreaBottomSheet.tsx`. Skipped in the first PR for tightness; same data, same component.
 
-- Add a `<PlantingTimeline>` strip at the top of `PlantingDetailDialog` (the tabbed dialog already exists).
-- Add a compact sparkline to each item in Today's "Growing" section so users see at-a-glance where each plant sits in its arc.
+#### 3. Social login
 
-Lifecycle stage derives from `sowDate`, `expectedHarvestStart/End`, and `actualHarvestDates`; perennials can reuse `calculatePerennialStatus()`.
-
-#### 3. "Boost this bed" — companion suggestions in area panel
-
-Vercro frames companion planting as a positive next action ("add marigolds to deter pests"). We have richer data already: `EnhancedCompanion` carries `mechanism` (`pest_repellent`, `nitrogen_fixation`, `disease_suppression`, …) and `confidence` — perfect for the "why" copy.
-
-- Add a "Boost this bed" section to `BedDetailPanel.tsx` and `MobileAreaBottomSheet.tsx`. For each current planting in the bed, surface up to 3 high-confidence companions with mechanism-derived copy, deduped across the bed.
-- Cross-reference `data.varieties[*].seedsByYear` to prefer companions the user already has seed for. Click → `AddPlantingForm` pre-filled with that variety.
-- Independent from the existing `SHOW_ROTATION_SUGGESTIONS` flag — this is positive-framed and shippable on day one; rotation suggestions can stay hidden.
-
-#### 4. Weather strip on Today (today / tomorrow / +1)
-
-Small forecast tiles above the existing rainfall line — icon, max/min temp, precipitation. Reuses everything that already exists: `fetchRainfall()` plumbing in `src/lib/weather/open-meteo.ts`, the localStorage cache, the coordinate gate, and `LocationPromptBanner`. Only changes:
-
-- Extend the Open-Meteo query with `weathercode`, `temperature_2m_max`, `temperature_2m_min` and bump `forecast_days` to 2 or 3.
-- Widen `RainfallSummary` (or split it) into a `WeatherSummary` with a `daily` array.
-- Map WMO weather codes to `lucide-react` icons (`Sun`, `Cloud`, `CloudRain`, `CloudSnow`, `CloudLightning`, `CloudDrizzle`).
-- New `<WeatherStrip>` component on `TodayDashboard.tsx`, ~3 tiles, hidden when `hasCoordinates` is false.
-
-Effort: ~1–2 hours; all infrastructure is already in place.
-
-#### 5. Social login
-
-Verify Google/Apple are enabled in the Clerk Dashboard for this project. Pure config; no code change. Worth doing alongside the Aitor re-enable since it lifts the friction on the auth gate that's about to do real work.
-
-#### 6. Drop: daily-plan positioning
-
-Today is already the landing route, the onboarding wizard already covers the "open, follow, done" framing, and the marketing surface is small. No build to do.
+Verify Google/Apple are enabled in the Clerk Dashboard for this project. Pure config; no code change.
 
 ### Future Phases (Contingent on User Adoption)
 

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -215,13 +215,47 @@ A round of research into adjacent gardening apps surfaced four small UI bets, al
 
 ### Frost & Climate Data (research)
 
-`docs/research/frost-and-climate-data.md` — fresh research into what we could do with frost and broader climate data on top of the existing Open-Meteo plumbing. Recommended track: frost dot on the WeatherStrip → `hardiness` field on `Vegetable` → last/first-frost dates cached on `meta.frostDates` from the Open-Meteo Climate API → frost-aware sow-date validation. ~12–18 hours total, very high leverage on UK/Scotland sowing decisions.
+`docs/research/frost-and-climate-data.md` — fresh research into extending the existing Open-Meteo plumbing with frost-aware features. The full background is in the research doc; the actionable tracks are in the backlog below.
 
 ### Research-Driven Improvements: Backlog
 
 Follow-ups from the same research round, in order of leverage:
 
-#### 1. Aitor as a signed-in, opt-in companion (polish on top of the re-enable)
+#### 1. Frost dot on WeatherStrip (~1 h)
+
+Pure UI. We already pull `temperature_2m_min` for the next 3 days but don't surface frost risk. Render a `Snowflake` (lucide) on any forecast tile where `tempMinC ≤ 0` (definite) or a faint dot for `tempMinC ≤ 3` (risk). No API change.
+
+- **Files:** `src/components/dashboard/WeatherStrip.tsx`, `src/__tests__/lib/weather/wmo-icons.test.ts` if the icon goes through the mapping.
+
+#### 2. `hardiness` field on `Vegetable` (~3–4 h)
+
+RHS H1a–H7 ratings on every plant. Manual but mechanical data fill across 17 category files. Defaults to `'H4'` (hardy) when unset, which under-warns for tender crops — the safe failure direction. Unblocks every targeted frost warning that follows.
+
+- **Files:** `src/types/garden-planner.ts` (add field), `src/lib/vegetables/data/*.ts` (17 files, ~30 s each), companion-validation fixtures may need a touch.
+
+#### 3. Last/first frost dates from Open-Meteo Climate API (~4–6 h)
+
+New `fetchFrostDates(lat, lng)` helper that hits `api.open-meteo.com/v1/climate` for daily `temperature_2m_min` over a 15-year window, derives average last spring frost and first autumn frost dates, caches forever (or 1-year TTL), and stores the result on `meta.frostDates` so the whole app can read it without refetching. Free, no key.
+
+- **Files:** `src/lib/weather/open-meteo.ts` (new function + cache), `src/types/unified-allotment.ts` (`meta.frostDates`), `src/services/storage-migrations.ts` (schema v20 if we add the meta field at the same time as Aitor opt-in).
+
+#### 4. Tonight's frost warning banner (~2 h, depends on #2 + #3)
+
+When `forecast[0].tempMinC ≤ 0` and the user has any planting whose `hardiness` is H2 or warmer, show a yellow banner on Today: *"Frost tonight — protect your tender crops"* with the affected beds listed.
+
+- **Files:** new `src/components/dashboard/FrostWarningBanner.tsx`, `src/components/dashboard/TodayDashboard.tsx` (mount next to `LocationPromptBanner`).
+
+#### 5. Frost-aware `validateSowDate()` (~2 h, depends on #2 + #3)
+
+`validateSowDate()` currently only checks the plant's database calendar. With `hardiness` populated and frost dates cached, replace text-based warnings ("after last frost") with date-driven ones: *"Cucumber is H2 (frost tender). Your average last frost is 14 May; sowing outdoors before then risks frost damage."* Form copy already renders validation warnings in `AddPlantingForm`.
+
+- **Files:** `src/lib/date-calculator.ts`.
+
+#### 6. Soil temperature for sowing tasks (~2–3 h)
+
+Add `soil_temperature_0_to_7cm` to the existing forecast call. Suppress sow tasks when soil temp is below the species threshold (peas/carrots: 7°C, beans: 12°C, sweetcorn: 13°C). YAGNI for most plants — hold until #1–5 are in and adoption tells us it matters.
+
+#### 7. Aitor as a signed-in, opt-in companion (polish on top of the re-enable)
 
 The chat is back for signed-in users via `AitorAuthGate`. Remaining polish:
 
@@ -231,11 +265,11 @@ The chat is back for signed-in users via `AitorAuthGate`. Remaining polish:
 - **Files:** `src/types/unified-allotment.ts` (`meta.aiAdvisorEnabled`), `src/services/storage-migrations.ts` (v20), `src/components/ai-advisor/AitorAuthGate.tsx`, `src/components/dashboard/TodayDashboard.tsx` (one-time banner), `src/components/ai-advisor/QuickTopics.tsx`, `src/components/ai-advisor/AitorChatButton.tsx`.
 - **Risk to weigh:** server-side fallback (`OPENAI_API_KEY`) becomes a real cost line once auth-gated users opt in en masse — keep BYO key as the default and only allow server-side for a future paid/free-tier when ready.
 
-#### 2. "Boost this bed" on mobile
+#### 8. "Boost this bed" on mobile
 
 Port the `<BoostThisBed>` section from `BedDetailPanel.tsx` to `MobileAreaBottomSheet.tsx`. Skipped in the first PR for tightness; same data, same component.
 
-#### 3. Social login
+#### 9. Social login
 
 Verify Google/Apple are enabled in the Clerk Dashboard for this project. Pure config; no code change.
 

--- a/docs/research/frost-and-climate-data.md
+++ b/docs/research/frost-and-climate-data.md
@@ -1,0 +1,145 @@
+# Frost & Climate Data Research
+
+Date: 2026-05-01
+Status: Research — no code changes yet
+
+## Why this is interesting
+
+The app already pulls live weather (Open-Meteo, schema v19) and uses rainfall to suppress watering tasks. Frost is the next-most-actionable weather signal for a UK/Scotland gardener:
+
+- **Sowing decisions** — half the entries in `scotland-calendar.ts` and many plant `tips[]` warn about frost ("after last frost", "wait until June"), but the warnings are free-text and not date-driven.
+- **Variety choice** — "frost tender" vs "very hardy" determines whether something can overwinter, go out in April, or has to wait until June.
+- **Today's tasks** — overnight low ≤ 0°C ought to trigger a "cover tender plants tonight" task when the user has tender crops outdoors.
+- **Date validation** — `validateSowDate()` already exists; it currently only checks the plant's `sowOutdoorsMonths` window, not the user's local frost-free dates.
+
+What we have today:
+
+- `src/lib/weather/open-meteo.ts` already fetches `temperature_2m_min` for past 3 days + 3 forecast days, but only uses it for the strip's "min" tile.
+- `src/lib/date-calculator.ts` has a Scotland-specific `getFallFactorDays()` for autumn growth slowdown.
+- `Vegetable` type has `growingRequirement` (`'outdoor' | 'greenhouse' | 'windowsill' | 'polytunnel'`) — proxies for tenderness but doesn't capture "hardy down to X°C".
+- No `hardiness`, `frostTolerance`, `minTempC`, or last/first-frost-date fields anywhere.
+
+## Data sources
+
+### Open-Meteo (already integrated)
+
+The forecast endpoint we already call exposes everything we need short-term, no extra API key:
+
+| Field | Use |
+|---|---|
+| `temperature_2m_min` (daily) | overnight low → frost risk for next 3 days. Already in our query. |
+| `temperature_2m_max` (daily) | already in our query, used in the WeatherStrip tiles. |
+| `soil_temperature_0_to_7cm` (hourly) | sowing decisions ("soil is at 8°C, peas can go in") |
+| `precipitation_sum` (daily) | already used for watering |
+| `wind_speed_10m_max` (daily) | transplanting decisions; high-wind warnings |
+| `apparent_temperature_min` (daily) | felt cold for soft fruit / blossom |
+
+For historical / climatological data:
+
+- **Open-Meteo Climate API** (`api.open-meteo.com/v1/climate`) — free, no API key, returns daily ERA5 reanalysis going back to 1950. From this we can derive a coordinate-specific:
+  - **Average last spring frost** — the date in spring when daily `temperature_2m_min < 0°C` last occurs in the historical record (per year, then averaged over 10–30 years).
+  - **Average first autumn frost** — same but the first sub-zero day after summer.
+  - **10%/50%/90% probability** windows — more accurate than simple averages and worth showing in tooltips.
+  - **Frost-free days remaining** — derived live: today vs first-frost-average.
+
+One climate-API call per coordinate, cached forever (these averages don't change month-to-month). 1 fetch on first geolocation, rounded to the same 2-decimal lat/lng key the rainfall cache already uses.
+
+### RHS hardiness ratings (static plant data)
+
+The RHS uses H1a–H7 (warmest greenhouse → exposed mountain). We already store `rhsUrl` on most plants. Adding a `hardiness?: 'H1a' | 'H1b' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'H7'` field would let us map frost forecasts to "is THIS plant at risk?" without per-plant min-temp lookups.
+
+Mapping (RHS-published):
+
+| Rating | Min temperature | Examples |
+|---|---|---|
+| H1a | > 15°C | Tropical houseplants |
+| H1b | 10 → 15°C | Tomato, basil indoors |
+| H1c | 5 → 10°C | Tomato outdoors midsummer |
+| H2 | 1 → 5°C | Tender — courgette, cucumber, French bean |
+| H3 | -5 → 1°C | Half-hardy — most lettuces, rocket |
+| H4 | -10 → -5°C | Hardy — broad bean, garlic, brassicas |
+| H5 | -15 → -10°C | Very hardy — leek, parsnip, kale |
+| H6 | -20 → -15°C | Most overwintering crops |
+| H7 | < -20°C | Highland shelter-belt species |
+
+Most edible UK crops fall in H2–H5. Populating the field for all 192 plants is manual but small (a one-time chore, can be done from the plant data files). Defaulting to `'H4'` (hardy) when unset is safe — it under-warns for tender crops, which is the failure direction we want to avoid.
+
+### Met Office DataPoint
+
+Considered and rejected. UK-specific, free tier exists but requires registration and the data is no richer than Open-Meteo for our needs. Adds an API key dependency without enabling anything new.
+
+## Proposed additions, in order of leverage
+
+### 1. Frost dot on the WeatherStrip (smallest, ~1 hour)
+
+We're already fetching `temperature_2m_min` for the next 3 days. Add a small frost icon (lucide `Snowflake`) on any tile where `tempMinC ≤ 0` (definite frost) or a faint dot for `tempMinC ≤ 3` (frost risk). Pure UI; no API change.
+
+Files: `src/components/dashboard/WeatherStrip.tsx`. Add a new test row to `wmo-icons.test.ts` if we add the icon to the mapping.
+
+### 2. Tonight's frost warning banner (~2 hours)
+
+When `forecast[0].tempMinC ≤ 0` and the user has any planting whose `hardiness` is H2 or warmer, show a yellow banner on Today: "Frost tonight — protect your tender crops" with a list of affected beds. When `hardiness` is missing on plants, fall back to `growingRequirement === 'outdoor'` plants flagged in the plant database with a `frostSensitive` tip — coarse but better than nothing until we populate hardiness.
+
+Files: new `src/components/dashboard/FrostWarningBanner.tsx`, wired into `TodayDashboard.tsx` next to `LocationPromptBanner`.
+
+### 3. Add `hardiness` to `Vegetable` (~3–4 hours)
+
+Type change + data fill across 17 category files in `src/lib/vegetables/data/`. Most plants take 30 seconds — RHS pages already classify them. This unblocks #2 cleanly and makes future planning UX much sharper (e.g. "you can still sow these H4+ crops, frost or not").
+
+Files: `src/types/garden-planner.ts`, `src/lib/vegetables/data/*.ts` (17 files), `src/__tests__/lib/companion-validation.test.ts` may need a fixture update.
+
+### 4. Last/first frost dates from Open-Meteo Climate API (~4–6 hours)
+
+New endpoint helper: `fetchFrostDates(lat, lng)` → `{ avgLastFrost: string; avgFirstFrost: string; lastFrostP90: string }`.
+
+- Hits `api.open-meteo.com/v1/climate?...&daily=temperature_2m_min&start_date=2010-01-01&end_date=2025-12-31`.
+- For each year in the response, find the last day in Jan–Jun where `temperature_2m_min < 0` (last spring frost) and the first day after Jul where it next goes sub-zero (first autumn frost).
+- Average the day-of-year values; convert back to a date for the *current* year.
+- Cache forever (or: 1 year TTL — these averages do shift with climate, just slowly). Keyed by coordinates rounded to 2dp like the rainfall cache.
+
+Surface options: small "Frost-free window: 14 May – 12 Oct (avg)" line under the WeatherStrip, OR feed into `validateSowDate()` so warnings get more specific than the current text-based ones.
+
+Files: extend `src/lib/weather/open-meteo.ts` (new function + cache), `src/types/unified-allotment.ts` (cache the dates on `meta.frostDates` so the whole app can read them without refetching), `src/lib/date-calculator.ts` (consume in validation).
+
+### 5. Frost-aware sow-date validation (~2 hours, depends on #3 + #4)
+
+`validateSowDate()` currently only checks the plant's database calendar. With `hardiness` populated and frost dates cached on `meta.frostDates`, it can warn:
+
+- *"Cucumber is H2 (frost tender). Your average last frost is 14 May; sowing outdoors before then risks frost damage."*
+- *"Garlic is H5 (very hardy). Plant in October–November for best results."*
+
+Files: `src/lib/date-calculator.ts`, plus form copy in `AddPlantingForm.tsx` already renders validation warnings.
+
+### 6. Soil temperature for sowing tasks (~2–3 hours)
+
+Add `soil_temperature_0_to_7cm` to the existing forecast call. For tasks like "sow peas" or "sow carrots", suppress when soil temp is below the species threshold (peas: 7°C, carrots: 7°C, beans: 12°C, sweetcorn: 13°C). Could become a new `sowSoilTempC` field on `Vegetable` — or just a category-level lookup.
+
+Open question: is this worth the friction of more plant data? Probably yes for the half-dozen crops where it really matters; YAGNI for the rest. Hold until #1–4 are in.
+
+## Effort summary
+
+| Item | Effort | Depends on |
+|---|---|---|
+| Frost dot on WeatherStrip | ~1 h | — |
+| Tonight's frost warning banner | ~2 h | #3 (or coarse fallback) |
+| `hardiness` field on Vegetable | ~3–4 h | — |
+| Last/first frost dates (Climate API) | ~4–6 h | — |
+| Frost-aware `validateSowDate()` | ~2 h | #3 + #4 |
+| Soil temperature for sowing | ~2–3 h | — |
+| **Total focused track** | **~12–18 h** | |
+
+## Recommended sequencing
+
+1. **Frost dot in WeatherStrip** — visible win, tiny code, no data work.
+2. **`hardiness` on Vegetable** — unblocks every targeted warning that follows. Manual data fill but mechanical.
+3. **Frost dates from Climate API + cache on `meta.frostDates`** — one-time API cost per location, then cheap forever.
+4. **Tonight's frost warning banner** + **frost-aware sow validation** — both ride on top of (2) and (3).
+5. Hold soil temperature until adoption tells us it matters.
+
+## Risks / open questions
+
+- **Open-Meteo non-commercial use limit** is a known constraint. Adding the Climate API call once per location stays well under any reasonable rate limit.
+- **Climatological averages can mislead** in a warming climate — a 2010-2025 baseline is more representative than 1990-2020 for current planning. We should make this configurable in code, not hardcoded.
+- **Hardiness data quality** — RHS ratings vary across sources for the same crop. We'll pick one canonical source (RHS plant pages) and note exceptions in the data file.
+- **Microclimate** — coastal Scotland and highland Scotland have very different last frost dates even at the same latitude. Coordinate-based lookup handles this for free; postcode-based would not.
+- **What about non-frost low-temp damage?** Tomato blossom drops below 13°C, basil sulks below 10°C. Hardiness alone doesn't capture this; the soil-temperature track addresses the sowing side, but the "growing-on" risks are out of scope here.

--- a/docs/research/product-roadmap-quick-reference.md
+++ b/docs/research/product-roadmap-quick-reference.md
@@ -53,7 +53,7 @@ Completed across PRs #151, #153, #167, #169, #171, #180-188. Each section review
 - Grid: AllotmentGrid, AllotmentMobileView, BedItem
 - Forms: AddAreaForm, EditAreaForm, AddPlantingForm, PlantCombobox
 - Details: BedDetailPanel, PermanentDetailPanel, InfrastructureDetailPanel, ItemDetailSwitcher
-- Plantings: PlantingCard, PlantingDetailDialog, PlantingTimeline, PerennialStatusBadge
+- Plantings: PlantingCard, PlantingDetailDialog, PlantingProgress, SowDateValidator, PerennialStatusBadge
 - Notes: BedNotes, CareLogSection, HarvestTracker, UnderplantingsList
 - Status: SeasonStatusWidget
 **Key Questions:**

--- a/src/__tests__/api/ai-advisor.test.ts
+++ b/src/__tests__/api/ai-advisor.test.ts
@@ -6,7 +6,17 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
-import { POST } from '@/app/api/ai-advisor/route'
+
+// Mock Clerk's server-side auth() — every test except the "unauthenticated"
+// case runs as a signed-in user. The unauthenticated test overrides this.
+const mockAuth = vi.fn<() => Promise<{ userId: string | null }>>(async () => ({
+  userId: 'user_test_123',
+}))
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+}))
+
+const { POST } = await import('@/app/api/ai-advisor/route')
 
 // Mock fetch - necessary for API route testing
 const mockFetch = vi.fn()
@@ -15,7 +25,23 @@ global.fetch = mockFetch
 describe('AI Advisor API - Validation & Error Handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAuth.mockResolvedValue({ userId: 'user_test_123' })
     vi.stubEnv('OPENAI_API_KEY', '')
+  })
+
+  describe('Authentication', () => {
+    it('rejects requests from unauthenticated callers with 401', async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null })
+      vi.stubEnv('OPENAI_API_KEY', 'sk-test-valid-key-12345678901234')
+
+      const response = await POST(createRequest({ message: 'Hello' }))
+      const data = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(data.error).toMatch(/sign in/i)
+      // The env key must not have been used.
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
   })
 
   function createRequest(

--- a/src/__tests__/components/AddPlantingForm.test.tsx
+++ b/src/__tests__/components/AddPlantingForm.test.tsx
@@ -95,9 +95,9 @@ vi.mock('@/components/allotment/PlantCombobox', () => ({
   ),
 }))
 
-// Mock PlantingTimeline
-vi.mock('@/components/allotment/PlantingTimeline', () => ({
-  default: () => <div data-testid="planting-timeline">Timeline preview</div>,
+// Mock SowDateValidator
+vi.mock('@/components/allotment/SowDateValidator', () => ({
+  default: () => <div data-testid="sow-date-validator">Sow-date validator</div>,
 }))
 
 describe('AddPlantingForm Component', () => {

--- a/src/__tests__/components/PlantingProgress.test.tsx
+++ b/src/__tests__/components/PlantingProgress.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for PlantingProgress component (the lifecycle strip rendered
+ * inside PlantingDetailDialog).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PlantingProgress from '@/components/allotment/PlantingProgress'
+import { Planting } from '@/types/unified-allotment'
+
+function makePlanting(overrides: Partial<Planting> = {}): Planting {
+  return {
+    id: 'p1',
+    plantId: 'tomato',
+    sowDate: '2026-04-01',
+    expectedHarvestStart: '2026-07-01',
+    expectedHarvestEnd: '2026-08-15',
+    ...overrides,
+  }
+}
+
+describe('PlantingProgress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-15T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders the progress strip when sowDate and expectedHarvestStart are present', () => {
+    render(<PlantingProgress planting={makePlanting()} />)
+    expect(screen.getByRole('region', { name: /planting progress/i })).toBeInTheDocument()
+  })
+
+  it('renders nothing when sowDate is missing', () => {
+    const { container } = render(<PlantingProgress planting={makePlanting({ sowDate: undefined })} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when expectedHarvestStart is missing', () => {
+    const { container } = render(
+      <PlantingProgress planting={makePlanting({ expectedHarvestStart: undefined })} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the today line when current date is within the range', () => {
+    render(<PlantingProgress planting={makePlanting()} />)
+    expect(screen.getByLabelText('Today')).toBeInTheDocument()
+  })
+
+  it('hides the today line when the range is entirely in the past', () => {
+    render(
+      <PlantingProgress
+        planting={makePlanting({
+          sowDate: '2025-01-01',
+          expectedHarvestStart: '2025-04-01',
+          expectedHarvestEnd: '2025-04-15',
+        })}
+      />
+    )
+    expect(screen.queryByLabelText('Today')).not.toBeInTheDocument()
+  })
+
+  it('renders the actual harvest overlay when actualHarvestStart is set', () => {
+    render(
+      <PlantingProgress
+        planting={makePlanting({
+          actualHarvestStart: '2026-07-10',
+          actualHarvestEnd: '2026-07-25',
+        })}
+      />
+    )
+    expect(screen.getByLabelText('Actual harvest')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/lib/boost-suggestions.test.ts
+++ b/src/__tests__/lib/boost-suggestions.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getBoostSuggestions } from '@/lib/boost-suggestions'
+import type { Planting, StoredVariety } from '@/types/unified-allotment'
+
+vi.mock('@/lib/vegetable-database', () => {
+  const db: Record<string, {
+    id: string
+    name: string
+    enhancedCompanions: Array<{
+      plantId: string
+      confidence: 'proven' | 'likely' | 'traditional' | 'anecdotal'
+      mechanism?: string
+      bidirectional: boolean
+    }>
+  }> = {
+    tomato: {
+      id: 'tomato',
+      name: 'Tomato',
+      enhancedCompanions: [
+        { plantId: 'basil', confidence: 'likely', mechanism: 'pest_confusion', bidirectional: true },
+        { plantId: 'marigold', confidence: 'proven', mechanism: 'pest_trap', bidirectional: false },
+      ],
+    },
+    pepper: {
+      id: 'pepper',
+      name: 'Pepper',
+      enhancedCompanions: [
+        { plantId: 'basil', confidence: 'traditional', mechanism: 'beneficial_attraction', bidirectional: true },
+        { plantId: 'marigold', confidence: 'likely', mechanism: 'pest_trap', bidirectional: false },
+      ],
+    },
+    basil: { id: 'basil', name: 'Basil', enhancedCompanions: [] },
+    marigold: { id: 'marigold', name: 'Marigold', enhancedCompanions: [] },
+    'broad-bean': {
+      id: 'broad-bean',
+      name: 'Broad Bean',
+      enhancedCompanions: [
+        { plantId: 'sweetcorn', confidence: 'proven', mechanism: 'nitrogen_fixation', bidirectional: true },
+      ],
+    },
+    sweetcorn: { id: 'sweetcorn', name: 'Sweetcorn', enhancedCompanions: [] },
+    onion: { id: 'onion', name: 'Onion', enhancedCompanions: [] },
+  }
+  return {
+    getVegetableById: (id: string) => db[id] ?? null,
+  }
+})
+
+function planting(plantId: string): Planting {
+  return { id: `p-${plantId}`, plantId }
+}
+
+function variety(plantId: string, year: number, status: 'have' | 'ordered' | 'none' = 'have'): StoredVariety {
+  return {
+    id: `v-${plantId}`,
+    plantId,
+    name: `${plantId}-default`,
+    seedsByYear: { [year]: status },
+  } as StoredVariety
+}
+
+describe('getBoostSuggestions', () => {
+  it('returns no suggestions when the bed is empty', () => {
+    expect(getBoostSuggestions([], [], 2026)).toEqual([])
+  })
+
+  it('suggests companions for the plantings in the bed', () => {
+    const result = getBoostSuggestions([planting('tomato')], [], 2026)
+    const ids = result.map((s) => s.plantId)
+    expect(ids).toContain('basil')
+    expect(ids).toContain('marigold')
+  })
+
+  it('omits companions already present in the bed', () => {
+    const result = getBoostSuggestions([planting('tomato'), planting('basil')], [], 2026)
+    expect(result.map((s) => s.plantId)).not.toContain('basil')
+  })
+
+  it('ranks suggestions where the user has seed first', () => {
+    const result = getBoostSuggestions(
+      [planting('tomato')],
+      [variety('basil', 2026, 'have')],
+      2026
+    )
+    expect(result[0].plantId).toBe('basil')
+    expect(result[0].hasSeed).toBe(true)
+  })
+
+  it('falls back to confidence ranking when seed availability is equal', () => {
+    const result = getBoostSuggestions([planting('tomato')], [], 2026)
+    // marigold is "proven" via pest_trap, basil is "likely" via pest_confusion
+    expect(result[0].plantId).toBe('marigold')
+    expect(result[0].confidence).toBe('proven')
+  })
+
+  it('aggregates pairings across multiple plantings and keeps the strongest confidence', () => {
+    const result = getBoostSuggestions([planting('tomato'), planting('pepper')], [], 2026)
+    const basil = result.find((s) => s.plantId === 'basil')!
+    expect(basil.pairsWith.sort()).toEqual(['Pepper', 'Tomato'])
+    // Tomato's basil pairing is "likely" (stronger than pepper's "traditional")
+    expect(basil.confidence).toBe('likely')
+  })
+
+  it('applies the limit', () => {
+    const result = getBoostSuggestions([planting('tomato'), planting('pepper')], [], 2026, 1)
+    expect(result).toHaveLength(1)
+  })
+
+  it('produces a mechanism-based reason', () => {
+    const result = getBoostSuggestions([planting('broad-bean')], [], 2026)
+    const sweetcorn = result.find((s) => s.plantId === 'sweetcorn')!
+    expect(sweetcorn.reason).toBe('Fixes nitrogen for the bed')
+  })
+
+  it('ignores archived varieties for seed-availability ranking', () => {
+    const archived: StoredVariety = {
+      ...variety('basil', 2026, 'have'),
+      isArchived: true,
+    } as StoredVariety
+    const result = getBoostSuggestions([planting('tomato')], [archived], 2026)
+    const basil = result.find((s) => s.plantId === 'basil')!
+    expect(basil.hasSeed).toBe(false)
+  })
+})

--- a/src/__tests__/lib/weather/open-meteo.test.ts
+++ b/src/__tests__/lib/weather/open-meteo.test.ts
@@ -144,4 +144,47 @@ describe('fetchRainfall', () => {
     const result = await fetchRainfall(55.95, -3.18)
     expect(result).toBeNull()
   })
+
+  it('builds forecast tiles when the response includes weathercode and temps', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          daily: {
+            time: ['d-3', 'd-2', 'd-1', '2026-04-29', '2026-04-30', '2026-05-01'],
+            precipitation_sum: [0, 1, 2, 3, 0, 0.5],
+            weathercode: [0, 0, 0, 61, 3, 2],
+            temperature_2m_max: [10, 11, 12, 14.4, 16, 15],
+            temperature_2m_min: [4, 5, 6, 7.2, 8, 7],
+          },
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await fetchRainfall(55.95, -3.18)
+    expect(result?.forecast).toHaveLength(3)
+    expect(result?.forecast?.[0]).toEqual({
+      date: '2026-04-29',
+      weatherCode: 61,
+      tempMaxC: 14.4,
+      tempMinC: 7.2,
+      precipitationMm: 3,
+    })
+    expect(result?.forecast?.[2].date).toBe('2026-05-01')
+  })
+
+  it('omits forecast when the response lacks weathercode or temperature series', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          daily: { precipitation_sum: [0, 0, 0, 0] },
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await fetchRainfall(55.95, -3.18)
+    expect(result).not.toBeNull()
+    expect(result?.forecast).toBeUndefined()
+  })
 })

--- a/src/__tests__/lib/weather/wmo-icons.test.ts
+++ b/src/__tests__/lib/weather/wmo-icons.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { Sun, CloudSun, Cloud, CloudFog, CloudDrizzle, CloudRain, CloudSnow, CloudLightning } from 'lucide-react'
+import { getWeatherIcon } from '@/lib/weather/wmo-icons'
+
+describe('getWeatherIcon', () => {
+  it.each([
+    [0, Sun, 'Clear'],
+    [1, Sun, 'Mainly clear'],
+    [2, CloudSun, 'Partly cloudy'],
+    [3, Cloud, 'Overcast'],
+    [45, CloudFog, 'Fog'],
+    [48, CloudFog, 'Fog'],
+    [51, CloudDrizzle, 'Drizzle'],
+    [55, CloudDrizzle, 'Drizzle'],
+    [57, CloudDrizzle, 'Drizzle'],
+    [61, CloudRain, 'Rain'],
+    [65, CloudRain, 'Rain'],
+    [71, CloudSnow, 'Snow'],
+    [77, CloudSnow, 'Snow'],
+    [80, CloudRain, 'Showers'],
+    [82, CloudRain, 'Showers'],
+    [85, CloudSnow, 'Snow showers'],
+    [86, CloudSnow, 'Snow showers'],
+    [95, CloudLightning, 'Thunderstorm'],
+    [99, CloudLightning, 'Thunderstorm'],
+  ])('maps WMO code %i to the expected icon and label', (code, expectedIcon, expectedLabel) => {
+    const { Icon, label } = getWeatherIcon(code)
+    expect(Icon).toBe(expectedIcon)
+    expect(label).toBe(expectedLabel)
+  })
+
+  it('falls back to a generic cloudy icon for unknown codes', () => {
+    const { Icon, label } = getWeatherIcon(999)
+    expect(Icon).toBe(Cloud)
+    expect(label).toBe('Cloudy')
+  })
+})

--- a/src/app/allotment/page.tsx
+++ b/src/app/allotment/page.tsx
@@ -95,6 +95,15 @@ function AllotmentPageContent() {
   } = useAllotment()
 
   const [showAddDialog, setShowAddDialog] = useState(false)
+  const [addDialogPrefilledPlantId, setAddDialogPrefilledPlantId] = useState<string | undefined>(undefined)
+  const openAddDialog = useCallback((prefilledPlantId?: string) => {
+    setAddDialogPrefilledPlantId(prefilledPlantId)
+    setShowAddDialog(true)
+  }, [])
+  const closeAddDialog = useCallback(() => {
+    setShowAddDialog(false)
+    setAddDialogPrefilledPlantId(undefined)
+  }, [])
   const [showAddAreaDialog, setShowAddAreaDialog] = useState(false)
   const [showEditAreaDialog, setShowEditAreaDialog] = useState(false)
   const [yearToDelete, setYearToDelete] = useState<number | null>(null)
@@ -448,7 +457,8 @@ function AllotmentPageContent() {
               getCareLogs={getCareLogs}
               getHarvestTotal={getHarvestTotal}
               selectedYear={selectedYear}
-              onAddPlanting={() => setShowAddDialog(true)}
+              varieties={data?.varieties || []}
+              onAddPlanting={openAddDialog}
               onAddPlantingToArea={addPlanting}
               onDeletePlanting={handleDeletePlanting}
               onRemovePlantingFromArea={removePlanting}
@@ -475,7 +485,7 @@ function AllotmentPageContent() {
         return (
           <Dialog
             isOpen={showAddDialog}
-            onClose={() => setShowAddDialog(false)}
+            onClose={closeAddDialog}
             title="Add Planting"
             description="Add a new planting to this bed for the current season."
           >
@@ -483,11 +493,12 @@ function AllotmentPageContent() {
               onSubmit={(planting) => {
                 handleAddPlanting(planting)
               }}
-              onCancel={() => setShowAddDialog(false)}
+              onCancel={closeAddDialog}
               existingPlantings={selectedPlantings}
               selectedYear={selectedYear}
               varieties={data?.varieties || []}
               initialCategoryFilter={selectedArea?.kind === 'berry' ? 'berries' : 'all'}
+              initialPlantId={addDialogPrefilledPlantId}
             />
           </Dialog>
         )
@@ -532,7 +543,7 @@ function AllotmentPageContent() {
       {isMobile && (
         <MobileFloatingActions
           onAddArea={() => setShowAddAreaDialog(true)}
-          onAddPlanting={selectedBedId ? () => setShowAddDialog(true) : undefined}
+          onAddPlanting={selectedBedId ? () => openAddDialog() : undefined}
           hasSelectedArea={!!selectedBedId}
         />
       )}
@@ -547,7 +558,7 @@ function AllotmentPageContent() {
           getAreaNotes={getAreaNotes}
           getPreviousYearRotation={getPreviousRotation}
           selectedYear={selectedYear}
-          onAddPlanting={() => setShowAddDialog(true)}
+          onAddPlanting={() => openAddDialog()}
           onDeletePlanting={handleDeletePlanting}
           onUpdatePlanting={(plantingId, updates) => selectedBedId && updatePlanting(selectedBedId, plantingId, updates)}
           onAddNote={(note) => selectedBedId && addAreaNote(selectedBedId, note)}

--- a/src/app/api/ai-advisor/route.ts
+++ b/src/app/api/ai-advisor/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
 import { aiAdvisorRequestSchema } from '@/lib/validations/ai-advisor'
 import { logger } from '@/lib/logger'
 import {
@@ -153,6 +154,20 @@ function buildApiConfig(apiKey: string) {
 
 export async function POST(request: NextRequest) {
   try {
+    // Aitor is gated on a signed-in Clerk session. The chat UI is hidden for
+    // anonymous users via AitorAuthGate; matching that gate at the route
+    // level prevents the env-key fallback (OPENAI_API_KEY) from being
+    // drained by unauthenticated callers. When Clerk is not configured at
+    // all, auth() returns { userId: null } and we reject — matching the UI,
+    // which also stays hidden.
+    const { userId } = await auth()
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Sign in to use Aitor.' },
+        { status: 401 }
+      )
+    }
+
     // Parse and validate request body with Zod
     const body = await request.json()
     const validationResult = aiAdvisorRequestSchema.safeParse(body)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import OfflineIndicator from '@/components/ui/OfflineIndicator'
 import InstallPrompt from '@/components/ui/InstallPrompt'
 import { WebVitalsReporter } from '@/components/web-vitals'
 import { AitorChatProvider } from '@/contexts/AitorChatContext'
+import AitorAuthGate from '@/components/ai-advisor/AitorAuthGate'
 import TourProvider from '@/components/onboarding/TourProvider'
 import TourKeyboardShortcut from '@/components/onboarding/TourKeyboardShortcut'
 import './globals.css'
@@ -58,7 +59,8 @@ export default function RootLayout({
           </footer>
           <InstallPrompt />
           <WebVitalsReporter />
-          {/* AitorChatButton and AitorChatModal hidden for first release */}
+          {/* Aitor (AI advisor) is rendered for signed-in users only — see AitorAuthGate. */}
+          <AitorAuthGate />
           <TourKeyboardShortcut />
           </TourProvider>
         </AitorChatProvider>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,7 +11,6 @@ import DataTab from '@/components/settings/DataTab'
 import PageTour from '@/components/onboarding/PageTour'
 import TourManager from '@/components/onboarding/TourManager'
 import Tabs from '@/components/ui/Tabs'
-import { SHOW_AI_ADVISOR } from '@/config/release-visibility'
 
 export default function SettingsPage() {
   const { isSignedIn, signOut, userEmail } = useOptionalAuth()
@@ -59,7 +58,7 @@ export default function SettingsPage() {
         <Tabs
           defaultTab="data"
           tabs={[
-            ...(SHOW_AI_ADVISOR ? [{
+            ...(isSignedIn ? [{
               id: 'ai-location',
               label: 'AI & Location',
               icon: <Leaf className="w-4 h-4" />,

--- a/src/components/ai-advisor/AitorAuthGate.tsx
+++ b/src/components/ai-advisor/AitorAuthGate.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+import AitorChatButton from './AitorChatButton'
+import AitorChatModal from './AitorChatModal'
+
+/**
+ * Renders the floating Aitor chat button and modal only for signed-in users.
+ *
+ * Aitor (the AI advisor) is gated behind Clerk authentication so we have
+ * a real user identity for any future server-side fallback, and so anonymous
+ * onboarding stays focused. When Clerk is not configured (e.g. local dev
+ * without keys), `useOptionalAuth` returns `isSignedIn: false` and Aitor
+ * stays hidden — same gate, same UI.
+ */
+export default function AitorAuthGate() {
+  const { isSignedIn } = useOptionalAuth()
+  if (!isSignedIn) return null
+  return (
+    <>
+      <AitorChatButton />
+      <AitorChatModal />
+    </>
+  )
+}

--- a/src/components/allotment/AddPlantingForm.tsx
+++ b/src/components/allotment/AddPlantingForm.tsx
@@ -9,7 +9,7 @@ import { populateExpectedHarvest } from '@/lib/date-calculator'
 import { NewPlanting, Planting, StoredVariety, SowMethod, PlantingStatus } from '@/types/unified-allotment'
 import { VegetableCategory } from '@/types/garden-planner'
 import PlantCombobox from './PlantCombobox'
-import PlantingTimeline from './PlantingTimeline'
+import SowDateValidator from './SowDateValidator'
 
 interface AddPlantingFormProps {
   onSubmit: (planting: NewPlanting) => void
@@ -350,9 +350,10 @@ export default function AddPlantingForm({
                   </div>
                 )}
 
-                {/* Planting Timeline Preview */}
+                {/* Sow-date validator: shows the calculated harvest window
+                    and any warnings for the chosen sow date / method. */}
                 {selectedVegetable && sowDate && (
-                  <PlantingTimeline
+                  <SowDateValidator
                     sowDate={sowDate}
                     sowMethod={sowMethod}
                     vegetable={selectedVegetable}

--- a/src/components/allotment/AddPlantingForm.tsx
+++ b/src/components/allotment/AddPlantingForm.tsx
@@ -18,6 +18,8 @@ interface AddPlantingFormProps {
   selectedYear: number
   varieties?: StoredVariety[]
   initialCategoryFilter?: VegetableCategory | 'all'
+  /** Optional plant ID to pre-select (e.g. from a "Boost this bed" suggestion). */
+  initialPlantId?: string
 }
 
 // Helper to check if variety has seeds for year
@@ -31,9 +33,10 @@ export default function AddPlantingForm({
   existingPlantings = [],
   selectedYear,
   varieties = [],
-  initialCategoryFilter = 'all'
+  initialCategoryFilter = 'all',
+  initialPlantId,
 }: AddPlantingFormProps) {
-  const [plantId, setVegetableId] = useState('')
+  const [plantId, setVegetableId] = useState(initialPlantId ?? '')
   const [varietyName, setVarietyName] = useState('')
   const [sowMethod, setSowMethod] = useState<SowMethod>('outdoor')
   const [sowMethodRecommendation, setSowMethodRecommendation] = useState<SowMethodRecommendation | null>(null)

--- a/src/components/allotment/BoostThisBed.tsx
+++ b/src/components/allotment/BoostThisBed.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { Sparkles, Plus, Sprout } from 'lucide-react'
+import type { Planting, StoredVariety } from '@/types/unified-allotment'
+import { getBoostSuggestions } from '@/lib/boost-suggestions'
+
+interface BoostThisBedProps {
+  plantings: Planting[]
+  varieties: StoredVariety[]
+  selectedYear: number
+  onAddSuggestion: (plantId: string) => void
+}
+
+export default function BoostThisBed({
+  plantings,
+  varieties,
+  selectedYear,
+  onAddSuggestion,
+}: BoostThisBedProps) {
+  const suggestions = getBoostSuggestions(plantings, varieties, selectedYear)
+  if (suggestions.length === 0) return null
+
+  return (
+    <div className="bg-zen-moss-50 border border-zen-moss-100 rounded-zen p-3 mb-4">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-zen-moss-700 mb-2">
+        <Sparkles className="w-3.5 h-3.5" />
+        Boost this bed
+      </div>
+      <ul className="space-y-1.5">
+        {suggestions.map((suggestion) => (
+          <li key={suggestion.plantId} className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => onAddSuggestion(suggestion.plantId)}
+              className="flex-1 flex items-center justify-between gap-2 text-left px-2 py-2 min-h-[44px] rounded-zen bg-white hover:bg-zen-moss-100 border border-zen-moss-100 transition"
+              title={`Pairs with ${suggestion.pairsWith.join(', ')}`}
+            >
+              <span className="flex flex-col">
+                <span className="flex items-center gap-1.5 text-sm text-zen-ink-800">
+                  <span className="font-medium">{suggestion.plantName}</span>
+                  {suggestion.hasSeed && (
+                    <span
+                      className="inline-flex items-center gap-0.5 text-xs text-zen-moss-700"
+                      title="You have seed for this"
+                    >
+                      <Sprout className="w-3 h-3" />
+                      seed
+                    </span>
+                  )}
+                </span>
+                <span className="text-xs text-zen-stone-500">{suggestion.reason}</span>
+              </span>
+              <Plus className="w-4 h-4 text-zen-moss-600 flex-shrink-0" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/allotment/PlantingDetailDialog.tsx
+++ b/src/components/allotment/PlantingDetailDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react'
 import Dialog, { ConfirmDialog } from '@/components/ui/Dialog'
 import Tabs, { Tab } from '@/components/ui/Tabs'
+import PlantingProgress from './PlantingProgress'
 import { Planting, PlantingUpdate, SowMethod } from '@/types/unified-allotment'
 import { getVegetableById } from '@/lib/vegetable-database'
 import { getCompanionStatusForPlanting } from '@/lib/companion-utils'
@@ -396,6 +397,9 @@ export default function PlantingDetailDialog({
           <p className="text-xs text-zen-stone-500 mb-3">
             Changes save automatically as you edit.
           </p>
+
+          {/* Lifecycle progress strip — only renders when sowDate + expected harvest exist */}
+          <PlantingProgress planting={planting} />
 
           {/* Tabs */}
           <div className="flex-1">

--- a/src/components/allotment/PlantingProgress.tsx
+++ b/src/components/allotment/PlantingProgress.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useState } from 'react'
+import { Sprout, Leaf } from 'lucide-react'
+import { Planting } from '@/types/unified-allotment'
+
+interface PlantingProgressProps {
+  planting: Planting
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function fmt(ts: number): string {
+  return new Date(ts).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+}
+
+/**
+ * Visual strip for a planting's life: sow → (transplant) → expected harvest
+ * window, with the actual harvest period overlaid and a "today" line.
+ *
+ * Hidden when the planting lacks the minimum data to draw something useful
+ * (sowDate plus expectedHarvestStart). The Dates tab still shows the raw
+ * fields when this strip is missing.
+ */
+export default function PlantingProgress({ planting }: PlantingProgressProps) {
+  // Captured once on mount so renders are pure (per the react-hooks/purity
+  // rule) — if the dialog is kept open across midnight the line is at most
+  // one day off.
+  const [today] = useState(() => Date.now())
+
+  const {
+    sowDate,
+    transplantDate,
+    expectedHarvestStart,
+    expectedHarvestEnd,
+    actualHarvestStart,
+    actualHarvestEnd,
+  } = planting
+
+  if (!sowDate || !expectedHarvestStart) return null
+
+  const start = new Date(sowDate).getTime()
+  const harvestStart = new Date(expectedHarvestStart).getTime()
+  const harvestEnd = expectedHarvestEnd ? new Date(expectedHarvestEnd).getTime() : harvestStart
+  const actualEndTs = actualHarvestEnd ? new Date(actualHarvestEnd).getTime() : 0
+  // Add a small tail past the harvest window so the "today" line has somewhere
+  // to sit when we're at or just past the end of the expected window.
+  const end = Math.max(harvestEnd, actualEndTs, harvestStart + 7 * DAY_MS)
+
+  const totalSpan = end - start
+  if (totalSpan <= 0) return null
+
+  const pct = (ts: number) => Math.max(0, Math.min(100, ((ts - start) / totalSpan) * 100))
+
+  const todayPct = pct(today)
+  const isTodayWithinRange = today >= start && today <= end
+  const harvestStartPct = pct(harvestStart)
+  const harvestEndPct = pct(harvestEnd)
+  const transplantPct = transplantDate ? pct(new Date(transplantDate).getTime()) : null
+  const actualStartPct = actualHarvestStart ? pct(new Date(actualHarvestStart).getTime()) : null
+  const actualEndPct = actualHarvestEnd ? pct(new Date(actualHarvestEnd).getTime()) : null
+
+  return (
+    <div className="my-3" role="region" aria-label="Planting progress">
+      <div className="relative h-2 rounded-full bg-zen-stone-100">
+        {/* Expected harvest window */}
+        <div
+          className="absolute top-0 h-full bg-zen-moss-200 rounded-full"
+          style={{
+            left: `${harvestStartPct}%`,
+            width: `${Math.max(2, harvestEndPct - harvestStartPct)}%`,
+          }}
+          aria-label={`Expected harvest ${fmt(harvestStart)}${
+            harvestEnd > harvestStart ? ` to ${fmt(harvestEnd)}` : ''
+          }`}
+        />
+
+        {/* Actual harvest period overlaid darker */}
+        {actualStartPct !== null && (
+          <div
+            className="absolute top-0 h-full bg-zen-moss-500 rounded-full"
+            style={{
+              left: `${actualStartPct}%`,
+              width: `${Math.max(2, (actualEndPct ?? todayPct) - actualStartPct)}%`,
+            }}
+            aria-label="Actual harvest"
+          />
+        )}
+
+        {/* Transplant marker */}
+        {transplantPct !== null && transplantDate && (
+          <div
+            className="absolute top-[-2px] w-1.5 h-3 -ml-[3px] rounded-sm bg-zen-water-400"
+            style={{ left: `${transplantPct}%` }}
+            title={`Transplanted ${fmt(new Date(transplantDate).getTime())}`}
+          />
+        )}
+
+        {/* Today line */}
+        {isTodayWithinRange && (
+          <div
+            className="absolute top-[-4px] bottom-[-4px] w-0.5 bg-zen-water-600"
+            style={{ left: `${todayPct}%` }}
+            title={`Today, ${fmt(today)}`}
+            aria-label="Today"
+          />
+        )}
+      </div>
+
+      <div className="mt-1.5 flex justify-between text-xs text-zen-stone-500">
+        <span className="flex items-center gap-1">
+          <Sprout className="w-3 h-3" />
+          {fmt(start)}
+        </span>
+        <span className="flex items-center gap-1">
+          <Leaf className="w-3 h-3 text-zen-moss-600" />
+          {fmt(harvestStart)}
+          {harvestEnd > harvestStart && <> – {fmt(harvestEnd)}</>}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/allotment/SowDateValidator.tsx
+++ b/src/components/allotment/SowDateValidator.tsx
@@ -10,7 +10,7 @@ import {
   getGerminationDays,
 } from '@/lib/date-calculator'
 
-interface PlantingTimelineProps {
+interface SowDateValidatorProps {
   sowDate: string
   sowMethod: SowMethod
   vegetable: Vegetable
@@ -21,12 +21,12 @@ interface PlantingTimelineProps {
  * Displays calculated harvest timeline and validation warnings
  * when a user enters sow date information in the planting form.
  */
-export default function PlantingTimeline({
+export default function SowDateValidator({
   sowDate,
   sowMethod,
   vegetable,
   transplantDate,
-}: PlantingTimelineProps) {
+}: SowDateValidatorProps) {
   // Calculate dates and validation
   const { dates, validation, germination } = useMemo(() => {
     const calculatedDates = calculatePlantingDates({

--- a/src/components/allotment/details/BedDetailPanel.tsx
+++ b/src/components/allotment/details/BedDetailPanel.tsx
@@ -7,8 +7,9 @@ import { getVegetableName } from '@/lib/vegetable-loader'
 import { getNextRotationGroup, ROTATION_GROUP_DISPLAY, getVegetablesForRotationGroup } from '@/lib/rotation'
 import { SHOW_ROTATION_SUGGESTIONS } from '@/config/release-visibility'
 import { RotationGroup } from '@/types/garden-planner'
-import { Planting, PlantingUpdate, Area, AreaSeason, AreaNote, NewAreaNote, AreaNoteUpdate } from '@/types/unified-allotment'
+import { Planting, PlantingUpdate, Area, AreaSeason, AreaNote, NewAreaNote, AreaNoteUpdate, StoredVariety } from '@/types/unified-allotment'
 import BedNotes from '@/components/allotment/BedNotes'
+import BoostThisBed from '@/components/allotment/BoostThisBed'
 import PlantingCard from '@/components/allotment/PlantingCard'
 import PlantingDetailDialog from '@/components/allotment/PlantingDetailDialog'
 import PlantSummaryDialog from '@/components/plants/PlantSummaryDialog'
@@ -22,7 +23,8 @@ interface BedDetailPanelProps {
   notes: AreaNote[]
   selectedYear: number
   previousYearRotation?: RotationGroup | null
-  onAddPlanting: () => void
+  varieties?: StoredVariety[]
+  onAddPlanting: (prefilledPlantId?: string) => void
   onDeletePlanting: (plantingId: string) => void
   onUpdatePlanting: (plantingId: string, updates: PlantingUpdate) => void
   onAddNote: (note: NewAreaNote) => void
@@ -41,6 +43,7 @@ export default function BedDetailPanel({
   notes,
   selectedYear,
   previousYearRotation,
+  varieties = [],
   onAddPlanting,
   onDeletePlanting,
   onUpdatePlanting,
@@ -187,6 +190,16 @@ export default function BedDetailPanel({
         />
       </div>
 
+      {/* Boost this bed — companion suggestions for the current plantings */}
+      {isRotationBed && plantings.length > 0 && (
+        <BoostThisBed
+          plantings={plantings}
+          varieties={varieties}
+          selectedYear={selectedYear}
+          onAddSuggestion={onAddPlanting}
+        />
+      )}
+
       {/* Plantings Section */}
       <div>
         <div className="flex items-center justify-between mb-2">
@@ -206,7 +219,7 @@ export default function BedDetailPanel({
               </button>
             )}
             <button
-              onClick={onAddPlanting}
+              onClick={() => onAddPlanting()}
               className="flex items-center gap-1.5 text-xs px-3 py-2.5 min-h-[44px] bg-zen-moss-100 text-zen-moss-700 rounded-zen hover:bg-zen-moss-200 transition"
             >
               <Plus className="w-4 h-4" />

--- a/src/components/allotment/details/BedDetailPanel.tsx
+++ b/src/components/allotment/details/BedDetailPanel.tsx
@@ -190,8 +190,12 @@ export default function BedDetailPanel({
         />
       </div>
 
-      {/* Boost this bed — companion suggestions for the current plantings */}
-      {isRotationBed && plantings.length > 0 && (
+      {/* Boost this bed — companion suggestions for the current plantings.
+          Renders for any bed with at least one planting; perennial beds
+          (e.g. asparagus + tomato) benefit from companions just as much as
+          rotation beds do. The component itself returns null when there
+          are no companion data for the plantings present. */}
+      {plantings.length > 0 && (
         <BoostThisBed
           plantings={plantings}
           varieties={varieties}

--- a/src/components/allotment/details/ItemDetailSwitcher.tsx
+++ b/src/components/allotment/details/ItemDetailSwitcher.tsx
@@ -2,7 +2,7 @@
 
 import { Map } from 'lucide-react'
 import { AllotmentItemRef, RotationGroup } from '@/types/garden-planner'
-import { Planting, PlantingUpdate, Area, AreaSeason, AreaNote, NewAreaNote, AreaNoteUpdate, NewPlanting, CareLogEntry, NewCareLogEntry } from '@/types/unified-allotment'
+import { Planting, PlantingUpdate, Area, AreaSeason, AreaNote, NewAreaNote, AreaNoteUpdate, NewPlanting, CareLogEntry, NewCareLogEntry, StoredVariety } from '@/types/unified-allotment'
 import BedDetailPanel from './BedDetailPanel'
 import PermanentDetailPanel from './PermanentDetailPanel'
 import InfrastructureDetailPanel from './InfrastructureDetailPanel'
@@ -26,7 +26,8 @@ interface ItemDetailSwitcherProps {
   getHarvestTotal: (areaId: string) => { quantity: number; unit: string } | null
   // Event handlers
   selectedYear: number
-  onAddPlanting: () => void
+  varieties?: StoredVariety[]
+  onAddPlanting: (prefilledPlantId?: string) => void
   onAddPlantingToArea: (areaId: string, planting: NewPlanting) => void
   onDeletePlanting: (plantingId: string) => void
   onRemovePlantingFromArea: (areaId: string, plantingId: string) => void
@@ -86,6 +87,7 @@ export default function ItemDetailSwitcher({
   getCareLogs,
   getHarvestTotal,
   selectedYear,
+  varieties,
   onAddPlanting,
   onAddPlantingToArea,
   onDeletePlanting,
@@ -129,6 +131,7 @@ export default function ItemDetailSwitcher({
         notes={getAreaNotes(area.id)}
         selectedYear={selectedYear}
         previousYearRotation={getPreviousYearRotation(area.id)}
+        varieties={varieties}
         onAddPlanting={onAddPlanting}
         onDeletePlanting={onDeletePlanting}
         onUpdatePlanting={onUpdatePlanting}

--- a/src/components/dashboard/TodayDashboard.tsx
+++ b/src/components/dashboard/TodayDashboard.tsx
@@ -7,6 +7,7 @@ import TaskList from './TaskList'
 import QuickActions from './QuickActions'
 import CompostAlerts from './CompostAlerts'
 import LocationPromptBanner from './LocationPromptBanner'
+import WeatherStrip from './WeatherStrip'
 import OnboardingWizard from '@/components/onboarding/OnboardingWizard'
 import PageTour from '@/components/onboarding/PageTour'
 import SignInPrompt from '@/components/auth/SignInPrompt'
@@ -114,8 +115,12 @@ export default function TodayDashboard() {
             <LocationPromptBanner onRequestLocation={onRequestLocation} />
           )}
 
-          {/* Rainfall summary when available */}
-          {rainfall && hasCoordinates && (
+          {/* Forecast strip (today / tomorrow / +1) when we have rich data,
+              otherwise fall back to the rainfall summary line. */}
+          {rainfall && hasCoordinates && rainfall.forecast && (
+            <WeatherStrip forecast={rainfall.forecast} />
+          )}
+          {rainfall && hasCoordinates && !rainfall.forecast && (
             <div className="text-xs text-zen-stone-500 -mt-4">
               Rainfall: {rainfall.past3DaysMm.toFixed(1)}mm last 3 days
               {rainfall.todayMm > 0 && `, ${rainfall.todayMm.toFixed(1)}mm forecast today`}

--- a/src/components/dashboard/WeatherStrip.tsx
+++ b/src/components/dashboard/WeatherStrip.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { ForecastDay } from '@/lib/weather/open-meteo'
+import { getWeatherIcon } from '@/lib/weather/wmo-icons'
+
+interface WeatherStripProps {
+  forecast: ForecastDay[]
+}
+
+const DAY_LABEL_FORMATTER = new Intl.DateTimeFormat('en-GB', { weekday: 'short' })
+
+function tileLabel(isoDate: string, index: number): string {
+  if (index === 0) return 'Today'
+  if (index === 1) return 'Tomorrow'
+  // Parse as local date — Open-Meteo returns YYYY-MM-DD without timezone.
+  const [y, m, d] = isoDate.split('-').map(Number)
+  if (!y || !m || !d) return isoDate
+  return DAY_LABEL_FORMATTER.format(new Date(y, m - 1, d))
+}
+
+export default function WeatherStrip({ forecast }: WeatherStripProps) {
+  if (forecast.length === 0) return null
+
+  return (
+    <div
+      className="grid grid-cols-3 gap-2 -mt-4"
+      role="region"
+      aria-label="Three day weather forecast"
+    >
+      {forecast.map((day, index) => {
+        const { Icon, label } = getWeatherIcon(day.weatherCode)
+        return (
+          <div
+            key={day.date}
+            className="zen-card px-3 py-3 flex flex-col items-center text-center"
+          >
+            <div className="text-xs font-medium text-zen-stone-500 mb-1">
+              {tileLabel(day.date, index)}
+            </div>
+            <Icon
+              className="w-7 h-7 text-zen-water-600 mb-1"
+              aria-label={label}
+            />
+            <div className="text-sm text-zen-ink-900">
+              {Math.round(day.tempMaxC)}° <span className="text-zen-stone-400">/ {Math.round(day.tempMinC)}°</span>
+            </div>
+            {day.precipitationMm > 0 && (
+              <div className="text-xs text-zen-water-600 mt-0.5">
+                {day.precipitationMm.toFixed(1)}mm
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/config/release-visibility.ts
+++ b/src/config/release-visibility.ts
@@ -17,6 +17,3 @@ export const SHOW_CARE_LOGS = true
 
 /** Underplantings list in permanent area detail panels */
 export const SHOW_UNDERPLANTINGS = false
-
-/** AI Advisor (Aitor) settings tab, including API key and location */
-export const SHOW_AI_ADVISOR = false

--- a/src/lib/boost-suggestions.ts
+++ b/src/lib/boost-suggestions.ts
@@ -1,0 +1,153 @@
+/**
+ * "Boost this bed" — companion suggestions for the plantings in an area.
+ *
+ * Walks the current plantings, dedupes their `enhancedCompanions`, ranks the
+ * results by confidence and seed availability, and returns up to `limit`
+ * suggestions with mechanism-derived "why" copy.
+ *
+ * Pure / synchronous — relies on the bundled vegetable database.
+ */
+
+import type {
+  CompanionConfidence,
+  CompanionMechanism,
+  EnhancedCompanion,
+} from '@/types/garden-planner'
+import type { Planting, StoredVariety } from '@/types/unified-allotment'
+import { getVegetableById } from '@/lib/vegetable-database'
+
+export interface BoostSuggestion {
+  plantId: string
+  plantName: string
+  reason: string
+  confidence: CompanionConfidence
+  hasSeed: boolean
+  /** Names of plantings in the bed that pair well with this suggestion. */
+  pairsWith: string[]
+}
+
+const CONFIDENCE_RANK: Record<CompanionConfidence, number> = {
+  proven: 4,
+  likely: 3,
+  traditional: 2,
+  anecdotal: 1,
+}
+
+/**
+ * Plain-English copy for each companion mechanism. Falls back to the generic
+ * "good companion" line when the mechanism is missing or unknown.
+ */
+function reasonFor(mechanism: CompanionMechanism | undefined): string {
+  switch (mechanism) {
+    case 'pest_confusion':
+      return 'Confuses pests'
+    case 'pest_trap':
+      return 'Lures pests away'
+    case 'allelopathy':
+      return 'Suppresses weeds'
+    case 'nitrogen_fixation':
+      return 'Fixes nitrogen for the bed'
+    case 'physical_support':
+      return 'Provides natural support'
+    case 'beneficial_attraction':
+      return 'Attracts pollinators and predators'
+    case 'disease_suppression':
+      return 'Reduces disease'
+    case 'unknown':
+    case undefined:
+      return 'Traditional good companion'
+    case 'nutrient_competition':
+      // Should not appear in companions — only in avoid lists — but be defensive.
+      return 'Good companion'
+    default:
+      return 'Good companion'
+  }
+}
+
+interface Accumulator {
+  companion: EnhancedCompanion
+  pairsWith: Set<string>
+}
+
+/**
+ * Build companion suggestions for a bed.
+ *
+ * @param plantings  Plantings currently in the bed.
+ * @param varieties  All stored varieties (used to flag suggestions where the
+ *                   user already has seed for the year).
+ * @param year       Year used for seed availability lookup.
+ * @param limit      Maximum number of suggestions to return.
+ */
+export function getBoostSuggestions(
+  plantings: Planting[],
+  varieties: StoredVariety[],
+  year: number,
+  limit = 3
+): BoostSuggestion[] {
+  if (plantings.length === 0) return []
+
+  // Plant IDs already in the bed — never suggest something the user already has.
+  const presentIds = new Set(plantings.map((p) => p.plantId))
+
+  // Map of suggestion plantId -> best companion entry plus the names it pairs with.
+  const acc = new Map<string, Accumulator>()
+
+  for (const planting of plantings) {
+    const veg = getVegetableById(planting.plantId)
+    if (!veg) continue
+    const sourceName = veg.name
+
+    for (const companion of veg.enhancedCompanions ?? []) {
+      if (presentIds.has(companion.plantId)) continue
+
+      const existing = acc.get(companion.plantId)
+      if (!existing) {
+        acc.set(companion.plantId, {
+          companion,
+          pairsWith: new Set([sourceName]),
+        })
+      } else {
+        existing.pairsWith.add(sourceName)
+        // Keep the higher-confidence record so the displayed reason is the
+        // strongest known pairing.
+        if (CONFIDENCE_RANK[companion.confidence] > CONFIDENCE_RANK[existing.companion.confidence]) {
+          existing.companion = companion
+        }
+      }
+    }
+  }
+
+  // Build seed-availability lookup once. A variety counts as "have seed" when
+  // its seedsByYear entry for the year is 'have'.
+  const haveSeedFor = new Set<string>()
+  for (const variety of varieties) {
+    if (variety.isArchived) continue
+    if (variety.seedsByYear?.[year] === 'have') {
+      haveSeedFor.add(variety.plantId)
+    }
+  }
+
+  const suggestions: BoostSuggestion[] = []
+  for (const [plantId, entry] of acc) {
+    const veg = getVegetableById(plantId)
+    if (!veg) continue
+    suggestions.push({
+      plantId,
+      plantName: veg.name,
+      reason: reasonFor(entry.companion.mechanism),
+      confidence: entry.companion.confidence,
+      hasSeed: haveSeedFor.has(plantId),
+      pairsWith: Array.from(entry.pairsWith),
+    })
+  }
+
+  // Rank: seeds-on-hand first, then by confidence, then by name for stability.
+  suggestions.sort((a, b) => {
+    if (a.hasSeed !== b.hasSeed) return a.hasSeed ? -1 : 1
+    const confDelta = CONFIDENCE_RANK[b.confidence] - CONFIDENCE_RANK[a.confidence]
+    if (confDelta !== 0) return confDelta
+    return a.plantName.localeCompare(b.plantName)
+  })
+
+  return suggestions.slice(0, limit)
+}

--- a/src/lib/weather/open-meteo.ts
+++ b/src/lib/weather/open-meteo.ts
@@ -1,9 +1,11 @@
 /**
  * Open-Meteo Weather Service
  *
- * Lightweight rainfall lookup used by the task generator to suppress watering
- * reminders after recent rain. Open-Meteo is free for non-commercial use,
- * needs no API key, and supports CORS, so we call it directly from the browser.
+ * Lightweight rainfall and forecast lookup. The task generator uses the
+ * rainfall summary to suppress watering reminders after recent rain, and
+ * the Today dashboard renders the forecast tiles. Open-Meteo is free for
+ * non-commercial use, needs no API key, and supports CORS, so we call it
+ * directly from the browser.
  *
  * The result is cached in localStorage with a 3-hour TTL keyed by coordinates
  * + the day of the request, so repeat task-list renders don't refetch.
@@ -16,6 +18,19 @@ const CACHE_PREFIX = 'bwp-weather-'
 const CACHE_TTL_MS = 3 * 60 * 60 * 1000 // 3 hours
 const FETCH_TIMEOUT_MS = 5000
 
+export interface ForecastDay {
+  /** ISO date (YYYY-MM-DD) for the forecast day. */
+  date: string
+  /** WMO weather interpretation code. See open-meteo.com/en/docs#weathervariables. */
+  weatherCode: number
+  /** Forecast max temperature in °C. */
+  tempMaxC: number
+  /** Forecast min temperature in °C. */
+  tempMinC: number
+  /** Forecast precipitation total in mm. */
+  precipitationMm: number
+}
+
 export interface RainfallSummary {
   /** Rain in mm during the last 3 days (excluding today). */
   past3DaysMm: number
@@ -23,12 +38,17 @@ export interface RainfallSummary {
   todayMm: number
   /** ISO timestamp when this summary was fetched. */
   fetchedAt: string
+  /** Optional forecast tiles for today and the next two days. */
+  forecast?: ForecastDay[]
 }
 
 interface OpenMeteoResponse {
   daily?: {
     time?: string[]
     precipitation_sum?: number[]
+    weathercode?: number[]
+    temperature_2m_max?: number[]
+    temperature_2m_min?: number[]
   }
 }
 
@@ -86,7 +106,7 @@ export async function fetchRainfall(
   const cached = readCache(key)
   if (cached) return cached
 
-  const url = `${ENDPOINT}?latitude=${latitude}&longitude=${longitude}&daily=precipitation_sum&past_days=3&forecast_days=1&timezone=auto`
+  const url = `${ENDPOINT}?latitude=${latitude}&longitude=${longitude}&daily=precipitation_sum,weathercode,temperature_2m_max,temperature_2m_min&past_days=3&forecast_days=3&timezone=auto`
 
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
@@ -104,13 +124,14 @@ export async function fetchRainfall(
       return null
     }
 
-    // past_days=3 + forecast_days=1 -> 4 entries: [d-3, d-2, d-1, today]
+    // past_days=3 + forecast_days=3 -> 6 entries: [d-3, d-2, d-1, today, +1, +2]
     const past3 = (series[0] ?? 0) + (series[1] ?? 0) + (series[2] ?? 0)
     const today = series[3] ?? 0
     const summary: RainfallSummary = {
       past3DaysMm: round1(past3),
       todayMm: round1(today),
       fetchedAt: new Date().toISOString(),
+      forecast: buildForecast(data.daily),
     }
     writeCache(key, summary)
     return summary
@@ -120,6 +141,32 @@ export async function fetchRainfall(
   } finally {
     clearTimeout(timeout)
   }
+}
+
+/**
+ * Build forecast tiles for today and the next two days from a daily payload.
+ * Returns undefined when any required series is missing or too short, so
+ * the rainfall summary falls back gracefully when the API is partial.
+ */
+function buildForecast(daily?: OpenMeteoResponse['daily']): ForecastDay[] | undefined {
+  if (!daily) return undefined
+  const { time, weathercode, temperature_2m_max, temperature_2m_min, precipitation_sum } = daily
+  if (!time || !weathercode || !temperature_2m_max || !temperature_2m_min || !precipitation_sum) {
+    return undefined
+  }
+  // Today is at index 3 (after past_days=3). We want today, +1, +2.
+  const start = 3
+  const tiles: ForecastDay[] = []
+  for (let i = start; i < start + 3 && i < time.length; i++) {
+    tiles.push({
+      date: time[i],
+      weatherCode: weathercode[i] ?? 0,
+      tempMaxC: round1(temperature_2m_max[i] ?? 0),
+      tempMinC: round1(temperature_2m_min[i] ?? 0),
+      precipitationMm: round1(precipitation_sum[i] ?? 0),
+    })
+  }
+  return tiles.length === 3 ? tiles : undefined
 }
 
 function round1(value: number): number {

--- a/src/lib/weather/wmo-icons.ts
+++ b/src/lib/weather/wmo-icons.ts
@@ -1,0 +1,39 @@
+/**
+ * Maps WMO weather interpretation codes to a small set of lucide-react icons
+ * and a short label. WMO codes come from the Open-Meteo `weathercode` field.
+ *
+ * Reference: https://open-meteo.com/en/docs (Weather variable documentation,
+ * "WMO Weather interpretation codes (WW)").
+ */
+
+import {
+  Sun,
+  CloudSun,
+  Cloud,
+  CloudFog,
+  CloudDrizzle,
+  CloudRain,
+  CloudSnow,
+  CloudLightning,
+  type LucideIcon,
+} from 'lucide-react'
+
+export interface WeatherIcon {
+  Icon: LucideIcon
+  label: string
+}
+
+export function getWeatherIcon(code: number): WeatherIcon {
+  if (code === 0) return { Icon: Sun, label: 'Clear' }
+  if (code === 1) return { Icon: Sun, label: 'Mainly clear' }
+  if (code === 2) return { Icon: CloudSun, label: 'Partly cloudy' }
+  if (code === 3) return { Icon: Cloud, label: 'Overcast' }
+  if (code === 45 || code === 48) return { Icon: CloudFog, label: 'Fog' }
+  if (code >= 51 && code <= 57) return { Icon: CloudDrizzle, label: 'Drizzle' }
+  if (code >= 61 && code <= 67) return { Icon: CloudRain, label: 'Rain' }
+  if (code >= 71 && code <= 77) return { Icon: CloudSnow, label: 'Snow' }
+  if (code >= 80 && code <= 82) return { Icon: CloudRain, label: 'Showers' }
+  if (code === 85 || code === 86) return { Icon: CloudSnow, label: 'Snow showers' }
+  if (code >= 95 && code <= 99) return { Icon: CloudLightning, label: 'Thunderstorm' }
+  return { Icon: Cloud, label: 'Cloudy' }
+}


### PR DESCRIPTION
## Summary

A round of research into adjacent gardening apps surfaced four small UI bets, all of which landed on this branch alongside a new research doc on frost/climate data.

## What's in the branch

### Today weather strip (`76ff0ef`)
Three-tile today/tomorrow/+1 forecast on the Today dashboard. The Open-Meteo query is extended with `weathercode` and min/max temperatures; `RainfallSummary` carries an optional `forecast` field with daily tiles. Falls back to the previous rainfall summary line when the forecast is unavailable. WMO codes mapped to lucide icons via a new `wmo-icons.ts` module.

### Crop progress strip (`a197ad4`)
New `<PlantingProgress>` component rendered inside `PlantingDetailDialog`. Shows sow date → expected harvest window → today, with the actual harvest period overlaid when recorded and a transplant marker when started indoors. Pure UI over existing `Planting` fields.

### "Boost this bed" companion suggestions (`2ba4c67`)
New section in `BedDetailPanel` for any bed with at least one planting. Surfaces up to three high-confidence companions for the plants currently in the bed, ranked by:

1. Whether the user already has seed for the year
2. Strongest companion confidence (proven > likely > traditional > anecdotal)
3. Plant name (for stable ordering)

Each row shows a mechanism-derived "why" line ("Fixes nitrogen for the bed", "Confuses pests", "Attracts pollinators and predators") and opens the existing add-planting dialog with the suggested variety pre-selected. Logic in `src/lib/boost-suggestions.ts`. Mobile bottom-sheet port is on the roadmap as a follow-up.

### Aitor re-enabled for signed-in users (`5255f4c`, `c4bb9a0`)
Replaces the global `SHOW_AI_ADVISOR` flag with Clerk authentication as the gate. The floating Aitor button + chat modal render via a small `AitorAuthGate` client wrapper that checks `useOptionalAuth()`. The Settings "AI & Location" tab is shown to signed-in users only via the same hook. Anonymous users continue to see no AI surfaces (so first-run onboarding stays focused). When Clerk is not configured at all, `useOptionalAuth` returns `isSignedIn: false` and Aitor stays hidden — same gate, same UI.

The `/api/ai-advisor` route now requires a Clerk userId at the top of the handler, matching the UI gate. This prevents the `OPENAI_API_KEY` env fallback from being drained by unauthenticated callers.

### Frost & climate data research (`d159100`, `87c7cb1`)
New `docs/research/frost-and-climate-data.md` exploring how to extend the Open-Meteo plumbing with frost-aware features: a frost dot on the weather strip, an RHS hardiness field on `Vegetable`, last/first frost dates from the Open-Meteo Climate API cached on `meta.frostDates`, and frost-aware sow-date validation. Sequenced and effort-estimated. Roadmap entries for each track promoted into `current-plan.md`.

## Other follow-ups in the roadmap

- **Aitor polish** — per-user `meta.aiAdvisorEnabled` opt-in (schema v20), photo-diagnosis pre-seed entry-point, refreshed prompt suggestions in `QuickTopics.tsx`.
- **Boost this bed on mobile** — port to `MobileAreaBottomSheet`.
- **Social login** — verify Google/Apple are enabled in the Clerk Dashboard.

## Review fixes applied (`c4bb9a0`)

1. Auth-gate `/api/ai-advisor` on a Clerk userId so the env-key fallback can't be drained anonymously.
2. Dropped the `isRotationBed` guard on `BoostThisBed` so perennial beds also get companion suggestions.
3. Renamed the existing `PlantingTimeline` (sow-date validation widget) to `SowDateValidator` to disambiguate from the new `PlantingProgress` lifecycle visualisation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 897 tests passing (was 859 before the branch; +38 new)
- [x] All CI checks green (CodeQL, Build, Lint, Plant Data Validation, Unit Tests, Type Check, E2E Tests)
- [ ] Manual browser verification of weather strip, crop progress, boost-this-bed wiring, and Aitor sign-in flow before merge

https://claude.ai/code/session_016FaWT4g2ZoZRYmWifTkwLJ