### PR TITLE
chore(security): bump postcss to patch GHSA-qx2v-qp2m-jg93

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10234,34 +10234,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -10800,10 +10772,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
   },
   "overrides": {
     "rollup": "^4.59.0",
-    "minimatch": "^9.0.8"
+    "minimatch": "^9.0.8",
+    "postcss": "^8.5.10"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #53 (GHSA-qx2v-qp2m-jg93, moderate): PostCSS XSS via unescaped `</style>` in CSS stringify output.

The vulnerable copy was a transitive `postcss@8.4.31` nested under `next`. Added `postcss: ^8.5.10` to the package.json `overrides` block so the nested copy is hoisted to the patched version. All postcss instances now resolve to `8.5.13`.

## Verification

- `npm audit` → 0 vulnerabilities
- `npm ls postcss` → all entries at 8.5.13
- `npm run lint` → clean
- `npm run test:unit` → 859 passed, 4 skipped

## Test plan

- [ ] CI green (lint, unit tests, build, Playwright)
- [ ] Dependabot alert #53 auto-closes after merge

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>