### PR TITLE
chore: add github-actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,5 +64,10 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Europe/London"
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,3 +56,13 @@ updates:
       type-definitions:
         patterns:
           - "@types/node"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/London"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Adds the `github-actions` ecosystem to `.github/dependabot.yml` so the 4 existing workflow files get tracked for action-version bumps. Matches the portfolio standard (npm + github-actions). One of 4 PRs from a Dependabot config audit across the portfolio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)