### PR TITLE
feat(compost): make pile names editable inline

### DIFF
--- a/src/app/compost/page.tsx
+++ b/src/app/compost/page.tsx
@@ -241,7 +241,9 @@ export default function CompostPage() {
                               type="text"
                               defaultValue={pile.name}
                               autoFocus
+                              aria-label="Edit pile name"
                               className="zen-input font-medium text-lg w-full"
+                              onFocus={(e) => e.currentTarget.select()}
                               onBlur={(e) => {
                                 const next = e.target.value.trim()
                                 if (next && next !== pile.name) {
@@ -254,6 +256,7 @@ export default function CompostPage() {
                                 if (e.key === 'Enter') {
                                   e.currentTarget.blur()
                                 } else if (e.key === 'Escape') {
+                                  e.currentTarget.value = pile.name
                                   setEditingName(null)
                                 }
                               }}

--- a/src/app/compost/page.tsx
+++ b/src/app/compost/page.tsx
@@ -79,6 +79,7 @@ export default function CompostPage() {
   const [pileToDelete, setPileToDelete] = useState<string | null>(null)
   const [expandedPiles, setExpandedPiles] = useState<Set<string>>(new Set())
   const [editingStartDate, setEditingStartDate] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState<string | null>(null)
   const [showCareTips, setShowCareTips] = useState(false)
 
   // Form state for new pile
@@ -234,8 +235,39 @@ export default function CompostPage() {
                     <div className="flex items-start justify-between gap-3 mb-4">
                       <div className="flex items-center gap-3 min-w-0 flex-1">
                         <span className="text-2xl sm:text-3xl flex-shrink-0">{getSystemEmoji(pile.systemType)}</span>
-                        <div className="min-w-0">
-                          <h3 className="font-medium text-lg text-zen-ink-800 truncate">{pile.name}</h3>
+                        <div className="min-w-0 flex-1">
+                          {editingName === pile.id ? (
+                            <input
+                              type="text"
+                              defaultValue={pile.name}
+                              autoFocus
+                              className="zen-input font-medium text-lg w-full"
+                              onBlur={(e) => {
+                                const next = e.target.value.trim()
+                                if (next && next !== pile.name) {
+                                  updatePile(pile.id, { name: next })
+                                }
+                                setEditingName(null)
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                  e.currentTarget.blur()
+                                } else if (e.key === 'Escape') {
+                                  setEditingName(null)
+                                }
+                              }}
+                            />
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => setEditingName(pile.id)}
+                              className="inline-flex items-center gap-1.5 hover:text-zen-moss-700 transition-colors text-left max-w-full"
+                              aria-label={`Rename ${pile.name}`}
+                            >
+                              <h3 className="font-medium text-lg text-zen-ink-800 truncate">{pile.name}</h3>
+                              <Pencil className="w-3 h-3 text-zen-stone-400 flex-shrink-0" />
+                            </button>
+                          )}
                           <p className="text-sm text-zen-stone-500">{SYSTEM_TYPES.find(s => s.value === pile.systemType)?.label}</p>
                         </div>
                       </div>

--- a/src/app/compost/page.tsx
+++ b/src/app/compost/page.tsx
@@ -250,6 +250,7 @@ export default function CompostPage() {
                                 setEditingName(null)
                               }}
                               onKeyDown={(e) => {
+                                if (e.nativeEvent.isComposing) return
                                 if (e.key === 'Enter') {
                                   e.currentTarget.blur()
                                 } else if (e.key === 'Escape') {
@@ -261,10 +262,10 @@ export default function CompostPage() {
                             <button
                               type="button"
                               onClick={() => setEditingName(pile.id)}
-                              className="inline-flex items-center gap-1.5 hover:text-zen-moss-700 transition-colors text-left max-w-full"
+                              className="inline-flex items-center gap-1.5 hover:text-zen-moss-700 transition-colors text-left max-w-full min-w-0"
                               aria-label={`Rename ${pile.name}`}
                             >
-                              <h3 className="font-medium text-lg text-zen-ink-800 truncate">{pile.name}</h3>
+                              <span className="font-medium text-lg text-zen-ink-800 truncate">{pile.name}</span>
                               <Pencil className="w-3 h-3 text-zen-stone-400 flex-shrink-0" />
                             </button>
                           )}


### PR DESCRIPTION
## Summary
- Click a compost pile's name to edit it inline; save on blur or Enter, cancel on Escape
- Mirrors the existing inline-edit pattern used for the pile start date
- No type or storage changes needed — `updateCompostPile` already supports name updates

## Test plan
- [ ] Open `/compost`, click a pile's name → input appears with current value
- [ ] Edit and press Enter → name updates and persists across reload
- [ ] Edit and click away → name updates on blur
- [ ] Edit and press Escape → no change
- [ ] Submit empty/whitespace value → no change

https://claude.ai/code/session_01Uz1U1V6ddZgUQKSi2sYJRU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uz1U1V6ddZgUQKSi2sYJRU)_