### PR TITLE
Reorganize navigation: swap Seeds and Plant Guide positions

### DIFF
--- a/docs/research/ux-verification-checklist.md
+++ b/docs/research/ux-verification-checklist.md
@@ -586,7 +586,7 @@
 ## 8. Navigation
 
 ### Desktop Navigation
-- ✅ Primary nav items visible (Today, This Month, Seeds, Compost, Allotment)
+- ✅ Primary nav items visible (Today, This Month, Plant Guide, Compost, Allotment)
 - ✅ "More" dropdown button visible
 - ✅ Dropdown opens on click
 - ✅ Settings link in dropdown

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -46,14 +46,14 @@ function NavAuthSection({
 const primaryNavLinks = [
   { href: '/', label: 'Today' },
   { href: '/this-month', label: 'This Month' },
-  { href: '/seeds', label: 'Seeds' },
+  { href: '/plants', label: 'Plant Guide' },
   { href: '/compost', label: 'Compost' },
   { href: '/allotment', label: 'Allotment' },
 ]
 
 // Secondary links shown in "More" dropdown
 export const secondaryLinks = [
-  { href: '/plants', label: 'Plant Guide', description: 'Growing info & tips' },
+  { href: '/seeds', label: 'Seeds', description: 'Inventory & varieties' },
   { href: '/settings', label: 'Settings', description: 'Sync & preferences' },
 ]
 


### PR DESCRIPTION
## Summary

Phase 1 of the seasonal menu reorganization. Swaps the primary/secondary placement of `/seeds` and `/plants`:
- "Plant Guide" promoted from the "More" dropdown into the primary nav (more useful day-to-day).
- "Seeds" demoted into the "More" dropdown (mostly relevant during planning).

Routes are unchanged — only nav placement and the Seeds dropdown description were updated.

## Type of change

- [x] New feature (UX reorganization)

## Notes

- Existing E2E tests that navigate via `/seeds` and `/plants` URLs continue to work unchanged.
- Also updated `docs/research/ux-verification-checklist.md` to reflect the new primary-nav list.
- Follow-up phases planned: merge related pages (e.g. fold Seeds into Plant Guide), and seasonal auto-adjust of primary-nav slots.

https://claude.ai/code/session_01BFVmbaZibQcksDykPz11WJ