### PR TITLE
fix(sync): prevent silent cloud overwrite on login

### DIFF
--- a/src/__tests__/hooks/useSyncedStorage.test.ts
+++ b/src/__tests__/hooks/useSyncedStorage.test.ts
@@ -16,13 +16,18 @@ vi.mock('@/hooks/useOptionalAuth', () => ({
   }),
 }))
 
-// Mock Supabase sync
+// Mock Supabase sync — keep contentSnapshot/isLocalStructurallySmaller real
+// since they are pure helpers that the hook depends on for its logic.
 const mockFetchRemote = vi.fn()
 const mockPushToRemote = vi.fn()
-vi.mock('@/lib/supabase/sync', () => ({
-  fetchRemote: (...args: unknown[]) => mockFetchRemote(...args),
-  pushToRemote: (...args: unknown[]) => mockPushToRemote(...args),
-}))
+vi.mock('@/lib/supabase/sync', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/supabase/sync')>('@/lib/supabase/sync')
+  return {
+    ...actual,
+    fetchRemote: (...args: unknown[]) => mockFetchRemote(...args),
+    pushToRemote: (...args: unknown[]) => mockPushToRemote(...args),
+  }
+})
 
 // Mock Supabase client
 vi.mock('@/lib/supabase/client', () => ({
@@ -197,7 +202,11 @@ describe('useSyncedStorage', () => {
     )
 
     const localData = makeTestData(pastSyncTime) // local unchanged since last sync
-    const remoteData = makeTestData('2026-03-10T14:00:00Z')
+    // Remote has different content (an extra variety) so the content
+    // short-circuit doesn't fire — we want the LWW newer-wins path.
+    const remoteData = makeTestData('2026-03-10T14:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v2', name: 'Pea' }] as unknown as AllotmentData['varieties'],
+    })
     mockLocalData = localData
     mockFetchRemote.mockResolvedValue({
       data: remoteData,
@@ -221,10 +230,14 @@ describe('useSyncedStorage', () => {
       JSON.stringify({ lastSyncedAt: pastSyncTime })
     )
 
-    const localData = makeTestData('2026-03-10T14:00:00Z')
+    // Local has extra content vs remote so it isn't structurally smaller —
+    // the safety check requires local >= remote on every axis to push.
+    const localData = makeTestData('2026-03-10T14:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v2', name: 'Pea' }] as unknown as AllotmentData['varieties'],
+    })
     mockLocalData = localData
     mockFetchRemote.mockResolvedValue({
-      data: makeTestData(pastSyncTime), // remote unchanged
+      data: makeTestData(pastSyncTime), // remote unchanged, different content
       updatedAt: pastSyncTime,
     })
     mockPushToRemote.mockResolvedValue(undefined)
@@ -247,8 +260,12 @@ describe('useSyncedStorage', () => {
       JSON.stringify({ lastSyncedAt: pastSyncTime })
     )
 
-    const localData = makeTestData('2026-03-05T10:00:00Z')
-    const remoteData = makeTestData('2026-03-05T14:00:00Z')
+    const localData = makeTestData('2026-03-05T10:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v-local', name: 'Local-only' }] as unknown as AllotmentData['varieties'],
+    })
+    const remoteData = makeTestData('2026-03-05T14:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v-remote', name: 'Remote-only' }] as unknown as AllotmentData['varieties'],
+    })
     mockLocalData = localData
     mockFetchRemote.mockResolvedValue({
       data: remoteData,
@@ -276,8 +293,12 @@ describe('useSyncedStorage', () => {
       JSON.stringify({ lastSyncedAt: pastSyncTime })
     )
 
-    const localData = makeTestData('2026-03-05T10:00:00Z')
-    const remoteData = makeTestData('2026-03-05T14:00:00Z')
+    const localData = makeTestData('2026-03-05T10:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v-local', name: 'Local-only' }] as unknown as AllotmentData['varieties'],
+    })
+    const remoteData = makeTestData('2026-03-05T14:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v-remote', name: 'Remote-only' }] as unknown as AllotmentData['varieties'],
+    })
     mockLocalData = localData
     mockFetchRemote.mockResolvedValue({
       data: remoteData,
@@ -307,8 +328,12 @@ describe('useSyncedStorage', () => {
       JSON.stringify({ lastSyncedAt: pastSyncTime })
     )
 
-    const localData = makeTestData('2026-03-05T10:00:00Z')
-    const remoteData = makeTestData('2026-03-05T14:00:00Z')
+    const localData = makeTestData('2026-03-05T10:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v-local', name: 'Local-only' }] as unknown as AllotmentData['varieties'],
+    })
+    const remoteData = makeTestData('2026-03-05T14:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v-remote', name: 'Remote-only' }] as unknown as AllotmentData['varieties'],
+    })
     mockLocalData = localData
     mockFetchRemote.mockResolvedValue({
       data: remoteData,
@@ -329,6 +354,43 @@ describe('useSyncedStorage', () => {
     expect(mockPushToRemote).toHaveBeenCalledWith('test-token', 'user-123', localData)
     expect(result.current.syncStatus).toBe('synced')
     expect(result.current.syncConflict).toBeNull()
+  })
+
+  // Cloud-overwrite incident regression: a stale local with a newer timestamp
+  // (e.g. fooled by saveAllotmentData's old unconditional bump or a
+  // load-time migration) must NOT silently overwrite a richer cloud snapshot.
+  it('routes through conflict when local is structurally smaller than remote despite a newer local timestamp', async () => {
+    const pastSyncTime = '2026-03-01T12:00:00Z'
+    localStorage.setItem(
+      'bonnie-synced-user-123',
+      JSON.stringify({ lastSyncedAt: pastSyncTime })
+    )
+
+    // Local has a newer updatedAt but FEWER varieties than remote.
+    const localData = makeTestData('2026-03-10T14:00:00Z', {
+      varieties: [{ id: 'v1', name: 'Tomato' }] as unknown as AllotmentData['varieties'],
+    })
+    const remoteData = makeTestData(pastSyncTime, {
+      varieties: [
+        { id: 'v1', name: 'Tomato' },
+        { id: 'v2', name: 'Pea' },
+        { id: 'v3', name: 'Carrot' },
+      ] as unknown as AllotmentData['varieties'],
+    })
+    mockLocalData = localData
+    mockFetchRemote.mockResolvedValue({
+      data: remoteData,
+      updatedAt: pastSyncTime,
+    })
+
+    const { result } = renderHook(() => useSyncedStorage(hookOptions))
+
+    await waitFor(() => {
+      expect(result.current.syncStatus).toBe('conflict')
+    })
+    expect(mockPushToRemote).not.toHaveBeenCalled()
+    expect(result.current.syncConflict?.local).toBe(localData)
+    expect(result.current.syncConflict?.remote).toBe(remoteData)
   })
 
   it('ignores stale initial-sync results when user changes mid-request', async () => {

--- a/src/__tests__/hooks/useSyncedStorage.test.ts
+++ b/src/__tests__/hooks/useSyncedStorage.test.ts
@@ -393,6 +393,44 @@ describe('useSyncedStorage', () => {
     expect(result.current.syncConflict?.remote).toBe(remoteData)
   })
 
+  // Regression: when local and remote have identical timestamps but their
+  // CONTENT disagrees (typically a one-sided load-time data repair), the
+  // old code path silently kept local. With the content-snapshot
+  // short-circuit at the top, we know we only reach the equal-timestamp
+  // branch when content has already diverged — so route to conflict.
+  it('routes through conflict when timestamps are equal but content differs', async () => {
+    const sharedTime = '2026-03-04T12:00:00Z'
+    localStorage.setItem(
+      'bonnie-synced-user-123',
+      JSON.stringify({ lastSyncedAt: sharedTime })
+    )
+
+    const localData = makeTestData(sharedTime, {
+      varieties: [{ id: 'v1', name: 'Tomato' }] as unknown as AllotmentData['varieties'],
+    })
+    const remoteData = makeTestData(sharedTime, {
+      varieties: [
+        { id: 'v1', name: 'Tomato' },
+        { id: 'v2', name: 'Pea' },
+      ] as unknown as AllotmentData['varieties'],
+    })
+    mockLocalData = localData
+    mockFetchRemote.mockResolvedValue({
+      data: remoteData,
+      updatedAt: sharedTime,
+    })
+
+    const { result } = renderHook(() => useSyncedStorage(hookOptions))
+
+    await waitFor(() => {
+      expect(result.current.syncStatus).toBe('conflict')
+    })
+    expect(mockPushToRemote).not.toHaveBeenCalled()
+    expect(mockSetData).not.toHaveBeenCalled()
+    expect(result.current.syncConflict?.local).toBe(localData)
+    expect(result.current.syncConflict?.remote).toBe(remoteData)
+  })
+
   it('ignores stale initial-sync results when user changes mid-request', async () => {
     const localData = makeTestData('2026-03-04T14:00:00Z')
     const staleRemoteData = makeTestData('2026-03-04T18:00:00Z')

--- a/src/__tests__/lib/supabase-sync.test.ts
+++ b/src/__tests__/lib/supabase-sync.test.ts
@@ -5,6 +5,8 @@ import {
   deleteRemote,
   fetchHistoryList,
   fetchHistorySnapshot,
+  contentSnapshot,
+  isLocalStructurallySmaller,
 } from '@/lib/supabase/sync'
 import type { AllotmentData } from '@/types/unified-allotment'
 
@@ -112,6 +114,104 @@ describe('deleteRemote', () => {
     expect(mockFrom).toHaveBeenCalledWith('allotments')
     expect(mockDelete).toHaveBeenCalled()
     expect(mockEq).toHaveBeenCalledWith('user_id', 'user-123')
+  })
+})
+
+function makeData(overrides: Partial<AllotmentData> = {}): AllotmentData {
+  return {
+    version: 21,
+    meta: {
+      name: 'Test',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-05-08T12:00:00Z',
+    },
+    layout: { areas: [] },
+    seasons: [],
+    currentYear: 2026,
+    varieties: [],
+    ...overrides,
+  } as unknown as AllotmentData
+}
+
+describe('contentSnapshot', () => {
+  it('returns the same fingerprint regardless of meta.updatedAt', () => {
+    const a = makeData({
+      meta: {
+        name: 'Test',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-05-08T12:00:00Z',
+      },
+    } as unknown as Partial<AllotmentData>)
+    const b = makeData({
+      meta: {
+        name: 'Test',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-05-08T18:00:00Z',
+      },
+    } as unknown as Partial<AllotmentData>)
+    expect(contentSnapshot(a)).toBe(contentSnapshot(b))
+  })
+
+  it('returns different fingerprints when content changes', () => {
+    const a = makeData({ currentYear: 2026 })
+    const b = makeData({ currentYear: 2027 })
+    expect(contentSnapshot(a)).not.toBe(contentSnapshot(b))
+  })
+})
+
+describe('isLocalStructurallySmaller', () => {
+  it('returns true when local has fewer plantings than remote', () => {
+    const remote = makeData({
+      seasons: [
+        {
+          year: 2026,
+          status: 'current',
+          areas: [
+            { areaId: 'a', plantings: [{ id: 'p1' }, { id: 'p2' }] },
+          ],
+        } as unknown,
+      ] as unknown as AllotmentData['seasons'],
+    })
+    const local = makeData({
+      seasons: [
+        {
+          year: 2026,
+          status: 'current',
+          areas: [{ areaId: 'a', plantings: [{ id: 'p1' }] }],
+        } as unknown,
+      ] as unknown as AllotmentData['seasons'],
+    })
+    expect(isLocalStructurallySmaller(local, remote)).toBe(true)
+  })
+
+  it('returns true when local has fewer areas than remote', () => {
+    const remote = makeData({ layout: { areas: [{ id: 'a' }, { id: 'b' }] } as unknown as AllotmentData['layout'] })
+    const local = makeData({ layout: { areas: [{ id: 'a' }] } as unknown as AllotmentData['layout'] })
+    expect(isLocalStructurallySmaller(local, remote)).toBe(true)
+  })
+
+  it('returns true when local has fewer varieties than remote', () => {
+    const remote = makeData({ varieties: [{ id: 'v1' }, { id: 'v2' }] as unknown as AllotmentData['varieties'] })
+    const local = makeData({ varieties: [{ id: 'v1' }] as unknown as AllotmentData['varieties'] })
+    expect(isLocalStructurallySmaller(local, remote)).toBe(true)
+  })
+
+  it('returns false when local matches remote on all axes', () => {
+    const data = makeData({
+      layout: { areas: [{ id: 'a' }] } as unknown as AllotmentData['layout'],
+      varieties: [{ id: 'v1' }] as unknown as AllotmentData['varieties'],
+    })
+    expect(isLocalStructurallySmaller(data, data)).toBe(false)
+  })
+
+  it('returns false when local has more content than remote', () => {
+    const local = makeData({
+      varieties: [{ id: 'v1' }, { id: 'v2' }] as unknown as AllotmentData['varieties'],
+    })
+    const remote = makeData({
+      varieties: [{ id: 'v1' }] as unknown as AllotmentData['varieties'],
+    })
+    expect(isLocalStructurallySmaller(local, remote)).toBe(false)
   })
 })
 

--- a/src/hooks/useSyncedStorage.ts
+++ b/src/hooks/useSyncedStorage.ts
@@ -15,7 +15,12 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useOptionalAuth } from './useOptionalAuth'
 import { usePersistedStorage, UsePersistedStorageOptions, UsePersistedStorageReturn } from './usePersistedStorage'
 import { useNetworkStatus } from './useNetworkStatus'
-import { fetchRemote, pushToRemote } from '@/lib/supabase/sync'
+import {
+  fetchRemote,
+  pushToRemote,
+  contentSnapshot,
+  isLocalStructurallySmaller,
+} from '@/lib/supabase/sync'
 import { isSupabaseConfigured } from '@/lib/supabase/client'
 import type { AllotmentData } from '@/types/unified-allotment'
 import type { SyncStatus } from '@/types/storage'
@@ -92,7 +97,10 @@ export function useSyncedStorage(
     activeUserIdRef.current !== expectedUserId
 
   const applyRemoteSnapshot = (remoteData: AllotmentData) => {
-    const snapshot = JSON.stringify(remoteData)
+    // Use content-only fingerprint so a subsequent local save (which may
+    // re-stamp meta.updatedAt) doesn't look like a content change to the
+    // push effect.
+    const snapshot = contentSnapshot(remoteData)
     pulledSnapshotRef.current = snapshot
     local.setData(remoteData)
     lastPushedRef.current = snapshot
@@ -123,7 +131,7 @@ export function useSyncedStorage(
         const token = await getSupabaseToken()
         if (token && !isStaleSyncUser(syncUserId)) {
           await pushToRemote(token, syncUserId, conflict.local)
-          lastPushedRef.current = JSON.stringify(conflict.local)
+          lastPushedRef.current = contentSnapshot(conflict.local)
         }
       } catch (err) {
         console.error('[useSyncedStorage] Failed to push after conflict resolution:', err)
@@ -171,7 +179,7 @@ export function useSyncedStorage(
           // First-time cloud user — push local data up
           await pushToRemote(token, syncUserId, local.data!)
           if (isStaleSyncUser(syncUserId)) return
-          lastPushedRef.current = JSON.stringify(local.data)
+          lastPushedRef.current = contentSnapshot(local.data!)
           markSynced(syncUserId)
           setSyncStatus('synced')
           setSyncError(null)
@@ -199,6 +207,19 @@ export function useSyncedStorage(
         const localChanged = localTime > lastSyncTime
         const remoteChanged = remoteTime > lastSyncTime
 
+        // Content-level short-circuit: if local and remote serialise to the
+        // same content (ignoring meta.updatedAt), there is nothing to push
+        // or pull. Just refresh the sync flag and move on.
+        const localSnap = contentSnapshot(localData)
+        const remoteSnap = contentSnapshot(remote.data)
+        if (localSnap === remoteSnap) {
+          lastPushedRef.current = localSnap
+          markSynced(syncUserId)
+          setSyncStatus('synced')
+          setSyncError(null)
+          return
+        }
+
         if (localChanged && remoteChanged) {
           // Both sides changed since last sync — conflict
           setSyncConflict({
@@ -214,13 +235,26 @@ export function useSyncedStorage(
           // Only remote changed, or remote is newer
           applyRemoteSnapshot(remote.data)
         } else if (localChanged || localTime > remoteTime) {
-          // Only local changed, or local is newer
+          // Local appears newer. Belt-and-braces: if local is structurally
+          // smaller than remote on any axis (plantings/areas/varieties),
+          // route through the conflict UI rather than silently overwriting
+          // the cloud — this is the failure mode that cost the user a few
+          // days of activity in the 2026-05-08 incident.
+          if (isLocalStructurallySmaller(localData, remote.data)) {
+            setSyncConflict({
+              local: localData,
+              remote: remote.data,
+              remoteUpdatedAt: remote.updatedAt,
+            })
+            setSyncStatus('conflict')
+            return
+          }
           await pushToRemote(token, syncUserId, local.data!)
           if (isStaleSyncUser(syncUserId)) return
-          lastPushedRef.current = JSON.stringify(local.data)
+          lastPushedRef.current = contentSnapshot(local.data!)
         } else {
           // Same timestamp — already in sync
-          lastPushedRef.current = JSON.stringify(local.data)
+          lastPushedRef.current = contentSnapshot(local.data!)
         }
 
         markSynced(syncUserId)
@@ -253,7 +287,7 @@ export function useSyncedStorage(
     if (syncInProgressRef.current) return
     if (!initialSyncDoneRef.current) return
 
-    const serialized = JSON.stringify(local.data)
+    const serialized = contentSnapshot(local.data)
 
     // Skip push if this save matches the snapshot we just pulled from cloud
     if (pulledSnapshotRef.current && serialized === pulledSnapshotRef.current) {
@@ -307,7 +341,7 @@ export function useSyncedStorage(
         if (!remote) {
           await pushToRemote(token, syncUserId, local.data!)
           if (isStaleSyncUser(syncUserId)) return
-          lastPushedRef.current = JSON.stringify(local.data)
+          lastPushedRef.current = contentSnapshot(local.data!)
         } else {
           const localData = local.data!
           const localTime = toTimestamp(localData.meta?.updatedAt)
@@ -317,6 +351,17 @@ export function useSyncedStorage(
 
           const localChanged = localTime > lastSyncTime
           const remoteChanged = remoteTime > lastSyncTime
+
+          // Content-level short-circuit: nothing to do if both sides match.
+          const localSnap = contentSnapshot(localData)
+          const remoteSnap = contentSnapshot(remote.data)
+          if (localSnap === remoteSnap) {
+            lastPushedRef.current = localSnap
+            markSynced(syncUserId)
+            setSyncStatus('synced')
+            setSyncError(null)
+            return
+          }
 
           if (localChanged && remoteChanged) {
             setSyncConflict({
@@ -331,9 +376,20 @@ export function useSyncedStorage(
           if (remoteChanged || remoteTime > localTime) {
             applyRemoteSnapshot(remote.data)
           } else {
+            // Local appears newer — but bail to a conflict if it looks like a
+            // stale or freshly-initialised copy that would shrink the cloud.
+            if (isLocalStructurallySmaller(localData, remote.data)) {
+              setSyncConflict({
+                local: localData,
+                remote: remote.data,
+                remoteUpdatedAt: remote.updatedAt,
+              })
+              setSyncStatus('conflict')
+              return
+            }
             await pushToRemote(token, syncUserId, local.data!)
             if (isStaleSyncUser(syncUserId)) return
-            lastPushedRef.current = JSON.stringify(local.data)
+            lastPushedRef.current = contentSnapshot(local.data!)
           }
         }
         markSynced(syncUserId)

--- a/src/hooks/useSyncedStorage.ts
+++ b/src/hooks/useSyncedStorage.ts
@@ -253,8 +253,20 @@ export function useSyncedStorage(
           if (isStaleSyncUser(syncUserId)) return
           lastPushedRef.current = contentSnapshot(local.data!)
         } else {
-          // Same timestamp — already in sync
-          lastPushedRef.current = contentSnapshot(local.data!)
+          // Equal timestamps but the content snapshots disagree (otherwise
+          // we'd have short-circuited above). Neither side claims to have
+          // changed since the last sync, yet they no longer match — most
+          // likely a load-time data repair / migration on one device that
+          // didn't make it to the other. Surface a conflict so the user
+          // picks rather than silently keeping local; that's exactly the
+          // class of silent overwrite the rest of this PR is closing.
+          setSyncConflict({
+            local: localData,
+            remote: remote.data,
+            remoteUpdatedAt: remote.updatedAt,
+          })
+          setSyncStatus('conflict')
+          return
         }
 
         markSynced(syncUserId)

--- a/src/lib/supabase/sync.ts
+++ b/src/lib/supabase/sync.ts
@@ -7,6 +7,46 @@ export interface RemoteData {
 }
 
 /**
+ * Stable content fingerprint for an AllotmentData blob with `meta.updatedAt`
+ * blanked out. Used by the sync layer to decide whether two snapshots are the
+ * same regardless of timestamp drift — schema migrations, data repair, and
+ * other load-time side effects can churn `updatedAt` without changing any
+ * meaningful content, and we don't want that to trigger a cloud push.
+ */
+export function contentSnapshot(data: AllotmentData): string {
+  return JSON.stringify({ ...data, meta: { ...data.meta, updatedAt: '' } })
+}
+
+/**
+ * Heuristic: does `local` look structurally smaller than `remote` on any of
+ * the user-facing axes (plantings, areas, varieties)? Used as a safety net on
+ * initial sync — if LWW says "push local" but local has fewer plantings/areas/
+ * varieties than remote, treat it as a conflict instead of silently
+ * overwriting cloud data with what is probably a stale or freshly-initialised
+ * local copy.
+ */
+export function isLocalStructurallySmaller(local: AllotmentData, remote: AllotmentData): boolean {
+  const countPlantings = (d: AllotmentData) =>
+    (d.seasons || []).reduce(
+      (sum, s) => sum + (s.areas || []).reduce((a, area) => a + (area.plantings?.length || 0), 0),
+      0
+    )
+  const localPlantings = countPlantings(local)
+  const remotePlantings = countPlantings(remote)
+  if (localPlantings < remotePlantings) return true
+
+  const localAreas = local.layout?.areas?.length || 0
+  const remoteAreas = remote.layout?.areas?.length || 0
+  if (localAreas < remoteAreas) return true
+
+  const localVarieties = local.varieties?.length || 0
+  const remoteVarieties = remote.varieties?.length || 0
+  if (localVarieties < remoteVarieties) return true
+
+  return false
+}
+
+/**
  * Fetch the user's allotment from Supabase.
  * Returns null if no row exists (first-time user).
  */

--- a/src/services/storage-core.ts
+++ b/src/services/storage-core.ts
@@ -142,23 +142,21 @@ export function saveAllotmentData(data: AllotmentData): StorageResult<void> {
   }
 
   try {
-    // Update the updatedAt timestamp
-    const dataToSave: AllotmentData = {
-      ...data,
-      meta: {
-        ...data.meta,
-        updatedAt: new Date().toISOString(),
-      },
-    }
-
-    const jsonString = JSON.stringify(dataToSave)
+    // Persist exactly what was passed in. Mutations that represent a real
+    // user content change set `meta.updatedAt` themselves (see area-mutations
+    // and planting-operations). Bumping the timestamp here on every save
+    // would also bump it for load-time side effects (schema migrations,
+    // validation/repair, currentYear auto-update), which fooled LWW sync
+    // into thinking local was newer than the cloud and silently overwrote
+    // remote work — see the cloud-overwrite incident on 2026-05-08.
+    const jsonString = JSON.stringify(data)
 
     try {
       localStorage.setItem(STORAGE_KEY, jsonString)
       return { success: true }
     } catch (error) {
       if (isQuotaExceededError(error)) {
-        const dataSize = formatBytes(getDataSizeBytes(dataToSave))
+        const dataSize = formatBytes(getDataSizeBytes(data))
         logger.error('localStorage quota exceeded', { dataSize })
 
         return {


### PR DESCRIPTION
## Summary

Three layered fixes for the data-loss incident on 2026-05-08, where signing in on a window with stale localStorage silently overwrote several days of cloud activity:

1. **Drop the unconditional `meta.updatedAt` bump in `saveAllotmentData`.** Real mutations (area-mutations, planting-operations, variety-operations) already set `updatedAt` explicitly. The blanket bump here also fired for load-time side effects (schema migrations, data validation/repair, currentYear auto-update), which made LWW think local was newer than the cloud.

2. **Content-equality short-circuit before any push.** New `contentSnapshot()` helper serialises an `AllotmentData` blob with `meta.updatedAt` blanked out — a stable fingerprint that ignores timestamp drift. `useSyncedStorage` uses it for `lastPushedRef` / `pulledSnapshotRef` and short-circuits the push when local and remote have identical content snapshots. This is the "do not write stuff in the DB without checking if they are different" rule the user asked for.

3. **Initial-sync overwrite safety net.** If LWW says "push local" but local is structurally smaller than remote on plantings/areas/varieties (`isLocalStructurallySmaller`), route through the existing conflict dialog instead of silently pushing. Belt-and-braces for the exact failure mode that cost the user a few days of activity.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` — 929 pass, 4 skipped (was 921 + 4)
- [x] New unit tests cover `contentSnapshot` (timestamp-invariance) and `isLocalStructurallySmaller` (each axis + equal/larger cases).
- [x] New regression test in `useSyncedStorage`: stale local with newer timestamp + fewer varieties than remote routes to conflict, never calls pushToRemote.
- [ ] Manual: sign in on a second window, confirm cloud data is not silently overwritten.

## Notes

I removed the timestamp bump in `saveAllotmentData` rather than wrapping it with a "did anything actually change" check — every mutation in the codebase already sets `updatedAt` explicitly when it should, and the content-snapshot fingerprint (fix 2) catches any path that forgets. This keeps the save layer dumb and the sync layer in charge of timestamps and content equality.