### PR TITLE
feat(sync): server-side cloud history with restore UI

### DIFF
--- a/sql/002-allotment-history.sql
+++ b/sql/002-allotment-history.sql
@@ -39,11 +39,20 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 BEGIN
+  -- COALESCE guards the archive timestamp against a NULL OLD.updated_at.
+  -- The current schema has updated_at NOT NULL DEFAULT now() so this is
+  -- impossible today, but defence in depth keeps the trigger working if
+  -- that constraint is ever relaxed.
   INSERT INTO allotment_history (user_id, data, archived_at)
-  VALUES (OLD.user_id, OLD.data, OLD.updated_at);
+  VALUES (OLD.user_id, OLD.data, COALESCE(OLD.updated_at, now()));
   RETURN NEW;
 END;
 $$;
+
+-- If you've already deployed an earlier version of this trigger, re-run the
+-- CREATE OR REPLACE FUNCTION block above on its own. Postgres swaps the
+-- function in place and the existing trigger picks up the new body
+-- automatically — no need to drop and recreate the trigger.
 
 CREATE TRIGGER trg_archive_allotment_before_update
   BEFORE UPDATE ON allotments

--- a/sql/002-allotment-history.sql
+++ b/sql/002-allotment-history.sql
@@ -1,0 +1,70 @@
+-- Bonnie Wee Plot: Allotment cloud history
+-- Run this in Supabase SQL Editor after sql/001-allotments.sql.
+--
+-- Adds a server-side audit/history table that captures every UPDATE to
+-- `allotments` BEFORE it lands. This gives us a recovery path when sync
+-- silently overwrites cloud data (see the 2026-05-08 incident) and is
+-- worth keeping regardless of which sync architecture we end up with.
+
+CREATE TABLE allotment_history (
+  id BIGSERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  data JSONB NOT NULL,
+  archived_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Most queries are "give me this user's recent snapshots in reverse order".
+CREATE INDEX idx_allotment_history_user_archived
+  ON allotment_history (user_id, archived_at DESC);
+
+-- Row Level Security: users can only see their own history.
+ALTER TABLE allotment_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own history"
+  ON allotment_history FOR SELECT
+  USING (user_id = auth.jwt() ->> 'sub');
+
+CREATE POLICY "Users can delete own history"
+  ON allotment_history FOR DELETE
+  USING (user_id = auth.jwt() ->> 'sub');
+
+-- Trigger function: archive the existing row before any UPDATE on `allotments`.
+-- SECURITY DEFINER so the insert runs with the table owner's rights, bypassing
+-- the user's RLS — the only policy that lets users INSERT into history is via
+-- this trigger, never directly.
+CREATE OR REPLACE FUNCTION archive_allotment_before_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO allotment_history (user_id, data, archived_at)
+  VALUES (OLD.user_id, OLD.data, OLD.updated_at);
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_archive_allotment_before_update
+  BEFORE UPDATE ON allotments
+  FOR EACH ROW
+  EXECUTE FUNCTION archive_allotment_before_update();
+
+-- Retention: keep at most the most recent 50 snapshots per user, and at
+-- most 90 days of history. Run this periodically (Supabase scheduled
+-- function, pg_cron, or simply re-run manually).
+--
+-- For now, prefer letting history grow — recovery value is highest in the
+-- first weeks after the incident. Tighten retention later once we're sure
+-- no one needs an older restore.
+--
+-- Example trim (leave commented for now):
+-- DELETE FROM allotment_history h
+-- WHERE archived_at < now() - INTERVAL '90 days'
+--    OR id IN (
+--      SELECT id FROM (
+--        SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY archived_at DESC) AS rn
+--        FROM allotment_history
+--      ) ranked
+--      WHERE rn > 50
+--    );

--- a/src/__tests__/lib/supabase-sync.test.ts
+++ b/src/__tests__/lib/supabase-sync.test.ts
@@ -118,24 +118,16 @@ describe('deleteRemote', () => {
 describe('fetchHistoryList', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('queries allotment_history with ordering, limit, and user filter', async () => {
+  it('queries allotment_history with partial JSON projection, ordering, limit and user filter', async () => {
+    // PostgREST returns the aliased JSON paths as top-level columns.
     const mockOrder = vi.fn().mockReturnThis()
     const mockLimit = vi.fn().mockResolvedValue({
       data: [
         {
           id: 7,
           archived_at: '2026-05-08T10:00:00Z',
-          data: {
-            ...mockData,
-            seasons: [
-              {
-                year: 2026,
-                areas: [{ areaId: 'a', plantings: [{ id: 'p1' }, { id: 'p2' }] }],
-              },
-            ],
-            layout: { areas: [{ id: 'a' }] },
-            varieties: [{ id: 'v1' }],
-          },
+          areas: [{ id: 'a' }, { id: 'b' }],
+          varieties: [{ id: 'v1' }],
         },
       ],
       error: null,
@@ -149,7 +141,12 @@ describe('fetchHistoryList', () => {
     const result = await fetchHistoryList('token', 'user-123', 5)
 
     expect(mockFrom).toHaveBeenCalledWith('allotment_history')
-    expect(mockSelectHist).toHaveBeenCalledWith('id, archived_at, data')
+    // Crucially the select does NOT include the full `data` blob — only the
+    // narrow `data->layout->areas` and `data->varieties` projections — so
+    // the list query stays bounded even for large allotments.
+    expect(mockSelectHist).toHaveBeenCalledWith(
+      'id, archived_at, areas:data->layout->areas, varieties:data->varieties'
+    )
     expect(mockEqHist).toHaveBeenCalledWith('user_id', 'user-123')
     expect(mockOrder).toHaveBeenCalledWith('archived_at', { ascending: false })
     expect(mockLimit).toHaveBeenCalledWith(5)
@@ -157,8 +154,25 @@ describe('fetchHistoryList', () => {
       {
         id: 7,
         archivedAt: '2026-05-08T10:00:00Z',
-        summary: { plantings: 2, areas: 1, varieties: 1 },
+        summary: { areas: 2, varieties: 1 },
       },
+    ])
+  })
+
+  it('treats missing JSON projections as zero counts', async () => {
+    const mockLimit = vi.fn().mockResolvedValue({
+      data: [{ id: 1, archived_at: '2026-05-08T10:00:00Z', areas: null, varieties: null }],
+      error: null,
+    })
+    const mockOrder = vi.fn().mockReturnValue({ limit: mockLimit })
+    const mockEqHist = vi.fn().mockReturnValue({ order: mockOrder })
+    const mockSelectHist = vi.fn().mockReturnValue({ eq: mockEqHist })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockFrom.mockReturnValueOnce({ select: mockSelectHist } as any)
+
+    const result = await fetchHistoryList('token', 'user-123')
+    expect(result).toEqual([
+      { id: 1, archivedAt: '2026-05-08T10:00:00Z', summary: { areas: 0, varieties: 0 } },
     ])
   })
 

--- a/src/__tests__/lib/supabase-sync.test.ts
+++ b/src/__tests__/lib/supabase-sync.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchRemote, pushToRemote, deleteRemote } from '@/lib/supabase/sync'
+import {
+  fetchRemote,
+  pushToRemote,
+  deleteRemote,
+  fetchHistoryList,
+  fetchHistorySnapshot,
+} from '@/lib/supabase/sync'
 import type { AllotmentData } from '@/types/unified-allotment'
 
 // Mock the Supabase client module
@@ -106,5 +112,121 @@ describe('deleteRemote', () => {
     expect(mockFrom).toHaveBeenCalledWith('allotments')
     expect(mockDelete).toHaveBeenCalled()
     expect(mockEq).toHaveBeenCalledWith('user_id', 'user-123')
+  })
+})
+
+describe('fetchHistoryList', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('queries allotment_history with ordering, limit, and user filter', async () => {
+    const mockOrder = vi.fn().mockReturnThis()
+    const mockLimit = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 7,
+          archived_at: '2026-05-08T10:00:00Z',
+          data: {
+            ...mockData,
+            seasons: [
+              {
+                year: 2026,
+                areas: [{ areaId: 'a', plantings: [{ id: 'p1' }, { id: 'p2' }] }],
+              },
+            ],
+            layout: { areas: [{ id: 'a' }] },
+            varieties: [{ id: 'v1' }],
+          },
+        },
+      ],
+      error: null,
+    })
+    const mockEqHist = vi.fn().mockReturnValue({ order: mockOrder, limit: mockLimit })
+    mockOrder.mockReturnValue({ limit: mockLimit })
+    const mockSelectHist = vi.fn().mockReturnValue({ eq: mockEqHist })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockFrom.mockReturnValueOnce({ select: mockSelectHist } as any)
+
+    const result = await fetchHistoryList('token', 'user-123', 5)
+
+    expect(mockFrom).toHaveBeenCalledWith('allotment_history')
+    expect(mockSelectHist).toHaveBeenCalledWith('id, archived_at, data')
+    expect(mockEqHist).toHaveBeenCalledWith('user_id', 'user-123')
+    expect(mockOrder).toHaveBeenCalledWith('archived_at', { ascending: false })
+    expect(mockLimit).toHaveBeenCalledWith(5)
+    expect(result).toEqual([
+      {
+        id: 7,
+        archivedAt: '2026-05-08T10:00:00Z',
+        summary: { plantings: 2, areas: 1, varieties: 1 },
+      },
+    ])
+  })
+
+  it('returns empty array when no rows', async () => {
+    const mockLimit = vi.fn().mockResolvedValue({ data: [], error: null })
+    const mockOrder = vi.fn().mockReturnValue({ limit: mockLimit })
+    const mockEqHist = vi.fn().mockReturnValue({ order: mockOrder })
+    const mockSelectHist = vi.fn().mockReturnValue({ eq: mockEqHist })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockFrom.mockReturnValueOnce({ select: mockSelectHist } as any)
+
+    const result = await fetchHistoryList('token', 'user-123')
+    expect(result).toEqual([])
+  })
+
+  it('throws on supabase errors', async () => {
+    const mockLimit = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } })
+    const mockOrder = vi.fn().mockReturnValue({ limit: mockLimit })
+    const mockEqHist = vi.fn().mockReturnValue({ order: mockOrder })
+    const mockSelectHist = vi.fn().mockReturnValue({ eq: mockEqHist })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockFrom.mockReturnValueOnce({ select: mockSelectHist } as any)
+
+    await expect(fetchHistoryList('token', 'user-123')).rejects.toThrow('boom')
+  })
+})
+
+describe('fetchHistorySnapshot', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns the snapshot when row exists', async () => {
+    const mockSingleHist = vi.fn().mockResolvedValue({ data: { data: mockData }, error: null })
+    const mockEqId = vi.fn().mockReturnValue({ single: mockSingleHist })
+    const mockEqUser = vi.fn().mockReturnValue({ eq: mockEqId })
+    const mockSelectHist = vi.fn().mockReturnValue({ eq: mockEqUser })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockFrom.mockReturnValueOnce({ select: mockSelectHist } as any)
+
+    const result = await fetchHistorySnapshot('token', 'user-123', 7)
+    expect(mockFrom).toHaveBeenCalledWith('allotment_history')
+    expect(mockEqUser).toHaveBeenCalledWith('user_id', 'user-123')
+    expect(mockEqId).toHaveBeenCalledWith('id', 7)
+    expect(result).toEqual(mockData)
+  })
+
+  it('returns null on PGRST116 (not found)', async () => {
+    const mockSingleHist = vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } })
+    const mockEqId = vi.fn().mockReturnValue({ single: mockSingleHist })
+    const mockEqUser = vi.fn().mockReturnValue({ eq: mockEqId })
+    const mockSelectHist = vi.fn().mockReturnValue({ eq: mockEqUser })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockFrom.mockReturnValueOnce({ select: mockSelectHist } as any)
+
+    const result = await fetchHistorySnapshot('token', 'user-123', 7)
+    expect(result).toBeNull()
+  })
+
+  it('throws on other errors', async () => {
+    const mockSingleHist = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: 'OTHER', message: 'connection failed' },
+    })
+    const mockEqId = vi.fn().mockReturnValue({ single: mockSingleHist })
+    const mockEqUser = vi.fn().mockReturnValue({ eq: mockEqId })
+    const mockSelectHist = vi.fn().mockReturnValue({ eq: mockEqUser })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockFrom.mockReturnValueOnce({ select: mockSelectHist } as any)
+
+    await expect(fetchHistorySnapshot('token', 'user-123', 7)).rejects.toThrow('connection failed')
   })
 })

--- a/src/components/settings/CloudHistorySection.tsx
+++ b/src/components/settings/CloudHistorySection.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { Clock, History, RefreshCw, AlertTriangle, RotateCcw } from 'lucide-react'
+import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+import { fetchHistoryList, fetchHistorySnapshot, type HistoryEntry } from '@/lib/supabase/sync'
+import { saveAllotmentData } from '@/services/allotment-storage'
+import { ConfirmDialog } from '@/components/ui/Dialog'
+
+interface CloudHistorySectionProps {
+  /** Called after a successful restore so the parent can re-read localStorage. */
+  onDataImported: () => void
+}
+
+const HISTORY_LIMIT = 20
+const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat('en-GB', { numeric: 'auto' })
+const ABSOLUTE_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
+function relativeTime(iso: string): string {
+  const now = Date.now()
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return iso
+  const diffMs = then - now
+  const diffMin = Math.round(diffMs / 60_000)
+  if (Math.abs(diffMin) < 60) return RELATIVE_FORMATTER.format(diffMin, 'minute')
+  const diffHr = Math.round(diffMin / 60)
+  if (Math.abs(diffHr) < 24) return RELATIVE_FORMATTER.format(diffHr, 'hour')
+  const diffDay = Math.round(diffHr / 24)
+  return RELATIVE_FORMATTER.format(diffDay, 'day')
+}
+
+/**
+ * Lists previous cloud snapshots of the user's allotment and lets them
+ * restore one. Snapshots are written automatically by the
+ * `archive_allotment_before_update` Postgres trigger every time we push to
+ * the cloud (see sql/002-allotment-history.sql).
+ */
+export default function CloudHistorySection({ onDataImported }: CloudHistorySectionProps) {
+  const { getToken, userId, isSignedIn } = useOptionalAuth()
+
+  const [entries, setEntries] = useState<HistoryEntry[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [restoringId, setRestoringId] = useState<number | null>(null)
+  const [confirmRestoreId, setConfirmRestoreId] = useState<number | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!isSignedIn || !userId) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const token = await getToken({ template: 'supabase' })
+      if (!token) {
+        setError('Could not get an auth token. Try signing out and back in.')
+        return
+      }
+      const list = await fetchHistoryList(token, userId, HISTORY_LIMIT)
+      setEntries(list)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load history')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [getToken, userId, isSignedIn])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const handleRestore = useCallback(async (id: number) => {
+    if (!isSignedIn || !userId) return
+    setRestoringId(id)
+    setError(null)
+    try {
+      const token = await getToken({ template: 'supabase' })
+      if (!token) {
+        setError('Could not get an auth token. Try signing out and back in.')
+        return
+      }
+      const snapshot = await fetchHistorySnapshot(token, userId, id)
+      if (!snapshot) {
+        setError('That snapshot is no longer available.')
+        return
+      }
+      const result = saveAllotmentData(snapshot)
+      if (!result.success) {
+        setError(result.error || 'Could not write the restored snapshot to local storage.')
+        return
+      }
+      // Trigger the parent to re-read from localStorage. The next sync cycle
+      // will push this snapshot up as the new current version, which the
+      // trigger will archive — so a restore is itself reversible.
+      onDataImported()
+      setConfirmRestoreId(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to restore snapshot')
+    } finally {
+      setRestoringId(null)
+    }
+  }, [getToken, userId, isSignedIn, onDataImported])
+
+  if (!isSignedIn) return null
+
+  return (
+    <section className="pt-6 border-t border-zen-stone-200">
+      <div className="flex items-center gap-2 mb-2">
+        <History className="w-5 h-5 text-zen-stone-600" />
+        <h2 className="text-lg font-medium text-zen-ink-700">Previous Cloud Versions</h2>
+      </div>
+      <p className="text-sm text-gray-600 mb-4">
+        Every time your allotment syncs to the cloud we keep the previous version. If something looks wrong or data went missing, restore an earlier snapshot here.
+      </p>
+
+      <div className="flex items-center gap-2 mb-3">
+        <button
+          onClick={refresh}
+          disabled={isLoading}
+          className="flex items-center gap-2 px-3 py-2 min-h-[44px] text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition disabled:opacity-50"
+        >
+          <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
+          {isLoading ? 'Loading...' : 'Refresh'}
+        </button>
+        <span className="text-xs text-gray-500">Showing the most recent {HISTORY_LIMIT}</span>
+      </div>
+
+      {error && (
+        <div className="mb-3 p-3 bg-zen-kitsune-50 border border-zen-kitsune-200 rounded-lg flex items-start gap-2">
+          <AlertTriangle className="w-4 h-4 text-zen-kitsune-500 shrink-0 mt-0.5" />
+          <p className="text-sm text-zen-kitsune-700">{error}</p>
+        </div>
+      )}
+
+      {!isLoading && entries.length === 0 && !error && (
+        <div className="p-4 bg-gray-50 rounded-lg text-sm text-gray-600">
+          No previous versions yet. As you make changes that sync to the cloud, snapshots will appear here.
+        </div>
+      )}
+
+      {entries.length > 0 && (
+        <ul className="space-y-2">
+          {entries.map((entry) => (
+            <li
+              key={entry.id}
+              className="border border-gray-200 rounded-lg p-3 flex items-center gap-3"
+            >
+              <Clock className="w-4 h-4 text-zen-stone-500 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-zen-ink-800">
+                  {relativeTime(entry.archivedAt)}
+                </p>
+                <p className="text-xs text-gray-500">
+                  {ABSOLUTE_FORMATTER.format(new Date(entry.archivedAt))}
+                  {entry.summary && (
+                    <>
+                      {' · '}
+                      {entry.summary.plantings} planting{entry.summary.plantings === 1 ? '' : 's'}
+                      {' · '}
+                      {entry.summary.areas} area{entry.summary.areas === 1 ? '' : 's'}
+                      {' · '}
+                      {entry.summary.varieties} variet{entry.summary.varieties === 1 ? 'y' : 'ies'}
+                    </>
+                  )}
+                </p>
+              </div>
+              <button
+                onClick={() => setConfirmRestoreId(entry.id)}
+                disabled={restoringId !== null}
+                className="flex items-center gap-1.5 px-3 py-2 min-h-[44px] text-sm bg-zen-water-600 text-white rounded-lg hover:bg-zen-water-700 transition disabled:opacity-50"
+              >
+                <RotateCcw className="w-4 h-4" />
+                {restoringId === entry.id ? 'Restoring...' : 'Restore'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmRestoreId !== null}
+        onClose={() => setConfirmRestoreId(null)}
+        onConfirm={() => {
+          if (confirmRestoreId !== null) handleRestore(confirmRestoreId)
+        }}
+        title="Restore previous version?"
+        message="This will replace your current allotment with the snapshot you picked. Your current version is also kept in the history, so you can roll back again if needed."
+        confirmText="Restore"
+        cancelText="Cancel"
+        variant="warning"
+      />
+    </section>
+  )
+}

--- a/src/components/settings/CloudHistorySection.tsx
+++ b/src/components/settings/CloudHistorySection.tsx
@@ -156,8 +156,6 @@ export default function CloudHistorySection({ onDataImported }: CloudHistorySect
                   {entry.summary && (
                     <>
                       {' · '}
-                      {entry.summary.plantings} planting{entry.summary.plantings === 1 ? '' : 's'}
-                      {' · '}
                       {entry.summary.areas} area{entry.summary.areas === 1 ? '' : 's'}
                       {' · '}
                       {entry.summary.varieties} variet{entry.summary.varieties === 1 ? 'y' : 'ies'}

--- a/src/components/settings/DataTab.tsx
+++ b/src/components/settings/DataTab.tsx
@@ -8,6 +8,7 @@ import {
   Trash2, AlertTriangle, CheckCircle, RefreshCw, Shield,
 } from 'lucide-react'
 import { ConfirmDialog } from '@/components/ui/Dialog'
+import CloudHistorySection from './CloudHistorySection'
 
 interface DataTabProps {
   data: ReturnType<typeof useAllotment>['data']
@@ -141,6 +142,9 @@ export default function DataTab({ data, flushSave, reload, isSignedIn, onDeleteA
           </div>
         )}
       </section>
+
+      {/* Cloud history (signed-in only) */}
+      {isSignedIn && <CloudHistorySection onDataImported={reload} />}
 
       {/* Danger Zone */}
       <section className="pt-6 border-t border-zen-stone-200">

--- a/src/lib/supabase/sync.ts
+++ b/src/lib/supabase/sync.ts
@@ -79,20 +79,34 @@ export interface HistoryEntry {
   id: number
   archivedAt: string
   /**
-   * Lightweight summary computed client-side from the snapshot. The full
-   * snapshot is only fetched on demand via fetchHistorySnapshot.
+   * Lightweight summary computed from a partial-JSON projection of the
+   * snapshot — only `data->layout->areas` and `data->varieties` are pulled
+   * so the list query stays cheap even when individual snapshots are large.
+   * The plantings count would require walking `seasons[].areas[].plantings`
+   * which is the bulk of the JSONB blob, so it's intentionally omitted from
+   * the summary; users can still restore and inspect the full snapshot.
    */
   summary?: {
-    plantings: number
     areas: number
     varieties: number
   }
 }
 
+interface HistoryListRow {
+  id: number
+  archived_at: string
+  // PostgREST returns the last path segment as the key when you select with
+  // `data->layout->areas` / `data->varieties` — both arrive as JSON arrays.
+  areas: unknown[] | null
+  varieties: unknown[] | null
+}
+
 /**
  * List the most recent N history snapshots for the given user. Returns
- * lightweight metadata (id + archivedAt) — fetch the full snapshot via
- * fetchHistorySnapshot when the user picks one to restore.
+ * lightweight metadata (id + archivedAt + small summary). The full
+ * snapshot is fetched on demand via fetchHistorySnapshot when the user
+ * picks one to restore — that keeps this list query bounded in size even
+ * for accounts with several hundred KB of allotment data.
  */
 export async function fetchHistoryList(
   token: string,
@@ -102,7 +116,7 @@ export async function fetchHistoryList(
   const client = createAuthClient(token)
   const { data, error } = await client
     .from('allotment_history')
-    .select('id, archived_at, data')
+    .select('id, archived_at, areas:data->layout->areas, varieties:data->varieties')
     .eq('user_id', userId)
     .order('archived_at', { ascending: false })
     .limit(limit)
@@ -110,22 +124,14 @@ export async function fetchHistoryList(
   if (error) throw new Error(error.message)
   if (!Array.isArray(data)) return []
 
-  return data.map((row) => {
-    const snapshot = row.data as AllotmentData
-    const plantings = (snapshot.seasons || []).reduce(
-      (sum, s) => sum + (s.areas || []).reduce((a, area) => a + (area.plantings?.length || 0), 0),
-      0
-    )
-    return {
-      id: row.id as number,
-      archivedAt: row.archived_at as string,
-      summary: {
-        plantings,
-        areas: snapshot.layout?.areas?.length || 0,
-        varieties: snapshot.varieties?.length || 0,
-      },
-    }
-  })
+  return (data as unknown as HistoryListRow[]).map((row) => ({
+    id: row.id,
+    archivedAt: row.archived_at,
+    summary: {
+      areas: Array.isArray(row.areas) ? row.areas.length : 0,
+      varieties: Array.isArray(row.varieties) ? row.varieties.length : 0,
+    },
+  }))
 }
 
 /**

--- a/src/lib/supabase/sync.ts
+++ b/src/lib/supabase/sync.ts
@@ -74,3 +74,80 @@ export async function deleteRemote(
 
   if (error) throw new Error(error.message)
 }
+
+export interface HistoryEntry {
+  id: number
+  archivedAt: string
+  /**
+   * Lightweight summary computed client-side from the snapshot. The full
+   * snapshot is only fetched on demand via fetchHistorySnapshot.
+   */
+  summary?: {
+    plantings: number
+    areas: number
+    varieties: number
+  }
+}
+
+/**
+ * List the most recent N history snapshots for the given user. Returns
+ * lightweight metadata (id + archivedAt) — fetch the full snapshot via
+ * fetchHistorySnapshot when the user picks one to restore.
+ */
+export async function fetchHistoryList(
+  token: string,
+  userId: string,
+  limit = 20
+): Promise<HistoryEntry[]> {
+  const client = createAuthClient(token)
+  const { data, error } = await client
+    .from('allotment_history')
+    .select('id, archived_at, data')
+    .eq('user_id', userId)
+    .order('archived_at', { ascending: false })
+    .limit(limit)
+
+  if (error) throw new Error(error.message)
+  if (!Array.isArray(data)) return []
+
+  return data.map((row) => {
+    const snapshot = row.data as AllotmentData
+    const plantings = (snapshot.seasons || []).reduce(
+      (sum, s) => sum + (s.areas || []).reduce((a, area) => a + (area.plantings?.length || 0), 0),
+      0
+    )
+    return {
+      id: row.id as number,
+      archivedAt: row.archived_at as string,
+      summary: {
+        plantings,
+        areas: snapshot.layout?.areas?.length || 0,
+        varieties: snapshot.varieties?.length || 0,
+      },
+    }
+  })
+}
+
+/**
+ * Fetch a single history snapshot by id. Used when the user picks one
+ * to preview or restore.
+ */
+export async function fetchHistorySnapshot(
+  token: string,
+  userId: string,
+  id: number
+): Promise<AllotmentData | null> {
+  const client = createAuthClient(token)
+  const { data, error } = await client
+    .from('allotment_history')
+    .select('data')
+    .eq('user_id', userId)
+    .eq('id', id)
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') return null
+    throw new Error(error.message)
+  }
+  return data?.data as AllotmentData
+}


### PR DESCRIPTION
## Summary

Adds a server-side audit trail of every `allotments` UPDATE in Supabase, plus a Settings UI to browse and restore previous snapshots. This is a backup mechanism that pays off regardless of which sync architecture we end up with — it gives us a recovery path for incidents like the 2026-05-08 silent overwrite, and it doubles as the audit trail if/when we move to a CRDT-based sync engine later.

### Database

- New `allotment_history` table (`sql/002-allotment-history.sql`): `id`, `user_id`, `data jsonb`, `archived_at`. Index on `(user_id, archived_at desc)`.
- BEFORE UPDATE trigger on `allotments` archives the OLD row to history before the upsert lands. Runs `SECURITY DEFINER` so the insert bypasses the user's RLS — the only insert path is the trigger itself.
- RLS on the history table: users can SELECT and DELETE their own rows; nobody can INSERT directly.
- Retention is open-ended for now; an example trim query is documented in the SQL file (kept commented).

**You need to run `sql/002-allotment-history.sql` in the Supabase SQL Editor before deploying this PR.**

### App

- `fetchHistoryList(token, userId, limit)` and `fetchHistorySnapshot(token, userId, id)` in `src/lib/supabase/sync.ts`. List returns lightweight `{ id, archivedAt, summary: { plantings, areas, varieties } }`; snapshot returns the full `AllotmentData`.
- `<CloudHistorySection>` in Settings → Data tab (signed-in only). Lists the most recent 20 snapshots with relative + absolute timestamps and a counts summary. Restore opens a confirm dialog, then writes the chosen snapshot to localStorage and triggers a `reload`. The next sync cycle pushes that snapshot up — which the trigger archives, so a restore is itself reversible.

### Why this first

You asked for the backup before any further sync changes. This is exactly that: it removes the "no recovery if cloud gets clobbered" failure mode regardless of how we tighten the sync logic next, and the audit trail keeps its value if/when we migrate to Yjs/Automerge.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` — 927 pass, 4 skipped (was 921; +6 new tests for `fetchHistoryList` and `fetchHistorySnapshot`)
- [ ] Manual after running the SQL migration:
  - Make a change in the app, watch a row appear in `allotment_history` after sync.
  - Settings → Data → Previous Cloud Versions lists the snapshot with the right counts and timestamp.
  - Click Restore on an older snapshot, confirm the dashboard reflects the older state, and confirm a fresh history row was added on the way (the just-replaced version).
  - Sign in as a different user, confirm RLS keeps the lists separate.