### PR TITLE
docs: add cloud-history follow-ups to the next-session plan

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,6 @@
 # Current Plan
 
-Last updated: 2026-05-09
+Last updated: 2026-05-09 (post-merge of #335/#332/#331)
 
 ## What's Been Completed
 
@@ -258,6 +258,35 @@ Branch: `fix/sync-overwrite-safety`. Three layered fixes that ship together:
 Includes regression test in `useSyncedStorage.test.ts` that asserts a stale-but-newer-stamped local with fewer varieties than remote routes to conflict, never calls `pushToRemote`. Also tightens five existing LWW tests that were using timestamp-only differences (now correctly short-circuited by fix 2) to use real content differences.
 
 Land #332 first so users have a recovery path while #331 is rolling out, then land #331. They don't conflict; #331 is content-only and #332 is additive (new table, new component).
+
+**Status:** Both #332 (`83ee236`) and #331 (`99dd858`) are merged on `main` as of 2026-05-09. #331 was rebased onto post-#332 main; the conflict in `src/__tests__/lib/supabase-sync.test.ts` was resolved by keeping all four test groups (fetchHistory* from #332 + contentSnapshot/isLocalStructurallySmaller from #331) plus a unified import.
+
+#### Cloud history follow-ups (next-session priority — observed in production)
+
+After #332 + #331 landed, the production cloud-history list grew faster than expected: ~4 snapshots within a single 1–2 minute window of activity, e.g. four "08:41 · 28 areas · 32 varieties" rows back-to-back. Root cause: every `setData` in the app triggers a debounced local save, every save fires the push effect in `useSyncedStorage` (`src/hooks/useSyncedStorage.ts`), every push hits the `BEFORE UPDATE` trigger on `allotments`, and so every meaningful in-app interaction (toggling a task, editing a name, dismissing a banner) creates one history row. This is the architecture working as designed — but it makes the restore list noisy and grows the history table fast.
+
+Two layered dampeners, in order of leverage:
+
+##### 1. Push-side debounce in `useSyncedStorage` (~20 lines, est. 80% reduction in noise)
+
+Currently the push effect fires on every `local.saveStatus === 'saved'` transition with no further coalescing. Add a ~30s timer: when a save lands, schedule the push for now+30s; if another save arrives during the window, reset the timer; only the last call wins. Net effect — a burst of changes within the window collapses to one push and one history row. Also wire `flushSave()` (already exposed by `usePersistedStorage`) into a `beforeunload` listener so closing the tab forces an immediate push rather than dropping the pending burst.
+
+- **Files:** `src/hooks/useSyncedStorage.ts` (timer + ref for the pending push), possibly a small `useFlushOnUnload` hook.
+- **Tests to add:** `useSyncedStorage.test.ts` — assert that 3 rapid `saveStatus='saved'` transitions within the window result in exactly one `pushToRemote` call; assert that `beforeunload` flushes immediately.
+- **Tradeoff:** cloud lags local by up to 30s. Fine for a single-user app; the local cache is always current.
+
+##### 2. Snapshot diff UI (future, larger task)
+
+The current restore list shows date + areas + varieties counts but no indication of *what changed* between adjacent snapshots. Once the debounce reduces volume to a manageable level, add a "View changes" affordance per row that diffs that snapshot against the next-newer one (or against current). Useful diff dimensions: areas added/removed/renamed, plantings added/removed/edited, varieties added/removed, schema version bumps. Could render inline in the row (tiny "+2 plantings, −1 variety" hint) or open a dedicated dialog.
+
+This is a heavier piece of work — needs a JSONB diff routine that understands the `AllotmentData` shape rather than a generic deep-diff (otherwise the noise from `meta.updatedAt`, `lastSyncedAt`, etc. would drown the meaningful changes). Worth doing once the debounce has reduced volume so the diff actually has something interesting to compare against.
+
+- **Files:** new `src/lib/allotment-diff.ts`, extend `<CloudHistorySection>` to show diff hints + a dialog component, possibly fetch two snapshots in parallel.
+- **Spike first:** decide on diff library (jsondiffpatch, deep-diff, or a hand-rolled walker tuned to AllotmentData shape).
+
+##### 3. Trigger-side coalesce / retention (optional, defer)
+
+If the client-side debounce is enough, skip this. If the history table still grows too fast, the SQL trigger can UPDATE the most recent history row in place when its `archived_at` is less than ~30s old, and the retention SQL in `sql/002-allotment-history.sql` can bucket older snapshots (one per 5-minute window after an hour, one per hour after a day, etc). Keep commented in the SQL file until volume justifies it.
 
 #### Future: revisit the sync engine (ADR 027 — not started)
 

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -269,10 +269,12 @@ Two layered dampeners, in order of leverage:
 
 ##### 1. Push-side debounce in `useSyncedStorage` (~20 lines, est. 80% reduction in noise)
 
-Currently the push effect fires on every `local.saveStatus === 'saved'` transition with no further coalescing. Add a ~30s timer: when a save lands, schedule the push for now+30s; if another save arrives during the window, reset the timer; only the last call wins. Net effect — a burst of changes within the window collapses to one push and one history row. Also wire `flushSave()` (already exposed by `usePersistedStorage`) into a `beforeunload` listener so closing the tab forces an immediate push rather than dropping the pending burst.
+Currently the push effect fires on every `local.saveStatus === 'saved'` transition with no further coalescing. Add a ~30s timer: when a save lands, schedule the push for now+30s; if another save arrives during the window, reset the timer; only the last call wins. Net effect — a burst of changes within the window collapses to one push and one history row. Also expose a `flushPush()` from `useSyncedStorage` and wire it into a `beforeunload` listener so closing the tab forces an immediate push of the pending data rather than dropping the burst.
 
-- **Files:** `src/hooks/useSyncedStorage.ts` (timer + ref for the pending push), possibly a small `useFlushOnUnload` hook.
-- **Tests to add:** `useSyncedStorage.test.ts` — assert that 3 rapid `saveStatus='saved'` transitions within the window result in exactly one `pushToRemote` call; assert that `beforeunload` flushes immediately.
+Important: just calling `usePersistedStorage.flushSave()` on unload is **not** sufficient on its own — that flushes the local persistence layer, which would then trigger the sync effect, which would then start a *new* 30s timer and the user would still have left before the push fires. The unload path needs to bypass the debounce: call `flushSave()` first to ensure the latest data is in localStorage, then synchronously cancel the pending debounce timer and call `pushToRemote(...)` directly (using `navigator.sendBeacon` if we want survivability of an actual unload, or a synchronous `fetch` keepalive).
+
+- **Files:** `src/hooks/useSyncedStorage.ts` (timer + ref for the pending push, new `flushPush()` exported), small `useFlushOnUnload` hook that wires `beforeunload`/`pagehide` and chains `flushSave()` → `flushPush()`.
+- **Tests to add:** `useSyncedStorage.test.ts` — assert that 3 rapid `saveStatus='saved'` transitions within the window result in exactly one `pushToRemote` call; assert that `flushPush()` cancels the pending timer and pushes immediately; assert that `beforeunload` triggers `flushPush()`.
 - **Tradeoff:** cloud lags local by up to 30s. Fine for a single-user app; the local cache is always current.
 
 ##### 2. Snapshot diff UI (future, larger task)
@@ -287,6 +289,8 @@ This is a heavier piece of work — needs a JSONB diff routine that understands 
 ##### 3. Trigger-side coalesce / retention (optional, defer)
 
 If the client-side debounce is enough, skip this. If the history table still grows too fast, the SQL trigger can UPDATE the most recent history row in place when its `archived_at` is less than ~30s old, and the retention SQL in `sql/002-allotment-history.sql` can bucket older snapshots (one per 5-minute window after an hour, one per hour after a day, etc). Keep commented in the SQL file until volume justifies it.
+
+The UPDATE must be strictly scoped to the user — pseudo-SQL: `UPDATE allotment_history SET data = OLD.data, archived_at = COALESCE(OLD.updated_at, now()) WHERE id = (SELECT id FROM allotment_history WHERE user_id = OLD.user_id AND archived_at > now() - INTERVAL '30 seconds' ORDER BY archived_at DESC LIMIT 1)`. Without the `WHERE user_id = OLD.user_id` filter on the inner SELECT, two different users saving within the same 30s window could merge each other's snapshots, which would be a much worse incident than the verbosity it's trying to fix.
 
 #### Future: revisit the sync engine (ADR 027 — not started)
 


### PR DESCRIPTION
## Summary

Captures the production observation that #332 + #331 generate one history row per save (verified: ~4 snapshots in a 1-2 min window during normal task editing) and lays out the next-session work to dampen it.

Three layered options in priority order:

1. **Push-side debounce in `useSyncedStorage`** — ~30s coalescing window for `pushToRemote`, plus a `flushSave()`-on-`beforeunload` hook so closing the tab doesn't drop the pending burst. Estimated ~20 lines, ~80% noise reduction. Cloud lags local by up to 30s; fine for a single-user app.
2. **Snapshot diff UI** — "View changes" affordance per row in `<CloudHistorySection>` showing what's different between adjacent snapshots. Needs an `AllotmentData`-aware diff routine (not a generic deep-diff — meta timestamps would drown the meaningful changes). Worth doing once the debounce reduces volume so the diff has interesting content.
3. **Trigger-side coalesce / bucketed retention** — optional. If the client debounce isn't enough, the SQL trigger can UPDATE in place when the previous row is < 30s old, and the retention SQL can bucket older snapshots. Keep commented in `sql/002-allotment-history.sql` until volume justifies.

Also stamps the post-merge state (PR #335 `02ed7c9` / PR #332 `83ee236` / PR #331 `99dd858`) so a fresh session can pick up cleanly.

## Test plan
- [x] Doc-only change.