### PR TITLE
feat(sync): debounce cloud pushes to coalesce burst saves

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,6 @@
 # Current Plan
 
-Last updated: 2026-05-09 (post-merge of #335/#332/#331)
+Last updated: 2026-05-09 (post-merge of #335/#332/#331; push debounce in flight)
 
 ## What's Been Completed
 
@@ -261,21 +261,21 @@ Land #332 first so users have a recovery path while #331 is rolling out, then la
 
 **Status:** Both #332 (`83ee236`) and #331 (`99dd858`) are merged on `main` as of 2026-05-09. #331 was rebased onto post-#332 main; the conflict in `src/__tests__/lib/supabase-sync.test.ts` was resolved by keeping all four test groups (fetchHistory* from #332 + contentSnapshot/isLocalStructurallySmaller from #331) plus a unified import.
 
-#### Cloud history follow-ups (next-session priority — observed in production)
+#### Cloud history follow-ups
 
 After #332 + #331 landed, the production cloud-history list grew faster than expected: ~4 snapshots within a single 1–2 minute window of activity, e.g. four "08:41 · 28 areas · 32 varieties" rows back-to-back. Root cause: every `setData` in the app triggers a debounced local save, every save fires the push effect in `useSyncedStorage` (`src/hooks/useSyncedStorage.ts`), every push hits the `BEFORE UPDATE` trigger on `allotments`, and so every meaningful in-app interaction (toggling a task, editing a name, dismissing a banner) creates one history row. This is the architecture working as designed — but it makes the restore list noisy and grows the history table fast.
 
-Two layered dampeners, in order of leverage:
+Two layered dampeners, in order of leverage. The first has shipped; the others remain backlog.
 
-##### 1. Push-side debounce in `useSyncedStorage` (~20 lines, est. 80% reduction in noise)
+##### 1. Push-side debounce in `useSyncedStorage` — Shipped (PR #TBD, branch `feat/sync-push-debounce`)
 
-Currently the push effect fires on every `local.saveStatus === 'saved'` transition with no further coalescing. Add a ~30s timer: when a save lands, schedule the push for now+30s; if another save arrives during the window, reset the timer; only the last call wins. Net effect — a burst of changes within the window collapses to one push and one history row. Also expose a `flushPush()` from `useSyncedStorage` and wire it into a `beforeunload` listener so closing the tab forces an immediate push of the pending data rather than dropping the burst.
+The push effect now schedules pushes via a 30 s `PUSH_DEBOUNCE_MS` timer instead of firing on every `local.saveStatus === 'saved'` transition. Each new save during the window resets the timer and updates `pendingPushDataRef`; only the latest snapshot survives. A new `flushPush()` is exposed from `useSyncedStorage` (and re-exported through `useAllotmentData` and `useAllotment`) which cancels the timer and pushes immediately, returning a Promise.
 
-Important: just calling `usePersistedStorage.flushSave()` on unload is **not** sufficient on its own — that flushes the local persistence layer, which would then trigger the sync effect, which would then start a *new* 30s timer and the user would still have left before the push fires. The unload path needs to bypass the debounce: call `flushSave()` first to ensure the latest data is in localStorage, then synchronously cancel the pending debounce timer and call `pushToRemote(...)` directly (using `navigator.sendBeacon` if we want survivability of an actual unload, or a synchronous `fetch` keepalive).
+Unload safety net: `useSyncedStorage` registers a `pagehide` + `beforeunload` listener that runs `local.flushSave()` first (to ensure the latest data is in localStorage as the recovery floor) and then `flushPush()` synchronously bypasses the debounce. The plan deliberately rejected the simpler "just call `flushSave()` on unload" approach because flushing the local layer would re-trigger the push effect and start a fresh 30 s timer that the user is no longer around for.
 
-- **Files:** `src/hooks/useSyncedStorage.ts` (timer + ref for the pending push, new `flushPush()` exported), small `useFlushOnUnload` hook that wires `beforeunload`/`pagehide` and chains `flushSave()` → `flushPush()`.
-- **Tests to add:** `useSyncedStorage.test.ts` — assert that 3 rapid `saveStatus='saved'` transitions within the window result in exactly one `pushToRemote` call; assert that `flushPush()` cancels the pending timer and pushes immediately; assert that `beforeunload` triggers `flushPush()`.
-- **Tradeoff:** cloud lags local by up to 30s. Fine for a single-user app; the local cache is always current.
+The disabled-state effect also clears the timer + pending refs when the user signs out, so the pending push doesn't leak across an auth transition. New tests in `src/__tests__/hooks/useSyncedStorage.test.ts` cover all three guarantees: a burst of three saves coalesces to one push of the latest snapshot, `flushPush()` cancels the timer and pushes immediately, and a `beforeunload` event triggers the push. All 940 unit tests pass and lint/type-check are clean.
+
+Tradeoff: cloud lags local by up to 30 s. Fine for a single-user app — the local cache is always current and the restore-from-history floor handles the worst case.
 
 ##### 2. Snapshot diff UI (future, larger task)
 

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -267,7 +267,7 @@ After #332 + #331 landed, the production cloud-history list grew faster than exp
 
 Two layered dampeners, in order of leverage. The first has shipped; the others remain backlog.
 
-##### 1. Push-side debounce in `useSyncedStorage` — Shipped (PR #TBD, branch `feat/sync-push-debounce`)
+##### 1. Push-side debounce in `useSyncedStorage` — PR #338 open (branch `feat/sync-push-debounce`)
 
 The push effect now schedules pushes via a 30 s `PUSH_DEBOUNCE_MS` timer instead of firing on every `local.saveStatus === 'saved'` transition. Each new save during the window resets the timer and updates `pendingPushDataRef`; only the latest snapshot survives. A new `flushPush()` is exposed from `useSyncedStorage` (and re-exported through `useAllotmentData` and `useAllotment`) which cancels the timer and pushes immediately, returning a Promise.
 

--- a/src/__tests__/hooks/useSyncedStorage.test.ts
+++ b/src/__tests__/hooks/useSyncedStorage.test.ts
@@ -500,4 +500,165 @@ describe('useSyncedStorage', () => {
 
     expect(result.current.syncStatus).toBe('offline')
   })
+
+  // Push debounce: a burst of saves within PUSH_DEBOUNCE_MS (30s) should
+  // collapse to a single push of the latest snapshot. This is the dampener
+  // for the cloud-history "4 snapshots in 1 minute" noise observed in
+  // production after #332/#331 landed.
+  describe('push debounce', () => {
+    // Drive useSyncedStorage past initial sync so the push effect arms.
+    // Returns a `triggerSave(data)` helper that updates mockLocalData and
+    // walks saveStatus through saving → saved so the push effect refires.
+    const setupSyncedHook = async () => {
+      const initialData = makeTestData('2026-04-01T12:00:00Z')
+      mockLocalData = initialData
+      // Past sync flag — subsequent-sync path
+      const pastSyncTime = '2026-03-01T12:00:00Z'
+      localStorage.setItem(
+        'bonnie-synced-user-123',
+        JSON.stringify({ lastSyncedAt: pastSyncTime })
+      )
+      // Remote matches initial local content so the content short-circuit
+      // fires; no push happens during initial sync.
+      mockFetchRemote.mockResolvedValue({
+        data: initialData,
+        updatedAt: '2026-04-01T12:00:00Z',
+      })
+      mockPushToRemote.mockResolvedValue(undefined)
+
+      const hook = renderHook(() => useSyncedStorage(hookOptions))
+      await waitFor(() => {
+        expect(hook.result.current.syncStatus).toBe('synced')
+      })
+      // Initial sync did not push (content matched), so the push counter
+      // starts at zero for the debounce assertions below.
+      expect(mockPushToRemote).not.toHaveBeenCalled()
+
+      const triggerSave = async (data: AllotmentData) => {
+        mockLocalData = data
+        mockSaveStatus = 'saving'
+        hook.rerender()
+        mockSaveStatus = 'saved'
+        hook.rerender()
+        // Let any microtasks queued by the effect drain
+        await Promise.resolve()
+      }
+
+      return { ...hook, triggerSave }
+    }
+
+    it('coalesces a burst of 3 rapid saves into a single push of the latest snapshot', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      try {
+        const { triggerSave } = await setupSyncedHook()
+
+        const v1 = makeTestData('2026-04-01T12:00:01Z', {
+          varieties: [{ id: 'v1', name: 'Tomato' }] as unknown as AllotmentData['varieties'],
+        })
+        const v2 = makeTestData('2026-04-01T12:00:02Z', {
+          varieties: [
+            { id: 'v1', name: 'Tomato' },
+            { id: 'v2', name: 'Pea' },
+          ] as unknown as AllotmentData['varieties'],
+        })
+        const v3 = makeTestData('2026-04-01T12:00:03Z', {
+          varieties: [
+            { id: 'v1', name: 'Tomato' },
+            { id: 'v2', name: 'Pea' },
+            { id: 'v3', name: 'Carrot' },
+          ] as unknown as AllotmentData['varieties'],
+        })
+
+        await act(async () => {
+          await triggerSave(v1)
+          vi.advanceTimersByTime(5_000)
+          await triggerSave(v2)
+          vi.advanceTimersByTime(5_000)
+          await triggerSave(v3)
+        })
+        // Still inside the debounce window — no push yet
+        expect(mockPushToRemote).not.toHaveBeenCalled()
+
+        // Advance past the 30s debounce window
+        await act(async () => {
+          vi.advanceTimersByTime(30_000)
+          // Drain the async push chain
+          await Promise.resolve()
+          await Promise.resolve()
+        })
+
+        await waitFor(() => {
+          expect(mockPushToRemote).toHaveBeenCalledTimes(1)
+        })
+        expect(mockPushToRemote).toHaveBeenCalledWith('test-token', 'user-123', v3)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('flushPush() cancels the pending debounce and pushes immediately', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      try {
+        const { result, triggerSave } = await setupSyncedHook()
+
+        const v1 = makeTestData('2026-04-01T12:00:01Z', {
+          varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v2', name: 'Pea' }] as unknown as AllotmentData['varieties'],
+        })
+
+        await act(async () => {
+          await triggerSave(v1)
+        })
+        expect(mockPushToRemote).not.toHaveBeenCalled()
+
+        await act(async () => {
+          await result.current.flushPush()
+        })
+
+        expect(mockPushToRemote).toHaveBeenCalledTimes(1)
+        expect(mockPushToRemote).toHaveBeenCalledWith('test-token', 'user-123', v1)
+
+        // Timer should be cancelled — advancing past the window must not
+        // produce a second push.
+        await act(async () => {
+          vi.advanceTimersByTime(60_000)
+          await Promise.resolve()
+        })
+        expect(mockPushToRemote).toHaveBeenCalledTimes(1)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('beforeunload triggers a flush of the pending push', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      try {
+        const { triggerSave } = await setupSyncedHook()
+
+        const v1 = makeTestData('2026-04-01T12:00:01Z', {
+          varieties: [{ id: 'v1', name: 'Tomato' }, { id: 'v2', name: 'Pea' }] as unknown as AllotmentData['varieties'],
+        })
+
+        await act(async () => {
+          await triggerSave(v1)
+        })
+        expect(mockPushToRemote).not.toHaveBeenCalled()
+
+        await act(async () => {
+          window.dispatchEvent(new Event('beforeunload'))
+          // flushSave is awaited inside the listener; drain the chain
+          await Promise.resolve()
+          await Promise.resolve()
+          await Promise.resolve()
+        })
+
+        await waitFor(() => {
+          expect(mockPushToRemote).toHaveBeenCalledTimes(1)
+        })
+        expect(mockPushToRemote).toHaveBeenCalledWith('test-token', 'user-123', v1)
+        expect(mockFlushSave).toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
 })

--- a/src/hooks/allotment/useAllotmentData.ts
+++ b/src/hooks/allotment/useAllotmentData.ts
@@ -71,6 +71,7 @@ export interface UseAllotmentDataReturn {
   getYears: () => number[]
   reload: () => void
   flushSave: () => Promise<boolean>
+  flushPush: () => Promise<void>
   clearSaveError: () => void
   cancelPendingSave: () => void
   updateMeta: (updates: Partial<AllotmentData['meta']>) => void
@@ -97,6 +98,7 @@ export function useAllotmentData(): UseAllotmentDataReturn {
     lastSavedAt,
     reload: baseReload,
     flushSave,
+    flushPush,
     clearSaveError,
     cancelPendingSave,
     syncStatus,
@@ -185,6 +187,7 @@ export function useAllotmentData(): UseAllotmentDataReturn {
     getYears,
     reload,
     flushSave,
+    flushPush,
     clearSaveError,
     cancelPendingSave,
     updateMeta,

--- a/src/hooks/useAllotment.ts
+++ b/src/hooks/useAllotment.ts
@@ -184,6 +184,7 @@ export interface UseAllotmentActions {
   // Data operations
   reload: () => void
   flushSave: () => Promise<boolean>  // Force immediate save of pending data, returns true if successful
+  flushPush: () => Promise<void>  // Force immediate cloud push, bypassing the push debounce
   clearSaveError: () => void  // Clear any save error
   cancelPendingSave: () => void  // Cancel pending debounced save (use before direct localStorage writes)
 
@@ -217,6 +218,7 @@ export function useAllotment(): UseAllotmentReturn {
     getYears,
     reload,
     flushSave,
+    flushPush,
     clearSaveError,
     cancelPendingSave,
     updateMeta,
@@ -460,6 +462,7 @@ export function useAllotment(): UseAllotmentReturn {
     // Data operations
     reload,
     flushSave,
+    flushPush,
     clearSaveError,
     cancelPendingSave,
 

--- a/src/hooks/useSyncedStorage.ts
+++ b/src/hooks/useSyncedStorage.ts
@@ -38,7 +38,23 @@ export interface UseSyncedStorageReturn<T> extends UsePersistedStorageReturn<T> 
   syncError: string | null
   syncConflict: SyncConflict | null
   resolveConflict: (choice: 'cloud' | 'local') => void
+  /**
+   * Cancel the pending push debounce (if any) and immediately push the latest
+   * pending snapshot to the cloud. Resolves once the push completes (or
+   * immediately if there is nothing pending). Used by the unload listener and
+   * exposed for callers that need to force a flush before navigating away.
+   */
+  flushPush: () => Promise<void>
 }
+
+/**
+ * How long to coalesce push-to-cloud calls after a local save. A burst of
+ * `setData` calls (e.g. toggling tasks, editing a name) all collapse to one
+ * push and one history row instead of one per save. Cloud lags local by up
+ * to this much, which is fine for a single-user app — the local cache is
+ * always current.
+ */
+const PUSH_DEBOUNCE_MS = 30_000
 
 // Per-user sync flag stored in localStorage
 interface SyncFlag {
@@ -86,6 +102,9 @@ export function useSyncedStorage(
   const pulledSnapshotRef = useRef<string | null>(null)
   const lastPushedRef = useRef<string | null>(null)
   const activeUserIdRef = useRef<string | null>(userId)
+  const pushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingPushDataRef = useRef<AllotmentData | null>(null)
+  const pendingPushUserRef = useRef<string | null>(null)
 
   const canSync = isSignedIn && isSupabaseConfigured() && isOnline
 
@@ -292,7 +311,49 @@ export function useSyncedStorage(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canSync, userId, local.isLoading, hasLocalData])
 
-  // Push to cloud after local save completes (only after initial sync is done)
+  // Perform a push immediately. Used by the debounce timer, flushPush, and the
+  // unload listener. Updates lastPushedRef + sync status on success.
+  const performPush = useCallback(async (dataToPush: AllotmentData, syncUserId: string) => {
+    try {
+      setSyncStatus('syncing')
+      const token = await getSupabaseToken()
+      if (isStaleSyncUser(syncUserId)) return
+      if (!token) return
+
+      await pushToRemote(token, syncUserId, dataToPush)
+      if (isStaleSyncUser(syncUserId)) return
+      lastPushedRef.current = contentSnapshot(dataToPush)
+      markSynced(syncUserId)
+      setSyncStatus('synced')
+      setSyncError(null)
+    } catch (err) {
+      if (isStaleSyncUser(syncUserId)) return
+      console.error('[useSyncedStorage] Push failed:', err)
+      setSyncStatus('error')
+      setSyncError(err instanceof Error ? err.message : 'Sync failed')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Cancel the pending debounce timer (if any) and push whatever is queued
+  // immediately. Safe to call when nothing is pending — resolves to a no-op.
+  const flushPush = useCallback(async (): Promise<void> => {
+    if (pushTimerRef.current) {
+      clearTimeout(pushTimerRef.current)
+      pushTimerRef.current = null
+    }
+    const dataToPush = pendingPushDataRef.current
+    const syncUserId = pendingPushUserRef.current
+    pendingPushDataRef.current = null
+    pendingPushUserRef.current = null
+    if (!dataToPush || !syncUserId) return
+    if (isStaleSyncUser(syncUserId)) return
+    await performPush(dataToPush, syncUserId)
+  }, [performPush])
+
+  // Push to cloud after local save completes (only after initial sync is done).
+  // Coalesces a burst of saves into a single push via PUSH_DEBOUNCE_MS — every
+  // new save resets the timer; the latest data wins.
   useEffect(() => {
     if (!canSync || !userId || !local.data) return
     if (local.saveStatus !== 'saved') return
@@ -310,31 +371,57 @@ export function useSyncedStorage(
 
     if (serialized === lastPushedRef.current) return
 
-    const pushAsync = async () => {
-      const syncUserId = userId
-      try {
-        setSyncStatus('syncing')
-        const token = await getSupabaseToken()
-        if (isStaleSyncUser(syncUserId)) return
-        if (!token) return
-
-        await pushToRemote(token, syncUserId, local.data!)
-        if (isStaleSyncUser(syncUserId)) return
-        lastPushedRef.current = serialized
-        markSynced(syncUserId)
-        setSyncStatus('synced')
-        setSyncError(null)
-      } catch (err) {
-        if (isStaleSyncUser(syncUserId)) return
-        console.error('[useSyncedStorage] Push failed:', err)
-        setSyncStatus('error')
-        setSyncError(err instanceof Error ? err.message : 'Sync failed')
-      }
+    // Schedule (or reset) the debounced push. Capture the latest data + user
+    // in refs so the timer always pushes the most recent snapshot.
+    pendingPushDataRef.current = local.data
+    pendingPushUserRef.current = userId
+    if (pushTimerRef.current) {
+      clearTimeout(pushTimerRef.current)
     }
-
-    pushAsync()
+    pushTimerRef.current = setTimeout(() => {
+      pushTimerRef.current = null
+      const dataToPush = pendingPushDataRef.current
+      const syncUserId = pendingPushUserRef.current
+      pendingPushDataRef.current = null
+      pendingPushUserRef.current = null
+      if (!dataToPush || !syncUserId) return
+      if (isStaleSyncUser(syncUserId)) return
+      void performPush(dataToPush, syncUserId)
+    }, PUSH_DEBOUNCE_MS)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [local.saveStatus, canSync, userId])
+
+  // Cleanup pending timer on unmount so stray timers don't fire after the
+  // component is gone (would set state on an unmounted hook).
+  useEffect(() => {
+    return () => {
+      if (pushTimerRef.current) {
+        clearTimeout(pushTimerRef.current)
+        pushTimerRef.current = null
+      }
+    }
+  }, [])
+
+  // Flush both local persistence and the pending cloud push when the tab is
+  // closing. Just calling local.flushSave() is not sufficient — that would
+  // trigger the push effect, which would start a fresh PUSH_DEBOUNCE_MS timer
+  // the user is no longer around for. So flush the local cache first, then
+  // bypass the debounce by calling flushPush() directly.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (!canSync) return
+
+    const handleUnload = () => {
+      void local.flushSave().then(() => flushPush())
+    }
+    window.addEventListener('pagehide', handleUnload)
+    window.addEventListener('beforeunload', handleUnload)
+    return () => {
+      window.removeEventListener('pagehide', handleUnload)
+      window.removeEventListener('beforeunload', handleUnload)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canSync, flushPush])
 
   // Reconnect sync
   useEffect(() => {
@@ -424,6 +511,14 @@ export function useSyncedStorage(
       setSyncStatus('disabled')
       syncInProgressRef.current = false
       initialSyncDoneRef.current = false
+      // Drop any pending debounced push — the user is no longer signed in,
+      // so the push has nowhere to go.
+      if (pushTimerRef.current) {
+        clearTimeout(pushTimerRef.current)
+        pushTimerRef.current = null
+      }
+      pendingPushDataRef.current = null
+      pendingPushUserRef.current = null
     } else if (!isOnline) {
       setSyncStatus('offline')
       syncInProgressRef.current = false
@@ -436,5 +531,6 @@ export function useSyncedStorage(
     syncError,
     syncConflict,
     resolveConflict,
+    flushPush,
   }
 }


### PR DESCRIPTION
## Summary

- Schedules cloud pushes via a 30 s `PUSH_DEBOUNCE_MS` timer in `useSyncedStorage` instead of firing on every `saveStatus === 'saved'` transition. A burst of saves within the window collapses to one push and one `allotment_history` row — directly addresses the ~4-snapshots-per-minute noise observed in production after #332/#331 landed.
- Exposes `flushPush()` through `useSyncedStorage` → `useAllotmentData` → `useAllotment`. Cancels the pending timer and pushes the latest queued snapshot immediately.
- Wires `pagehide` + `beforeunload` to `local.flushSave()` then `flushPush()`. Just calling `flushSave()` on unload would re-trigger the push effect and start a fresh 30 s timer the user is no longer around for, so the unload path bypasses the debounce explicitly.
- Clears the pending timer + refs when sync becomes disabled (sign-out) so the queued push doesn't leak across an auth transition.

Tradeoff: cloud lags local by up to 30 s. Fine for a single-user app — the local cache is always current and the restore-from-history floor handles the worst case.

## Test plan

- [x] `npx vitest run src/__tests__/hooks/useSyncedStorage.test.ts` — 18/18 pass, including 3 new debounce tests (burst → single push, `flushPush` cancels timer + pushes, `beforeunload` triggers push)
- [x] `npm run test:unit` — 940 pass / 4 skipped
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [ ] Manual verification post-merge: open the app signed in, make a few rapid edits, watch the cloud-history list in Settings → Data — should see one new row per ~30 s of activity instead of one per save

Plan entry: `docs/plans/current-plan.md` follow-up #1 moved from "next-session priority" to Shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)