### PR TITLE
feat(weather): gate outdoor sow tasks on soil temperature

### DIFF
--- a/src/__tests__/lib/sowing-thresholds.test.ts
+++ b/src/__tests__/lib/sowing-thresholds.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getMinOutdoorSowSoilTempC,
+  shouldSuppressOutdoorSow,
+} from '@/lib/sowing-thresholds'
+
+describe('getMinOutdoorSowSoilTempC', () => {
+  it('returns 7°C for peas and carrots', () => {
+    expect(getMinOutdoorSowSoilTempC('peas')).toBe(7)
+    expect(getMinOutdoorSowSoilTempC('sugar-snap-peas')).toBe(7)
+    expect(getMinOutdoorSowSoilTempC('carrot')).toBe(7)
+  })
+
+  it('returns 12°C for beans', () => {
+    expect(getMinOutdoorSowSoilTempC('runner-beans')).toBe(12)
+    expect(getMinOutdoorSowSoilTempC('french-beans')).toBe(12)
+    expect(getMinOutdoorSowSoilTempC('broad-beans')).toBe(12)
+    expect(getMinOutdoorSowSoilTempC('climbing-french-beans')).toBe(12)
+    expect(getMinOutdoorSowSoilTempC('borlotti-beans')).toBe(12)
+  })
+
+  it('returns 13°C for sweetcorn', () => {
+    expect(getMinOutdoorSowSoilTempC('sweetcorn')).toBe(13)
+  })
+
+  it('returns undefined for plants not in the table', () => {
+    expect(getMinOutdoorSowSoilTempC('tomato')).toBeUndefined()
+    expect(getMinOutdoorSowSoilTempC('lettuce')).toBeUndefined()
+    expect(getMinOutdoorSowSoilTempC('radish')).toBeUndefined()
+    expect(getMinOutdoorSowSoilTempC('not-a-real-plant')).toBeUndefined()
+  })
+})
+
+describe('shouldSuppressOutdoorSow', () => {
+  it('suppresses peas at soil 5°C (below 7°C threshold)', () => {
+    expect(shouldSuppressOutdoorSow('peas', 5)).toBe(true)
+  })
+
+  it('does not suppress peas at exactly the threshold (7°C)', () => {
+    expect(shouldSuppressOutdoorSow('peas', 7)).toBe(false)
+  })
+
+  it('does not suppress peas at soil 8°C (above threshold)', () => {
+    expect(shouldSuppressOutdoorSow('peas', 8)).toBe(false)
+  })
+
+  it('suppresses sweetcorn at 12°C (below 13°C threshold)', () => {
+    expect(shouldSuppressOutdoorSow('sweetcorn', 12)).toBe(true)
+  })
+
+  it('does not suppress untracked plants regardless of soil temp', () => {
+    expect(shouldSuppressOutdoorSow('tomato', 0)).toBe(false)
+    expect(shouldSuppressOutdoorSow('lettuce', -5)).toBe(false)
+  })
+
+  it('does not suppress when soil temp is undefined (fallback)', () => {
+    expect(shouldSuppressOutdoorSow('peas', undefined)).toBe(false)
+    expect(shouldSuppressOutdoorSow('sweetcorn', undefined)).toBe(false)
+  })
+})

--- a/src/__tests__/lib/task-generator.test.ts
+++ b/src/__tests__/lib/task-generator.test.ts
@@ -1378,4 +1378,202 @@ describe('task-generator', () => {
       expect(feedTasks[0].notes).toContain('Apply general-purpose fertiliser')
     })
   })
+
+  describe('soil temperature gating for sow-outdoors tasks', () => {
+    const peasVeg = {
+      id: 'peas',
+      name: 'Peas',
+      planting: {
+        harvestMonths: [6, 7, 8],
+        sowIndoorsMonths: [3, 4],
+        sowOutdoorsMonths: [3, 4, 5],
+        transplantMonths: [],
+      },
+    }
+
+    const peasPlanting: Planting = {
+      id: 'planting-peas',
+      plantId: 'peas',
+    }
+
+    it('emits sow-outdoors task for peas when soil is warm enough (8°C)', () => {
+      mockGetVegetableById.mockReturnValue(peasVeg)
+
+      const tasks = generateTasksForMonth(
+        4 as Month,
+        [{ planting: peasPlanting, areaId: 'bed-a', areaName: 'Bed A' }],
+        [],
+        new Date('2026-04-15'),
+        [],
+        2026,
+        {},
+        { past3DaysMm: 0, todayMm: 0, fetchedAt: '', soilTempC: 8 }
+      )
+
+      const sowOutdoors = tasks.filter((t) => t.generatedType === 'sow-outdoors')
+      expect(sowOutdoors).toHaveLength(1)
+      expect(sowOutdoors[0].plantId).toBe('peas')
+    })
+
+    it('suppresses sow-outdoors task for peas when soil is too cold (5°C)', () => {
+      mockGetVegetableById.mockReturnValue(peasVeg)
+
+      const tasks = generateTasksForMonth(
+        4 as Month,
+        [{ planting: peasPlanting, areaId: 'bed-a', areaName: 'Bed A' }],
+        [],
+        new Date('2026-04-15'),
+        [],
+        2026,
+        {},
+        { past3DaysMm: 0, todayMm: 0, fetchedAt: '', soilTempC: 5 }
+      )
+
+      const sowOutdoors = tasks.filter((t) => t.generatedType === 'sow-outdoors')
+      expect(sowOutdoors).toHaveLength(0)
+    })
+
+    it('emits sow-outdoors task for peas when soil temp is unavailable (fallback)', () => {
+      mockGetVegetableById.mockReturnValue(peasVeg)
+
+      const tasks = generateTasksForMonth(
+        4 as Month,
+        [{ planting: peasPlanting, areaId: 'bed-a', areaName: 'Bed A' }],
+        [],
+        new Date('2026-04-15'),
+        [],
+        2026,
+        {},
+        null // no rainfall/soil data at all
+      )
+
+      const sowOutdoors = tasks.filter((t) => t.generatedType === 'sow-outdoors')
+      expect(sowOutdoors).toHaveLength(1)
+    })
+
+    it('emits sow-outdoors task for peas when rainfall has no soilTempC field', () => {
+      mockGetVegetableById.mockReturnValue(peasVeg)
+
+      const tasks = generateTasksForMonth(
+        4 as Month,
+        [{ planting: peasPlanting, areaId: 'bed-a', areaName: 'Bed A' }],
+        [],
+        new Date('2026-04-15'),
+        [],
+        2026,
+        {},
+        { past3DaysMm: 0, todayMm: 0, fetchedAt: '' } // no soilTempC
+      )
+
+      const sowOutdoors = tasks.filter((t) => t.generatedType === 'sow-outdoors')
+      expect(sowOutdoors).toHaveLength(1)
+    })
+
+    it('does not affect sow-indoors task for peas even when soil is cold', () => {
+      mockGetVegetableById.mockReturnValue(peasVeg)
+
+      const tasks = generateTasksForMonth(
+        3 as Month,
+        [{ planting: peasPlanting, areaId: 'bed-a', areaName: 'Bed A' }],
+        [],
+        new Date('2026-03-15'),
+        [],
+        2026,
+        {},
+        { past3DaysMm: 0, todayMm: 0, fetchedAt: '', soilTempC: 2 }
+      )
+
+      const sowIndoors = tasks.filter((t) => t.generatedType === 'sow-indoors')
+      expect(sowIndoors).toHaveLength(1)
+      expect(sowIndoors[0].plantId).toBe('peas')
+      // outdoor should be suppressed though
+      const sowOutdoors = tasks.filter((t) => t.generatedType === 'sow-outdoors')
+      expect(sowOutdoors).toHaveLength(0)
+    })
+
+    it('does not gate plants without a threshold (e.g. lettuce)', () => {
+      const lettuceVeg = {
+        id: 'lettuce',
+        name: 'Lettuce',
+        planting: {
+          harvestMonths: [5, 6, 7, 8],
+          sowIndoorsMonths: [],
+          sowOutdoorsMonths: [4, 5, 6],
+          transplantMonths: [],
+        },
+      }
+      mockGetVegetableById.mockReturnValue(lettuceVeg)
+
+      const tasks = generateTasksForMonth(
+        4 as Month,
+        [{ planting: { id: 'p1', plantId: 'lettuce' }, areaId: 'bed-a', areaName: 'Bed A' }],
+        [],
+        new Date('2026-04-15'),
+        [],
+        2026,
+        {},
+        { past3DaysMm: 0, todayMm: 0, fetchedAt: '', soilTempC: 0 }
+      )
+
+      const sowOutdoors = tasks.filter((t) => t.generatedType === 'sow-outdoors')
+      expect(sowOutdoors).toHaveLength(1)
+    })
+
+    it('suppresses variety-driven sow-outdoors for peas when soil is too cold', () => {
+      const peasVarietyOnlyVeg = {
+        ...peasVeg,
+        planting: {
+          ...peasVeg.planting,
+          sowIndoorsMonths: [], // force outdoor-only so variety task picks outdoor
+        },
+      }
+      mockGetVegetableById.mockReturnValue(peasVarietyOnlyVeg)
+
+      const variety: StoredVariety = {
+        id: 'v1',
+        plantId: 'peas',
+        name: 'Kelvedon Wonder',
+        seedsByYear: { 2026: 'have' },
+      }
+
+      const tasks = generateTasksForMonth(
+        4 as Month,
+        [],
+        [],
+        new Date('2026-04-15'),
+        [variety],
+        2026,
+        {},
+        { past3DaysMm: 0, todayMm: 0, fetchedAt: '', soilTempC: 5 }
+      )
+
+      const sowOutdoors = tasks.filter((t) => t.generatedType === 'sow-outdoors')
+      expect(sowOutdoors).toHaveLength(0)
+    })
+
+    it('does not suppress variety-driven sow-indoors when soil is cold', () => {
+      mockGetVegetableById.mockReturnValue(peasVeg)
+
+      const variety: StoredVariety = {
+        id: 'v1',
+        plantId: 'peas',
+        name: 'Kelvedon Wonder',
+        seedsByYear: { 2026: 'have' },
+      }
+
+      const tasks = generateTasksForMonth(
+        3 as Month,
+        [],
+        [],
+        new Date('2026-03-15'),
+        [variety],
+        2026,
+        {},
+        { past3DaysMm: 0, todayMm: 0, fetchedAt: '', soilTempC: 2 }
+      )
+
+      const sowIndoors = tasks.filter((t) => t.generatedType === 'sow-indoors')
+      expect(sowIndoors).toHaveLength(1)
+    })
+  })
 })

--- a/src/__tests__/lib/weather/open-meteo.test.ts
+++ b/src/__tests__/lib/weather/open-meteo.test.ts
@@ -173,6 +173,53 @@ describe('fetchRainfall', () => {
     expect(result?.forecast?.[2].date).toBe('2026-05-01')
   })
 
+  it('derives todays mean soil temperature from the hourly series', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          daily: {
+            time: ['d-3', 'd-2', 'd-1', '2026-04-29'],
+            precipitation_sum: [0, 0, 0, 0],
+          },
+          hourly: {
+            time: [
+              '2026-04-28T22:00',
+              '2026-04-28T23:00',
+              '2026-04-29T00:00',
+              '2026-04-29T06:00',
+              '2026-04-29T12:00',
+              '2026-04-29T18:00',
+              '2026-04-30T00:00',
+            ],
+            soil_temperature_0_to_7cm: [4, 4, 6, 8, 12, 10, 5],
+          },
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await fetchRainfall(55.95, -3.18)
+    // Mean of today's four entries: (6+8+12+10)/4 = 9
+    expect(result?.soilTempC).toBe(9)
+  })
+
+  it('leaves soilTempC undefined when the hourly series is missing', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          daily: {
+            time: ['d-3', 'd-2', 'd-1', '2026-04-29'],
+            precipitation_sum: [0, 0, 0, 0],
+          },
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await fetchRainfall(55.95, -3.18)
+    expect(result?.soilTempC).toBeUndefined()
+  })
+
   it('omits forecast when the response lacks weathercode or temperature series', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
       new Response(

--- a/src/lib/sowing-thresholds.ts
+++ b/src/lib/sowing-thresholds.ts
@@ -1,0 +1,49 @@
+/**
+ * Per-species minimum soil temperature (°C) for outdoor sowing.
+ *
+ * Used by the task generator to suppress sow-outdoors tasks when today's
+ * soil temperature is below the threshold for a cold-sensitive crop. Plants
+ * not listed here have no threshold — the generator falls back to the
+ * existing month-based behaviour. Soil temp gating is a refinement, not a
+ * hard gate, so missing data (no location, API failure) never suppresses.
+ *
+ * Numbers from common UK gardening guidance (RHS, Garden Organic):
+ * - Peas / carrots: 7°C — peas struggle to germinate in cold wet ground.
+ * - Beans (broad/runner/french): 12°C — chilling damage below this.
+ * - Sweetcorn: 13°C — frost-tender and demands warm soil to start.
+ */
+const SOIL_TEMP_THRESHOLDS_C: Readonly<Record<string, number>> = {
+  peas: 7,
+  'sugar-snap-peas': 7,
+  carrot: 7,
+  'broad-beans': 12,
+  'runner-beans': 12,
+  'french-beans': 12,
+  'climbing-french-beans': 12,
+  'borlotti-beans': 12,
+  sweetcorn: 13,
+}
+
+/**
+ * Look up the minimum outdoor-sowing soil temperature for a vegetable id.
+ * Returns undefined when the plant has no threshold (most plants).
+ */
+export function getMinOutdoorSowSoilTempC(plantId: string): number | undefined {
+  return SOIL_TEMP_THRESHOLDS_C[plantId]
+}
+
+/**
+ * Decide whether an outdoor sowing task for the given plant should be
+ * suppressed because the soil is currently too cold. Returns false when
+ * the plant has no threshold or when soilTempC is undefined — a missing
+ * reading must never suppress, so the user still sees their tasks.
+ */
+export function shouldSuppressOutdoorSow(
+  plantId: string,
+  soilTempC: number | undefined
+): boolean {
+  if (soilTempC === undefined) return false
+  const threshold = getMinOutdoorSowSoilTempC(plantId)
+  if (threshold === undefined) return false
+  return soilTempC < threshold
+}

--- a/src/lib/task-generator.ts
+++ b/src/lib/task-generator.ts
@@ -15,6 +15,7 @@ import { getGerminationDays } from '@/lib/date-calculator'
 import { calculatePerennialStatus } from '@/lib/perennial-calculator'
 import type { RainfallSummary } from '@/lib/weather/open-meteo'
 import { shouldSkipWatering } from '@/lib/weather/open-meteo'
+import { shouldSuppressOutdoorSow } from '@/lib/sowing-thresholds'
 
 export type GeneratedTaskType = 'harvest' | 'sow-indoors' | 'sow-outdoors' | 'transplant' | 'prune' | 'feed' | 'water' | 'mulch' | 'succession' | 'care-tip'
 
@@ -318,7 +319,8 @@ function generateMonthBasedTasks(
   plantings: PlantingWithContext[],
   areas: Area[],
   currentYear: number,
-  careLogDays: CareLogDaysMap = {}
+  careLogDays: CareLogDaysMap = {},
+  soilTempC: number | undefined = undefined
 ): GeneratedTask[] {
   const tasks: GeneratedTask[] = []
 
@@ -356,10 +358,12 @@ function generateMonthBasedTasks(
       }
     }
 
-    // Sow outdoors tasks — one per plant
+    // Sow outdoors tasks — one per plant. Suppressed for cold-sensitive
+    // crops when today's soil is below their threshold; missing soil temp
+    // never suppresses (falls back to the calendar-month behaviour).
     if (vegetable.planting.sowOutdoorsMonths.includes(currentMonth)) {
       const key = `sow-outdoors-${vegetable.id}`
-      if (!seenSowTasks.has(key)) {
+      if (!seenSowTasks.has(key) && !shouldSuppressOutdoorSow(vegetable.id, soilTempC)) {
         seenSowTasks.add(key)
         const task = createSowOutdoorsTask(vegetable, currentMonth)
         tasks.push({ ...task, calculatedFrom: 'calendar-month' })
@@ -461,7 +465,8 @@ export function generateVarietyTasks(
   currentMonth: Month,
   varieties: StoredVariety[],
   plantings: PlantingWithContext[],
-  currentYear: number
+  currentYear: number,
+  soilTempC: number | undefined = undefined
 ): GeneratedTask[] {
   const tasks: GeneratedTask[] = []
 
@@ -487,7 +492,11 @@ export function generateVarietyTasks(
     if (!vegetable) continue
 
     const canSowIndoors = vegetable.planting.sowIndoorsMonths.includes(currentMonth)
-    const canSowOutdoors = vegetable.planting.sowOutdoorsMonths.includes(currentMonth)
+    // Soil-temp gate only suppresses the outdoor option; indoor sowing is
+    // unaffected because the soil reading reflects outdoor conditions only.
+    const soilBlocksOutdoor = shouldSuppressOutdoorSow(vegetable.id, soilTempC)
+    const canSowOutdoors =
+      vegetable.planting.sowOutdoorsMonths.includes(currentMonth) && !soilBlocksOutdoor
 
     if (!canSowIndoors && !canSowOutdoors) continue
 
@@ -549,11 +558,14 @@ export function generateTasksForMonth(
   // Get watering reminders (cadence + weather aware)
   const wateringTasks = generateWateringTasks(currentMonth, plantings, areas, careLogDays, rainfall)
 
-  // Get month-based tasks (fallback for plantings without dates)
-  const monthBasedTasks = generateMonthBasedTasks(currentMonth, plantings, areas, currentYear, careLogDays)
+  // Get month-based tasks (fallback for plantings without dates).
+  // Pass today's soil temp through so cold-sensitive sow-outdoors tasks can
+  // be suppressed for crops with a threshold (peas, beans, sweetcorn, …).
+  const soilTempC = rainfall?.soilTempC
+  const monthBasedTasks = generateMonthBasedTasks(currentMonth, plantings, areas, currentYear, careLogDays, soilTempC)
 
   // Get variety-based tasks (seeds user has but hasn't planted)
-  const varietyTasks = generateVarietyTasks(currentMonth, varieties, plantings, currentYear)
+  const varietyTasks = generateVarietyTasks(currentMonth, varieties, plantings, currentYear, soilTempC)
 
   // Merge all tasks, preferring date-based
   const allDateBased = [...dateBasedTasks, ...successionTasks, ...wateringTasks]

--- a/src/lib/weather/open-meteo.ts
+++ b/src/lib/weather/open-meteo.ts
@@ -40,6 +40,13 @@ export interface RainfallSummary {
   fetchedAt: string
   /** Optional forecast tiles for today and the next two days. */
   forecast?: ForecastDay[]
+  /**
+   * Today's mean soil temperature at 0–7cm depth in °C, averaged across the
+   * hourly readings for the local day. Undefined when the API didn't return
+   * the soil-temp series. Used by the task generator to gate outdoor sowing
+   * tasks for cold-sensitive crops.
+   */
+  soilTempC?: number
 }
 
 interface OpenMeteoResponse {
@@ -49,6 +56,10 @@ interface OpenMeteoResponse {
     weathercode?: number[]
     temperature_2m_max?: number[]
     temperature_2m_min?: number[]
+  }
+  hourly?: {
+    time?: string[]
+    soil_temperature_0_to_7cm?: number[]
   }
 }
 
@@ -106,7 +117,7 @@ export async function fetchRainfall(
   const cached = readCache(key)
   if (cached) return cached
 
-  const url = `${ENDPOINT}?latitude=${latitude}&longitude=${longitude}&daily=precipitation_sum,weathercode,temperature_2m_max,temperature_2m_min&past_days=3&forecast_days=3&timezone=auto`
+  const url = `${ENDPOINT}?latitude=${latitude}&longitude=${longitude}&daily=precipitation_sum,weathercode,temperature_2m_max,temperature_2m_min&hourly=soil_temperature_0_to_7cm&past_days=3&forecast_days=3&timezone=auto`
 
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
@@ -132,6 +143,7 @@ export async function fetchRainfall(
       todayMm: round1(today),
       fetchedAt: new Date().toISOString(),
       forecast: buildForecast(data.daily),
+      soilTempC: deriveTodaySoilTemp(data.hourly, data.daily?.time?.[3]),
     }
     writeCache(key, summary)
     return summary
@@ -171,6 +183,30 @@ function buildForecast(daily?: OpenMeteoResponse['daily']): ForecastDay[] | unde
 
 function round1(value: number): number {
   return Math.round(value * 10) / 10
+}
+
+/**
+ * Average the hourly soil-temperature series for today's date and return a
+ * single °C reading. Returns undefined when the series is missing or no
+ * hourly entries match today, so callers fall back to ungated behaviour.
+ */
+function deriveTodaySoilTemp(
+  hourly: OpenMeteoResponse['hourly'],
+  todayIso: string | undefined
+): number | undefined {
+  if (!hourly?.time || !hourly.soil_temperature_0_to_7cm || !todayIso) return undefined
+  const { time, soil_temperature_0_to_7cm: temps } = hourly
+  let sum = 0
+  let count = 0
+  for (let i = 0; i < time.length; i++) {
+    if (!time[i].startsWith(todayIso)) continue
+    const t = temps[i]
+    if (typeof t !== 'number' || Number.isNaN(t)) continue
+    sum += t
+    count++
+  }
+  if (count === 0) return undefined
+  return round1(sum / count)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extend the Open-Meteo call with `soil_temperature_0_to_7cm` (hourly) and expose today's mean as `soilTempC` on `RainfallSummary`.
- Add a small per-species threshold table in `src/lib/sowing-thresholds.ts` (peas/carrots 7C, beans 12C, sweetcorn 13C); everything else stays ungated.
- Suppress `sow-outdoors` tasks (both planting-derived and variety-derived) when today's soil is below threshold. `sow-indoors`, untracked plants, and missing soil readings are unaffected — the gate is a refinement, not a hard stop.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` (960 pass, 4 skipped) — new coverage in `src/__tests__/lib/sowing-thresholds.test.ts`, soil-temp gating block in `task-generator.test.ts`, and soil-temp parsing in `open-meteo.test.ts`
- [ ] Manual smoke once a UK location has cold soil readings — peas/carrots should drop out of the Today task list while indoor sowing remains