### PR TITLE
feat(history): show what changed between cloud snapshots

### DIFF
--- a/src/__tests__/lib/allotment-diff.test.ts
+++ b/src/__tests__/lib/allotment-diff.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect } from 'vitest'
+import { diffAllotment, summariseDiff, isEmptyDiff } from '@/lib/allotment-diff'
+import type {
+  AllotmentData,
+  Area,
+  Planting,
+  StoredVariety,
+  SeasonRecord,
+} from '@/types/unified-allotment'
+
+function area(id: string, name: string, overrides: Partial<Area> = {}): Area {
+  return {
+    id,
+    name,
+    kind: 'rotation-bed',
+    canHavePlantings: true,
+    ...overrides,
+  }
+}
+
+function variety(id: string, name: string, overrides: Partial<StoredVariety> = {}): StoredVariety {
+  return {
+    id,
+    plantId: 'tomato',
+    name,
+    seedsByYear: {},
+    ...overrides,
+  }
+}
+
+function planting(id: string, plantId: string, overrides: Partial<Planting> = {}): Planting {
+  return {
+    id,
+    plantId,
+    ...overrides,
+  }
+}
+
+function season(year: number, areas: Array<{ areaId: string; plantings: Planting[] }>): SeasonRecord {
+  return {
+    year,
+    status: 'current',
+    areas: areas.map((a) => ({
+      areaId: a.areaId,
+      plantings: a.plantings,
+    })),
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+function buildData(overrides: Partial<AllotmentData> = {}): AllotmentData {
+  return {
+    version: 21,
+    meta: {
+      name: 'Test Allotment',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    },
+    layout: { areas: [] },
+    seasons: [],
+    currentYear: 2026,
+    varieties: [],
+    ...overrides,
+  }
+}
+
+describe('diffAllotment', () => {
+  it('returns empty diff for identical snapshots → "No changes"', () => {
+    const data = buildData({
+      layout: { areas: [area('bed-a', 'Bed A')] },
+      varieties: [variety('v1', 'Kelvedon')],
+      seasons: [
+        season(2026, [
+          { areaId: 'bed-a', plantings: [planting('p1', 'tomato', { sowDate: '2026-04-01' })] },
+        ]),
+      ],
+    })
+
+    const diff = diffAllotment(data, data)
+    expect(isEmptyDiff(diff)).toBe(true)
+    expect(summariseDiff(diff)).toBe('No changes')
+  })
+
+  it('treats timestamp-only meta churn as no meaningful change', () => {
+    const oldData = buildData({
+      meta: {
+        name: 'Test Allotment',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+      layout: { areas: [area('bed-a', 'Bed A')] },
+    })
+    const newData = buildData({
+      meta: {
+        name: 'Test Allotment',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-05-09T12:34:56Z', // only updatedAt changed
+      },
+      layout: { areas: [area('bed-a', 'Bed A')] },
+    })
+
+    const diff = diffAllotment(oldData, newData)
+    expect(isEmptyDiff(diff)).toBe(true)
+    expect(summariseDiff(diff)).toBe('No changes')
+  })
+
+  describe('areas', () => {
+    it('detects added areas', () => {
+      const oldData = buildData({ layout: { areas: [area('bed-a', 'Bed A')] } })
+      const newData = buildData({
+        layout: { areas: [area('bed-a', 'Bed A'), area('bed-b', 'Bed B')] },
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.areas.added).toEqual(['Bed B'])
+      expect(diff.areas.removed).toEqual([])
+      expect(diff.areas.renamed).toEqual([])
+      expect(summariseDiff(diff)).toBe('+1 area')
+    })
+
+    it('detects removed areas', () => {
+      const oldData = buildData({
+        layout: { areas: [area('bed-a', 'Bed A'), area('bed-b', 'Bed B')] },
+      })
+      const newData = buildData({ layout: { areas: [area('bed-a', 'Bed A')] } })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.areas.added).toEqual([])
+      expect(diff.areas.removed).toEqual(['Bed B'])
+      expect(summariseDiff(diff)).toBe('−1 area')
+    })
+
+    it('detects renamed areas (same id, different name)', () => {
+      const oldData = buildData({ layout: { areas: [area('bed-a', 'Old Name')] } })
+      const newData = buildData({ layout: { areas: [area('bed-a', 'New Name')] } })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.areas.added).toEqual([])
+      expect(diff.areas.removed).toEqual([])
+      expect(diff.areas.renamed).toEqual([
+        { id: 'bed-a', from: 'Old Name', to: 'New Name' },
+      ])
+      expect(summariseDiff(diff)).toBe('1 renamed')
+    })
+
+    it('handles multiple area added/removed pluralisation', () => {
+      const oldData = buildData({
+        layout: { areas: [area('a', 'A'), area('b', 'B')] },
+      })
+      const newData = buildData({
+        layout: { areas: [area('c', 'C'), area('d', 'D'), area('e', 'E')] },
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.areas.added).toEqual(['C', 'D', 'E'])
+      expect(diff.areas.removed).toEqual(['A', 'B'])
+      expect(summariseDiff(diff)).toBe('+3 areas, −2 areas')
+    })
+  })
+
+  describe('plantings', () => {
+    it('detects added plantings', () => {
+      const oldData = buildData({
+        layout: { areas: [area('bed-a', 'Bed A')] },
+        seasons: [season(2026, [{ areaId: 'bed-a', plantings: [] }])],
+      })
+      const newData = buildData({
+        layout: { areas: [area('bed-a', 'Bed A')] },
+        seasons: [
+          season(2026, [
+            {
+              areaId: 'bed-a',
+              plantings: [planting('p1', 'tomato'), planting('p2', 'pepper')],
+            },
+          ]),
+        ],
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.plantings).toEqual({ added: 2, removed: 0, edited: 0 })
+      expect(summariseDiff(diff)).toBe('+2 plantings')
+    })
+
+    it('detects removed plantings', () => {
+      const oldData = buildData({
+        layout: { areas: [area('bed-a', 'Bed A')] },
+        seasons: [
+          season(2026, [
+            { areaId: 'bed-a', plantings: [planting('p1', 'tomato')] },
+          ]),
+        ],
+      })
+      const newData = buildData({
+        layout: { areas: [area('bed-a', 'Bed A')] },
+        seasons: [season(2026, [{ areaId: 'bed-a', plantings: [] }])],
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.plantings).toEqual({ added: 0, removed: 1, edited: 0 })
+      expect(summariseDiff(diff)).toBe('−1 planting')
+    })
+
+    it('detects edited plantings (same id, non-id field differs)', () => {
+      const oldData = buildData({
+        layout: { areas: [area('bed-a', 'Bed A')] },
+        seasons: [
+          season(2026, [
+            {
+              areaId: 'bed-a',
+              plantings: [planting('p1', 'tomato', { sowDate: '2026-04-01' })],
+            },
+          ]),
+        ],
+      })
+      const newData = buildData({
+        layout: { areas: [area('bed-a', 'Bed A')] },
+        seasons: [
+          season(2026, [
+            {
+              areaId: 'bed-a',
+              plantings: [
+                planting('p1', 'tomato', { sowDate: '2026-04-01', notes: 'doing well' }),
+              ],
+            },
+          ]),
+        ],
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.plantings).toEqual({ added: 0, removed: 0, edited: 1 })
+      expect(summariseDiff(diff)).toBe('1 edited')
+    })
+
+    it('walks across all seasons and accumulates counts', () => {
+      const oldData = buildData({
+        layout: { areas: [area('a', 'A')] },
+        seasons: [
+          season(2025, [{ areaId: 'a', plantings: [planting('p1', 'tomato')] }]),
+          season(2026, [{ areaId: 'a', plantings: [planting('p2', 'pepper')] }]),
+        ],
+      })
+      const newData = buildData({
+        layout: { areas: [area('a', 'A')] },
+        seasons: [
+          season(2025, [
+            {
+              areaId: 'a',
+              plantings: [
+                planting('p1', 'tomato', { notes: 'edited' }), // edit
+                planting('p3', 'lettuce'), // add
+              ],
+            },
+          ]),
+          season(2026, [{ areaId: 'a', plantings: [] }]), // remove p2
+        ],
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.plantings).toEqual({ added: 1, removed: 1, edited: 1 })
+    })
+  })
+
+  describe('varieties', () => {
+    it('detects added varieties', () => {
+      const oldData = buildData({ varieties: [variety('v1', 'Kelvedon')] })
+      const newData = buildData({
+        varieties: [variety('v1', 'Kelvedon'), variety('v2', 'Sungold')],
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.varieties.added).toEqual(['Sungold'])
+      expect(summariseDiff(diff)).toBe('+1 variety')
+    })
+
+    it('detects removed varieties', () => {
+      const oldData = buildData({
+        varieties: [variety('v1', 'Kelvedon'), variety('v2', 'Sungold')],
+      })
+      const newData = buildData({ varieties: [variety('v1', 'Kelvedon')] })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.varieties.removed).toEqual(['Sungold'])
+      expect(summariseDiff(diff)).toBe('−1 variety')
+    })
+
+    it('detects renamed varieties', () => {
+      const oldData = buildData({ varieties: [variety('v1', 'Old Variety')] })
+      const newData = buildData({ varieties: [variety('v1', 'New Variety')] })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.varieties.renamed).toEqual([
+        { id: 'v1', from: 'Old Variety', to: 'New Variety' },
+      ])
+      expect(summariseDiff(diff)).toBe('1 variety rename')
+    })
+
+    it('pluralises varieties summary correctly', () => {
+      const oldData = buildData({
+        varieties: [variety('v1', 'A'), variety('v2', 'B')],
+      })
+      const newData = buildData({
+        varieties: [
+          variety('v1', 'A'),
+          variety('v2', 'B'),
+          variety('v3', 'C'),
+          variety('v4', 'D'),
+        ],
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(summariseDiff(diff)).toBe('+2 varieties')
+    })
+  })
+
+  describe('schema version', () => {
+    it('records schema version bump', () => {
+      const oldData = buildData({ version: 20 })
+      const newData = buildData({ version: 21 })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.meta.schemaVersionChanged).toEqual({ from: 20, to: 21 })
+      expect(summariseDiff(diff)).toBe('schema v20→v21')
+    })
+
+    it('does not record when schema versions match', () => {
+      const oldData = buildData({ version: 21 })
+      const newData = buildData({ version: 21 })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.meta.schemaVersionChanged).toBeUndefined()
+    })
+  })
+
+  describe('combined changes', () => {
+    it('summarises a multi-axis change in a single line', () => {
+      const oldData = buildData({
+        version: 20,
+        layout: { areas: [area('a', 'A'), area('b', 'B')] },
+        varieties: [variety('v1', 'Old')],
+        seasons: [
+          season(2026, [
+            { areaId: 'a', plantings: [planting('p1', 'tomato')] },
+          ]),
+        ],
+      })
+      const newData = buildData({
+        version: 21,
+        layout: { areas: [area('a', 'A renamed'), area('c', 'C')] }, // remove b, add c, rename a
+        varieties: [variety('v1', 'Old'), variety('v2', 'New')], // add v2
+        seasons: [
+          season(2026, [
+            {
+              areaId: 'a',
+              plantings: [
+                planting('p1', 'tomato', { notes: 'edit' }), // edit
+                planting('p2', 'pepper'), // add
+              ],
+            },
+          ]),
+        ],
+      })
+
+      const diff = diffAllotment(oldData, newData)
+      expect(diff.areas.added).toEqual(['C'])
+      expect(diff.areas.removed).toEqual(['B'])
+      expect(diff.areas.renamed).toEqual([{ id: 'a', from: 'A', to: 'A renamed' }])
+      expect(diff.plantings).toEqual({ added: 1, removed: 0, edited: 1 })
+      expect(diff.varieties.added).toEqual(['New'])
+      expect(diff.meta.schemaVersionChanged).toEqual({ from: 20, to: 21 })
+
+      expect(summariseDiff(diff)).toBe(
+        '+1 area, −1 area, 1 renamed, +1 planting, 1 edited, +1 variety, schema v20→v21',
+      )
+    })
+  })
+})

--- a/src/components/settings/CloudHistoryDiffDialog.tsx
+++ b/src/components/settings/CloudHistoryDiffDialog.tsx
@@ -34,6 +34,11 @@ const ABSOLUTE_FORMATTER = new Intl.DateTimeFormat('en-GB', {
   timeStyle: 'short',
 })
 
+function formatArchivedAt(archivedAt: string): string {
+  const d = new Date(archivedAt)
+  return Number.isNaN(d.getTime()) ? archivedAt : ABSOLUTE_FORMATTER.format(d)
+}
+
 export default function CloudHistoryDiffDialog({
   isOpen,
   onClose,
@@ -125,7 +130,7 @@ export default function CloudHistoryDiffDialog({
       isOpen={isOpen}
       onClose={onClose}
       title="What changed"
-      description={`Snapshot from ${ABSOLUTE_FORMATTER.format(new Date(archivedAt))} compared with ${
+      description={`Snapshot from ${formatArchivedAt(archivedAt)} compared with ${
         newerId === undefined ? 'your current allotment' : 'the next-newer snapshot'
       }.`}
       maxWidth="lg"

--- a/src/components/settings/CloudHistoryDiffDialog.tsx
+++ b/src/components/settings/CloudHistoryDiffDialog.tsx
@@ -1,0 +1,297 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import Dialog from '@/components/ui/Dialog'
+import { fetchHistorySnapshot } from '@/lib/supabase/sync'
+import { loadAllotmentData } from '@/services/allotment-storage'
+import { diffAllotment, isEmptyDiff, type AllotmentDiff } from '@/lib/allotment-diff'
+import type { AllotmentData } from '@/types/unified-allotment'
+
+interface CloudHistoryDiffDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  /** Snapshot row the user clicked. */
+  baseId: number
+  /**
+   * id of the next-newer snapshot to diff against. When undefined, the base
+   * row is the most recent snapshot in the list and we diff against the
+   * current local data instead.
+   */
+  newerId: number | undefined
+  archivedAt: string
+  getToken: (opts: { template: string }) => Promise<string | null>
+  userId: string
+  /**
+   * Fired with the computed diff once it has loaded. Lets the parent cache
+   * the diff for inline-hint rendering without re-fetching.
+   */
+  onDiffComputed?: (diff: AllotmentDiff) => void
+}
+
+const ABSOLUTE_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
+export default function CloudHistoryDiffDialog({
+  isOpen,
+  onClose,
+  baseId,
+  newerId,
+  archivedAt,
+  getToken,
+  userId,
+  onDiffComputed,
+}: CloudHistoryDiffDialogProps) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [diff, setDiff] = useState<AllotmentDiff | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) {
+      // Reset state when dialog closes so the next open re-fetches.
+      setDiff(null)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      setDiff(null)
+
+      try {
+        const token = await getToken({ template: 'supabase' })
+        if (!token) {
+          if (!cancelled) setError('Could not get an auth token. Try signing out and back in.')
+          return
+        }
+
+        // Fetch the base snapshot. If we have a newer snapshot in the list,
+        // fetch both in parallel; otherwise diff against current local data.
+        const [base, newer] = await Promise.all([
+          fetchHistorySnapshot(token, userId, baseId),
+          newerId !== undefined
+            ? fetchHistorySnapshot(token, userId, newerId)
+            : Promise.resolve<AllotmentData | null>(null),
+        ])
+
+        if (cancelled) return
+
+        if (!base) {
+          setError('That snapshot is no longer available.')
+          return
+        }
+
+        let comparedAgainst: AllotmentData | null = newer
+        if (newerId === undefined) {
+          // Most recent row — diff against current local data.
+          const localResult = loadAllotmentData()
+          comparedAgainst = localResult.success && localResult.data ? localResult.data : null
+        }
+
+        if (!comparedAgainst) {
+          setError(
+            newerId === undefined
+              ? 'No local data to compare against.'
+              : 'The newer snapshot is no longer available.',
+          )
+          return
+        }
+
+        const computed = diffAllotment(base, comparedAgainst)
+        setDiff(computed)
+        onDiffComputed?.(computed)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load snapshot')
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, baseId, newerId, getToken, userId, onDiffComputed])
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="What changed"
+      description={`Snapshot from ${ABSOLUTE_FORMATTER.format(new Date(archivedAt))} compared with ${
+        newerId === undefined ? 'your current allotment' : 'the next-newer snapshot'
+      }.`}
+      maxWidth="lg"
+    >
+      {isLoading && (
+        <div className="flex items-center gap-2 py-8 justify-center text-zen-stone-600">
+          <Loader2 className="w-5 h-5 animate-spin" />
+          <span className="text-sm">Loading changes…</span>
+        </div>
+      )}
+
+      {error && !isLoading && (
+        <div className="p-3 bg-zen-kitsune-50 border border-zen-kitsune-200 rounded-lg flex items-start gap-2">
+          <AlertTriangle className="w-4 h-4 text-zen-kitsune-500 shrink-0 mt-0.5" />
+          <p className="text-sm text-zen-kitsune-700">{error}</p>
+        </div>
+      )}
+
+      {diff && !isLoading && !error && <DiffSummary diff={diff} />}
+    </Dialog>
+  )
+}
+
+function DiffSummary({ diff }: { diff: AllotmentDiff }) {
+  if (isEmptyDiff(diff)) {
+    return (
+      <p className="text-sm text-zen-stone-600 py-4 text-center">
+        No meaningful changes between these two versions.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <DiffSection
+        title="Areas"
+        added={diff.areas.added}
+        removed={diff.areas.removed}
+        renamed={diff.areas.renamed}
+      />
+      <PlantingsSection counts={diff.plantings} />
+      <DiffSection
+        title="Varieties"
+        added={diff.varieties.added}
+        removed={diff.varieties.removed}
+        renamed={diff.varieties.renamed}
+      />
+      {diff.meta.schemaVersionChanged && (
+        <section>
+          <h3 className="text-sm font-medium text-zen-ink-700 mb-1">Schema</h3>
+          <p className="text-sm text-zen-stone-600">
+            Schema version v{diff.meta.schemaVersionChanged.from} → v{diff.meta.schemaVersionChanged.to}
+          </p>
+        </section>
+      )}
+    </div>
+  )
+}
+
+interface DiffSectionProps {
+  title: string
+  added: string[]
+  removed: string[]
+  renamed: Array<{ id: string; from: string; to: string }>
+}
+
+function DiffSection({ title, added, removed, renamed }: DiffSectionProps) {
+  if (added.length === 0 && removed.length === 0 && renamed.length === 0) {
+    return (
+      <section>
+        <h3 className="text-sm font-medium text-zen-ink-700 mb-1">{title}</h3>
+        <p className="text-sm text-zen-stone-500">No changes</p>
+      </section>
+    )
+  }
+
+  return (
+    <section>
+      <h3 className="text-sm font-medium text-zen-ink-700 mb-2">{title}</h3>
+      <div className="space-y-2 text-sm">
+        {added.length > 0 && (
+          <ChangeList label="Added" tone="moss" items={added} />
+        )}
+        {removed.length > 0 && (
+          <ChangeList label="Removed" tone="kitsune" items={removed} />
+        )}
+        {renamed.length > 0 && (
+          <div>
+            <p className="text-xs uppercase tracking-wide text-zen-stone-500 mb-1">Renamed</p>
+            <ul className="space-y-1">
+              {renamed.map((r) => (
+                <li key={r.id} className="text-zen-ink-700">
+                  <span className="text-zen-stone-500">{r.from}</span>
+                  <span className="mx-1 text-zen-stone-400">→</span>
+                  <span>{r.to}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function ChangeList({
+  label,
+  tone,
+  items,
+}: {
+  label: string
+  tone: 'moss' | 'kitsune'
+  items: string[]
+}) {
+  const labelClass =
+    tone === 'moss'
+      ? 'text-zen-moss-700 bg-zen-moss-50 border-zen-moss-200'
+      : 'text-zen-kitsune-700 bg-zen-kitsune-50 border-zen-kitsune-200'
+
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wide text-zen-stone-500 mb-1">{label}</p>
+      <ul className="flex flex-wrap gap-1">
+        {items.map((item, i) => (
+          <li
+            key={`${item}-${i}`}
+            className={`text-xs px-2 py-1 rounded-zen border ${labelClass}`}
+          >
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function PlantingsSection({ counts }: { counts: AllotmentDiff['plantings'] }) {
+  const { added, removed, edited } = counts
+  if (added === 0 && removed === 0 && edited === 0) {
+    return (
+      <section>
+        <h3 className="text-sm font-medium text-zen-ink-700 mb-1">Plantings</h3>
+        <p className="text-sm text-zen-stone-500">No changes</p>
+      </section>
+    )
+  }
+  return (
+    <section>
+      <h3 className="text-sm font-medium text-zen-ink-700 mb-2">Plantings</h3>
+      <ul className="text-sm text-zen-ink-700 space-y-1">
+        {added > 0 && (
+          <li>
+            <span className="text-zen-moss-700 font-medium">+{added}</span> added
+          </li>
+        )}
+        {removed > 0 && (
+          <li>
+            <span className="text-zen-kitsune-700 font-medium">−{removed}</span> removed
+          </li>
+        )}
+        {edited > 0 && (
+          <li>
+            <span className="text-zen-ink-700 font-medium">{edited}</span> edited
+          </li>
+        )}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/settings/CloudHistorySection.tsx
+++ b/src/components/settings/CloudHistorySection.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { Clock, History, RefreshCw, AlertTriangle, RotateCcw } from 'lucide-react'
+import { Clock, History, RefreshCw, AlertTriangle, RotateCcw, Eye } from 'lucide-react'
 import { useOptionalAuth } from '@/hooks/useOptionalAuth'
 import { fetchHistoryList, fetchHistorySnapshot, type HistoryEntry } from '@/lib/supabase/sync'
 import { saveAllotmentData } from '@/services/allotment-storage'
 import { ConfirmDialog } from '@/components/ui/Dialog'
+import CloudHistoryDiffDialog from './CloudHistoryDiffDialog'
+import { summariseDiff, type AllotmentDiff } from '@/lib/allotment-diff'
 
 interface CloudHistorySectionProps {
   /** Called after a successful restore so the parent can re-read localStorage. */
@@ -46,6 +48,11 @@ export default function CloudHistorySection({ onDataImported }: CloudHistorySect
   const [error, setError] = useState<string | null>(null)
   const [restoringId, setRestoringId] = useState<number | null>(null)
   const [confirmRestoreId, setConfirmRestoreId] = useState<number | null>(null)
+  const [diffDialogId, setDiffDialogId] = useState<number | null>(null)
+  // Cache of computed diffs by base snapshot id, used for the inline hint
+  // once the user has opened the dialog at least once. We deliberately do
+  // not pre-fetch — only entries the user has inspected get a hint.
+  const [diffCache, setDiffCache] = useState<Record<number, AllotmentDiff>>({})
 
   const refresh = useCallback(async () => {
     if (!isSignedIn || !userId) return
@@ -141,38 +148,72 @@ export default function CloudHistorySection({ onDataImported }: CloudHistorySect
 
       {entries.length > 0 && (
         <ul className="space-y-2">
-          {entries.map((entry) => (
-            <li
-              key={entry.id}
-              className="border border-gray-200 rounded-lg p-3 flex items-center gap-3"
-            >
-              <Clock className="w-4 h-4 text-zen-stone-500 shrink-0" />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-zen-ink-800">
-                  {relativeTime(entry.archivedAt)}
-                </p>
-                <p className="text-xs text-gray-500">
-                  {ABSOLUTE_FORMATTER.format(new Date(entry.archivedAt))}
-                  {entry.summary && (
-                    <>
-                      {' · '}
-                      {entry.summary.areas} area{entry.summary.areas === 1 ? '' : 's'}
-                      {' · '}
-                      {entry.summary.varieties} variet{entry.summary.varieties === 1 ? 'y' : 'ies'}
-                    </>
-                  )}
-                </p>
-              </div>
-              <button
-                onClick={() => setConfirmRestoreId(entry.id)}
-                disabled={restoringId !== null}
-                className="flex items-center gap-1.5 px-3 py-2 min-h-[44px] text-sm bg-zen-water-600 text-white rounded-lg hover:bg-zen-water-700 transition disabled:opacity-50"
+          {entries.map((entry, index) => {
+            const cachedDiff = diffCache[entry.id]
+            return (
+              <li
+                key={entry.id}
+                className="border border-gray-200 rounded-lg p-3 flex items-center gap-3 flex-wrap sm:flex-nowrap"
               >
-                <RotateCcw className="w-4 h-4" />
-                {restoringId === entry.id ? 'Restoring...' : 'Restore'}
-              </button>
-            </li>
-          ))}
+                <Clock className="w-4 h-4 text-zen-stone-500 shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-zen-ink-800">
+                    {relativeTime(entry.archivedAt)}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {ABSOLUTE_FORMATTER.format(new Date(entry.archivedAt))}
+                    {entry.summary && (
+                      <>
+                        {' · '}
+                        {entry.summary.areas} area{entry.summary.areas === 1 ? '' : 's'}
+                        {' · '}
+                        {entry.summary.varieties} variet{entry.summary.varieties === 1 ? 'y' : 'ies'}
+                      </>
+                    )}
+                  </p>
+                  {cachedDiff && (
+                    <p className="text-xs text-zen-stone-600 mt-1">
+                      {summariseDiff(cachedDiff)}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    onClick={() => setDiffDialogId(entry.id)}
+                    className="flex items-center gap-1.5 px-3 py-2 min-h-[44px] text-sm bg-zen-stone-100 text-zen-ink-700 rounded-zen hover:bg-zen-stone-200 transition"
+                  >
+                    <Eye className="w-4 h-4" />
+                    View changes
+                  </button>
+                  <button
+                    onClick={() => setConfirmRestoreId(entry.id)}
+                    disabled={restoringId !== null}
+                    className="flex items-center gap-1.5 px-3 py-2 min-h-[44px] text-sm bg-zen-water-600 text-white rounded-lg hover:bg-zen-water-700 transition disabled:opacity-50"
+                  >
+                    <RotateCcw className="w-4 h-4" />
+                    {restoringId === entry.id ? 'Restoring...' : 'Restore'}
+                  </button>
+                </div>
+                {/* Mount the diff dialog only for the entry the user clicked,
+                    so we never fetch eagerly. The dialog handles its own
+                    load state when isOpen flips. */}
+                {diffDialogId === entry.id && userId && (
+                  <CloudHistoryDiffDialog
+                    isOpen={true}
+                    onClose={() => setDiffDialogId(null)}
+                    baseId={entry.id}
+                    newerId={index === 0 ? undefined : entries[index - 1].id}
+                    archivedAt={entry.archivedAt}
+                    getToken={getToken}
+                    userId={userId}
+                    onDiffComputed={(diff) =>
+                      setDiffCache((prev) => ({ ...prev, [entry.id]: diff }))
+                    }
+                  />
+                )}
+              </li>
+            )
+          })}
         </ul>
       )}
 

--- a/src/lib/allotment-diff.ts
+++ b/src/lib/allotment-diff.ts
@@ -1,0 +1,295 @@
+/**
+ * AllotmentData-aware diff.
+ *
+ * Hand-rolled walker that summarises the meaningful differences between two
+ * AllotmentData snapshots. We avoid generic deep-diff libraries on purpose:
+ * the bulk of the noise between two adjacent cloud snapshots is timestamp
+ * churn (`meta.updatedAt`, etc.) which generic libraries surface verbatim
+ * and drown out the changes a user actually cares about — areas added,
+ * plantings edited, varieties renamed, schema bumps.
+ *
+ * The output is a structured summary, not a raw JSON patch. The
+ * `summariseDiff()` helper renders it as a one-line inline hint; the
+ * structured form is used by the dialog UI to render concrete lists.
+ */
+
+import type {
+  AllotmentData,
+  Area,
+  Planting,
+  StoredVariety,
+} from '@/types/unified-allotment'
+
+export interface RenameEntry {
+  id: string
+  from: string
+  to: string
+}
+
+export interface AllotmentDiff {
+  areas: {
+    added: string[]
+    removed: string[]
+    renamed: RenameEntry[]
+  }
+  plantings: {
+    added: number
+    removed: number
+    edited: number
+  }
+  varieties: {
+    added: string[]
+    removed: string[]
+    renamed: RenameEntry[]
+  }
+  meta: {
+    schemaVersionChanged?: { from: number; to: number }
+  }
+}
+
+function emptyDiff(): AllotmentDiff {
+  return {
+    areas: { added: [], removed: [], renamed: [] },
+    plantings: { added: 0, removed: 0, edited: 0 },
+    varieties: { added: [], removed: [], renamed: [] },
+    meta: {},
+  }
+}
+
+function indexById<T extends { id: string }>(items: readonly T[] | undefined): Map<string, T> {
+  const map = new Map<string, T>()
+  if (!items) return map
+  for (const item of items) {
+    if (item && typeof item.id === 'string') {
+      map.set(item.id, item)
+    }
+  }
+  return map
+}
+
+function diffAreas(oldAreas: readonly Area[] | undefined, newAreas: readonly Area[] | undefined) {
+  const oldMap = indexById(oldAreas)
+  const newMap = indexById(newAreas)
+  const added: string[] = []
+  const removed: string[] = []
+  const renamed: RenameEntry[] = []
+
+  for (const [id, area] of newMap) {
+    if (!oldMap.has(id)) {
+      added.push(area.name)
+    } else {
+      const prev = oldMap.get(id)!
+      if (prev.name !== area.name) {
+        renamed.push({ id, from: prev.name, to: area.name })
+      }
+    }
+  }
+  for (const [id, area] of oldMap) {
+    if (!newMap.has(id)) {
+      removed.push(area.name)
+    }
+  }
+
+  return { added, removed, renamed }
+}
+
+function diffVarieties(
+  oldVarieties: readonly StoredVariety[] | undefined,
+  newVarieties: readonly StoredVariety[] | undefined,
+) {
+  const oldMap = indexById(oldVarieties)
+  const newMap = indexById(newVarieties)
+  const added: string[] = []
+  const removed: string[] = []
+  const renamed: RenameEntry[] = []
+
+  for (const [id, variety] of newMap) {
+    if (!oldMap.has(id)) {
+      added.push(variety.name)
+    } else {
+      const prev = oldMap.get(id)!
+      if (prev.name !== variety.name) {
+        renamed.push({ id, from: prev.name, to: variety.name })
+      }
+    }
+  }
+  for (const [id, variety] of oldMap) {
+    if (!newMap.has(id)) {
+      removed.push(variety.name)
+    }
+  }
+
+  return { added, removed, renamed }
+}
+
+/**
+ * Two plantings are considered "edited" when any non-id field differs.
+ * Stable JSON comparison over the whole record (minus id) is good enough —
+ * the Planting shape has no nested objects of consequence beyond simple
+ * scalars, so key ordering will be stable.
+ */
+function plantingsEqual(a: Planting, b: Planting): boolean {
+  // Compare excluding id (we already matched on id)
+  const keysA = Object.keys(a).filter((k) => k !== 'id').sort()
+  const keysB = Object.keys(b).filter((k) => k !== 'id').sort()
+  if (keysA.length !== keysB.length) return false
+  for (let i = 0; i < keysA.length; i++) {
+    if (keysA[i] !== keysB[i]) return false
+  }
+  for (const key of keysA) {
+    const valA = (a as unknown as Record<string, unknown>)[key]
+    const valB = (b as unknown as Record<string, unknown>)[key]
+    if (JSON.stringify(valA) !== JSON.stringify(valB)) return false
+  }
+  return true
+}
+
+function collectPlantings(data: AllotmentData | undefined): Map<string, Planting> {
+  // Key on `${year}|${areaId}|${plantingId}` so we can detect plantings that
+  // moved across seasons or across areas without mistaking them for an
+  // edit-in-place. Same id under the same (year, areaId) pair = same planting.
+  const map = new Map<string, Planting>()
+  if (!data?.seasons) return map
+  for (const season of data.seasons) {
+    if (!season?.areas) continue
+    for (const areaSeason of season.areas) {
+      if (!areaSeason?.plantings) continue
+      for (const planting of areaSeason.plantings) {
+        if (planting && typeof planting.id === 'string') {
+          map.set(`${season.year}|${areaSeason.areaId}|${planting.id}`, planting)
+        }
+      }
+    }
+  }
+  return map
+}
+
+function diffPlantings(oldData: AllotmentData, newData: AllotmentData) {
+  const oldMap = collectPlantings(oldData)
+  const newMap = collectPlantings(newData)
+  let added = 0
+  let removed = 0
+  let edited = 0
+
+  for (const [key, planting] of newMap) {
+    const prev = oldMap.get(key)
+    if (!prev) {
+      added++
+    } else if (!plantingsEqual(prev, planting)) {
+      edited++
+    }
+  }
+  for (const key of oldMap.keys()) {
+    if (!newMap.has(key)) {
+      removed++
+    }
+  }
+
+  return { added, removed, edited }
+}
+
+/**
+ * Compute a structured summary of meaningful differences between two
+ * AllotmentData snapshots. Pure function — no side effects.
+ *
+ * Notes on what is intentionally ignored:
+ * - `meta.updatedAt` and other timestamp churn (we never look at them).
+ * - `meta.createdAt` (immutable in practice; comparing it would just add noise).
+ * - `currentYear` (UI-only state).
+ * - `customTasks`, `maintenanceTasks`, `gardenEvents`, `compost` (out of scope
+ *    for this surface — the main signal users want is areas / plantings /
+ *    varieties / schema).
+ */
+export function diffAllotment(oldData: AllotmentData, newData: AllotmentData): AllotmentDiff {
+  const diff = emptyDiff()
+
+  diff.areas = diffAreas(oldData.layout?.areas, newData.layout?.areas)
+  diff.varieties = diffVarieties(oldData.varieties, newData.varieties)
+  diff.plantings = diffPlantings(oldData, newData)
+
+  if (
+    typeof oldData.version === 'number' &&
+    typeof newData.version === 'number' &&
+    oldData.version !== newData.version
+  ) {
+    diff.meta.schemaVersionChanged = { from: oldData.version, to: newData.version }
+  }
+
+  return diff
+}
+
+/**
+ * True when the diff has no meaningful changes.
+ */
+export function isEmptyDiff(d: AllotmentDiff): boolean {
+  return (
+    d.areas.added.length === 0 &&
+    d.areas.removed.length === 0 &&
+    d.areas.renamed.length === 0 &&
+    d.plantings.added === 0 &&
+    d.plantings.removed === 0 &&
+    d.plantings.edited === 0 &&
+    d.varieties.added.length === 0 &&
+    d.varieties.removed.length === 0 &&
+    d.varieties.renamed.length === 0 &&
+    !d.meta.schemaVersionChanged
+  )
+}
+
+/**
+ * One-line, comma-separated summary of the diff. Returns "No changes" when
+ * the diff is empty. Uses a Unicode minus sign (U+2212) for negative counts
+ * since it reads more cleanly than ASCII hyphen-minus alongside the +.
+ */
+export function summariseDiff(d: AllotmentDiff): string {
+  if (isEmptyDiff(d)) return 'No changes'
+
+  const parts: string[] = []
+
+  // Areas — net add/remove + rename count
+  if (d.areas.added.length > 0) {
+    parts.push(`+${d.areas.added.length} area${d.areas.added.length === 1 ? '' : 's'}`)
+  }
+  if (d.areas.removed.length > 0) {
+    parts.push(`−${d.areas.removed.length} area${d.areas.removed.length === 1 ? '' : 's'}`)
+  }
+  if (d.areas.renamed.length > 0) {
+    parts.push(`${d.areas.renamed.length} renamed`)
+  }
+
+  // Plantings
+  if (d.plantings.added > 0) {
+    parts.push(`+${d.plantings.added} planting${d.plantings.added === 1 ? '' : 's'}`)
+  }
+  if (d.plantings.removed > 0) {
+    parts.push(
+      `−${d.plantings.removed} planting${d.plantings.removed === 1 ? '' : 's'}`,
+    )
+  }
+  if (d.plantings.edited > 0) {
+    parts.push(`${d.plantings.edited} edited`)
+  }
+
+  // Varieties
+  if (d.varieties.added.length > 0) {
+    parts.push(
+      `+${d.varieties.added.length} variet${d.varieties.added.length === 1 ? 'y' : 'ies'}`,
+    )
+  }
+  if (d.varieties.removed.length > 0) {
+    parts.push(
+      `−${d.varieties.removed.length} variet${d.varieties.removed.length === 1 ? 'y' : 'ies'}`,
+    )
+  }
+  if (d.varieties.renamed.length > 0) {
+    parts.push(
+      `${d.varieties.renamed.length} variety rename${d.varieties.renamed.length === 1 ? '' : 's'}`,
+    )
+  }
+
+  if (d.meta.schemaVersionChanged) {
+    parts.push(`schema v${d.meta.schemaVersionChanged.from}→v${d.meta.schemaVersionChanged.to}`)
+  }
+
+  return parts.join(', ')
+}

--- a/src/lib/allotment-diff.ts
+++ b/src/lib/allotment-diff.ts
@@ -67,55 +67,29 @@ function indexById<T extends { id: string }>(items: readonly T[] | undefined): M
   return map
 }
 
-function diffAreas(oldAreas: readonly Area[] | undefined, newAreas: readonly Area[] | undefined) {
-  const oldMap = indexById(oldAreas)
-  const newMap = indexById(newAreas)
-  const added: string[] = []
-  const removed: string[] = []
-  const renamed: RenameEntry[] = []
-
-  for (const [id, area] of newMap) {
-    if (!oldMap.has(id)) {
-      added.push(area.name)
-    } else {
-      const prev = oldMap.get(id)!
-      if (prev.name !== area.name) {
-        renamed.push({ id, from: prev.name, to: area.name })
-      }
-    }
-  }
-  for (const [id, area] of oldMap) {
-    if (!newMap.has(id)) {
-      removed.push(area.name)
-    }
-  }
-
-  return { added, removed, renamed }
-}
-
-function diffVarieties(
-  oldVarieties: readonly StoredVariety[] | undefined,
-  newVarieties: readonly StoredVariety[] | undefined,
+function diffNamedItems<T extends { id: string; name: string }>(
+  oldItems: readonly T[] | undefined,
+  newItems: readonly T[] | undefined,
 ) {
-  const oldMap = indexById(oldVarieties)
-  const newMap = indexById(newVarieties)
+  const oldMap = indexById(oldItems)
+  const newMap = indexById(newItems)
   const added: string[] = []
   const removed: string[] = []
   const renamed: RenameEntry[] = []
 
-  for (const [id, variety] of newMap) {
+  for (const [id, item] of newMap) {
     if (!oldMap.has(id)) {
-      added.push(variety.name)
+      added.push(item.name)
     } else {
       const prev = oldMap.get(id)!
-      if (prev.name !== variety.name) {
-        renamed.push({ id, from: prev.name, to: variety.name })
+      if (prev.name !== item.name) {
+        renamed.push({ id, from: prev.name, to: item.name })
       }
     }
   }
-  for (const [id, variety] of oldMap) {
+  for (const [id, item] of oldMap) {
     if (!newMap.has(id)) {
-      removed.push(variety.name)
+      removed.push(item.name)
     }
   }
 
@@ -124,22 +98,21 @@ function diffVarieties(
 
 /**
  * Two plantings are considered "edited" when any non-id field differs.
- * Stable JSON comparison over the whole record (minus id) is good enough —
- * the Planting shape has no nested objects of consequence beyond simple
- * scalars, so key ordering will be stable.
+ * The Planting shape is all scalars (strings, numbers, enum strings — see
+ * src/types/unified-allotment.ts), so a shallow comparison with nullish
+ * coalescing handles all real cases. We unify undefined and null because
+ * JSONB roundtrips through Supabase don't preserve the distinction.
  */
 function plantingsEqual(a: Planting, b: Planting): boolean {
-  // Compare excluding id (we already matched on id)
-  const keysA = Object.keys(a).filter((k) => k !== 'id').sort()
-  const keysB = Object.keys(b).filter((k) => k !== 'id').sort()
-  if (keysA.length !== keysB.length) return false
-  for (let i = 0; i < keysA.length; i++) {
-    if (keysA[i] !== keysB[i]) return false
-  }
-  for (const key of keysA) {
+  // Union of all keys (excluding id) so a key that exists on only one side
+  // counts as a difference rather than being silently skipped.
+  const keys = new Set<string>()
+  for (const k of Object.keys(a)) if (k !== 'id') keys.add(k)
+  for (const k of Object.keys(b)) if (k !== 'id') keys.add(k)
+  for (const key of keys) {
     const valA = (a as unknown as Record<string, unknown>)[key]
     const valB = (b as unknown as Record<string, unknown>)[key]
-    if (JSON.stringify(valA) !== JSON.stringify(valB)) return false
+    if ((valA ?? null) !== (valB ?? null)) return false
   }
   return true
 }
@@ -203,8 +176,8 @@ function diffPlantings(oldData: AllotmentData, newData: AllotmentData) {
 export function diffAllotment(oldData: AllotmentData, newData: AllotmentData): AllotmentDiff {
   const diff = emptyDiff()
 
-  diff.areas = diffAreas(oldData.layout?.areas, newData.layout?.areas)
-  diff.varieties = diffVarieties(oldData.varieties, newData.varieties)
+  diff.areas = diffNamedItems<Area>(oldData.layout?.areas, newData.layout?.areas)
+  diff.varieties = diffNamedItems<StoredVariety>(oldData.varieties, newData.varieties)
   diff.plantings = diffPlantings(oldData, newData)
 
   if (


### PR DESCRIPTION
## Summary

- New `src/lib/allotment-diff.ts` — hand-rolled walker over `AllotmentData` that produces a structured diff (areas added/removed/renamed, planting counts, varieties, schema bump) while ignoring timestamp churn that a generic deep-diff would surface.
- `CloudHistorySection` now has a "View changes" button per row; clicking it opens a new `CloudHistoryDiffDialog` that lazily fetches the snapshot plus its next-newer neighbour (or current local data for the most recent row) and renders the diff in human-readable sections. After the user opens the dialog once for a row, an inline `summariseDiff()` hint appears under that row.
- 17 unit tests in `src/__tests__/lib/allotment-diff.test.ts` cover identical snapshots, timestamp-only churn, areas added/removed/renamed, plantings added/removed/edited (across multiple seasons), varieties added/removed/renamed, schema bumps, and a combined-changes case.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` (957 passed, 4 skipped)
- [ ] Manual: sign in, open Settings → Data → Previous Cloud Versions, click "View changes" on a snapshot, confirm dialog renders structured diff and inline hint appears after closing.
- [ ] Manual: click "View changes" on the most recent snapshot — confirm it diffs against current local data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)