### PR TITLE
feat(settings): nudge users to back up if no recent export

### DIFF
--- a/src/__tests__/lib/backup-reminder.test.ts
+++ b/src/__tests__/lib/backup-reminder.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { shouldShowBackupReminder } from '@/lib/backup-reminder'
+
+const NOW = new Date('2026-05-09T12:00:00.000Z')
+const DAY = 24 * 60 * 60 * 1000
+
+function isoDaysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * DAY).toISOString()
+}
+
+describe('shouldShowBackupReminder', () => {
+  it('shows when never exported and no cloud sync', () => {
+    expect(shouldShowBackupReminder({}, 'disabled', NOW)).toBe(true)
+  })
+
+  it('does not show when exported within the last 30 days', () => {
+    const meta = { lastBackupExportAt: isoDaysAgo(5) }
+    expect(shouldShowBackupReminder(meta, 'disabled', NOW)).toBe(false)
+  })
+
+  it('shows when last export was more than 30 days ago', () => {
+    const meta = { lastBackupExportAt: isoDaysAgo(45) }
+    expect(shouldShowBackupReminder(meta, 'disabled', NOW)).toBe(true)
+  })
+
+  it('does not show when dismissed within the last 30 days', () => {
+    const meta = {
+      lastBackupExportAt: isoDaysAgo(45),
+      backupReminderDismissedAt: isoDaysAgo(3),
+    }
+    expect(shouldShowBackupReminder(meta, 'disabled', NOW)).toBe(false)
+  })
+
+  it('shows again once the dismissal is older than 30 days', () => {
+    const meta = {
+      lastBackupExportAt: isoDaysAgo(60),
+      backupReminderDismissedAt: isoDaysAgo(40),
+    }
+    expect(shouldShowBackupReminder(meta, 'disabled', NOW)).toBe(true)
+  })
+
+  it('does not show for cloud-synced signed-in users regardless of export history', () => {
+    const meta = {
+      lastBackupExportAt: isoDaysAgo(365),
+      backupReminderDismissedAt: undefined,
+    }
+    expect(shouldShowBackupReminder(meta, 'synced', NOW)).toBe(false)
+  })
+
+  it('still shows when sync is configured but not yet synced (e.g. syncing/error/offline)', () => {
+    const meta = { lastBackupExportAt: isoDaysAgo(60) }
+    expect(shouldShowBackupReminder(meta, 'syncing', NOW)).toBe(true)
+    expect(shouldShowBackupReminder(meta, 'error', NOW)).toBe(true)
+    expect(shouldShowBackupReminder(meta, 'offline', NOW)).toBe(true)
+  })
+
+  it('treats null meta as never-exported / never-dismissed', () => {
+    expect(shouldShowBackupReminder(null, 'disabled', NOW)).toBe(true)
+    expect(shouldShowBackupReminder(undefined, 'disabled', NOW)).toBe(true)
+  })
+
+  it('treats malformed ISO timestamps as missing', () => {
+    const meta = { lastBackupExportAt: 'not-a-date', backupReminderDismissedAt: 'also-bad' }
+    expect(shouldShowBackupReminder(meta, 'disabled', NOW)).toBe(true)
+  })
+})

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -14,7 +14,7 @@ import Tabs from '@/components/ui/Tabs'
 
 export default function SettingsPage() {
   const { isSignedIn, signOut, userEmail } = useOptionalAuth()
-  const { data, flushSave, reload } = useAllotment()
+  const { data, flushSave, reload, updateMeta, syncStatus } = useAllotment()
   const { token, saveToken, clearToken } = useApiToken()
   const { userLocation, locationError, detectUserLocation, isDetecting } = useLocation()
   const [tempToken, setTempToken] = useState('')
@@ -180,6 +180,8 @@ export default function SettingsPage() {
                   data={data}
                   flushSave={flushSave}
                   reload={reload}
+                  updateMeta={updateMeta}
+                  syncStatus={syncStatus}
                   isSignedIn={isSignedIn}
                   onDeleteAccount={isSignedIn ? handleDeleteAccount : undefined}
                   userEmail={userEmail}

--- a/src/components/settings/BackupReminderCallout.tsx
+++ b/src/components/settings/BackupReminderCallout.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { AlertCircle, Download, X } from 'lucide-react'
+
+interface BackupReminderCalloutProps {
+  /** ISO timestamp of the last successful export, if any. */
+  lastBackupExportAt?: string
+  onDownload: () => void
+  onDismiss: () => void
+}
+
+function formatRelative(iso: string | undefined): string {
+  if (!iso) return 'never'
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return 'never'
+  const days = Math.floor((Date.now() - t) / (24 * 60 * 60 * 1000))
+  if (days <= 0) return 'today'
+  if (days === 1) return 'yesterday'
+  if (days < 30) return `${days} days ago`
+  const months = Math.floor(days / 30)
+  if (months === 1) return '1 month ago'
+  return `${months} months ago`
+}
+
+/**
+ * Yellow callout shown in Settings → Data when the user hasn't exported
+ * a backup in the last 30 days (and isn't already covered by cloud sync).
+ *
+ * Visibility is decided by the parent via `shouldShowBackupReminder`; this
+ * component only renders the surface and routes the two actions.
+ */
+export default function BackupReminderCallout({
+  lastBackupExportAt,
+  onDownload,
+  onDismiss,
+}: BackupReminderCalloutProps) {
+  return (
+    <div
+      className="bg-zen-bamboo-50 border border-zen-bamboo-200 rounded-lg p-4 flex items-start gap-3"
+      role="status"
+      aria-label="Backup reminder"
+    >
+      <AlertCircle className="w-5 h-5 text-zen-bamboo-700 flex-shrink-0 mt-0.5" aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-zen-ink-900">
+          Time to back up your allotment
+        </p>
+        <p className="text-xs text-zen-stone-600 mt-1">
+          Last export: {formatRelative(lastBackupExportAt)}. Download a backup file so you don&apos;t lose your data if this device is lost or cleared.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            onClick={onDownload}
+            className="flex items-center gap-2 px-4 py-2 bg-zen-bamboo-600 text-white rounded-lg hover:bg-zen-bamboo-700 transition text-sm min-h-[44px]"
+          >
+            <Download className="w-4 h-4" />
+            Download backup
+          </button>
+          <button
+            onClick={onDismiss}
+            className="flex items-center gap-2 px-4 py-2 bg-white text-zen-bamboo-700 border border-zen-bamboo-300 rounded-lg hover:bg-zen-bamboo-100 transition text-sm min-h-[44px]"
+          >
+            Dismiss for 30 days
+          </button>
+        </div>
+      </div>
+      <button
+        onClick={onDismiss}
+        className="p-1 text-zen-stone-400 hover:text-zen-stone-600 transition-colors"
+        aria-label="Dismiss backup reminder"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/settings/BackupReminderCallout.tsx
+++ b/src/components/settings/BackupReminderCallout.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { AlertCircle, Download, X } from 'lucide-react'
 
 interface BackupReminderCalloutProps {
@@ -9,11 +10,11 @@ interface BackupReminderCalloutProps {
   onDismiss: () => void
 }
 
-function formatRelative(iso: string | undefined): string {
+function formatRelative(iso: string | undefined, now: number): string {
   if (!iso) return 'never'
   const t = Date.parse(iso)
   if (Number.isNaN(t)) return 'never'
-  const days = Math.floor((Date.now() - t) / (24 * 60 * 60 * 1000))
+  const days = Math.floor((now - t) / (24 * 60 * 60 * 1000))
   if (days <= 0) return 'today'
   if (days === 1) return 'yesterday'
   if (days < 30) return `${days} days ago`
@@ -34,6 +35,13 @@ export default function BackupReminderCallout({
   onDownload,
   onDismiss,
 }: BackupReminderCalloutProps) {
+  // Compute relative time on the client only to avoid SSR/CSR hydration drift
+  // around day boundaries (server renders "today", client hydrates "yesterday").
+  const [relative, setRelative] = useState<string | null>(null)
+  useEffect(() => {
+    setRelative(formatRelative(lastBackupExportAt, Date.now()))
+  }, [lastBackupExportAt])
+
   return (
     <div
       className="bg-zen-bamboo-50 border border-zen-bamboo-200 rounded-lg p-4 flex items-start gap-3"
@@ -46,7 +54,7 @@ export default function BackupReminderCallout({
           Time to back up your allotment
         </p>
         <p className="text-xs text-zen-stone-600 mt-1">
-          Last export: {formatRelative(lastBackupExportAt)}. Download a backup file so you don&apos;t lose your data if this device is lost or cleared.
+          Last export: {relative ?? '…'}. Download a backup file so you don&apos;t lose your data if this device is lost or cleared.
         </p>
         <div className="mt-3 flex flex-wrap gap-2">
           <button

--- a/src/components/settings/DataTab.tsx
+++ b/src/components/settings/DataTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useDataTransfer } from '@/hooks/useDataTransfer'
 import { useAllotment } from '@/hooks/useAllotment'
 import {
@@ -9,11 +9,16 @@ import {
 } from 'lucide-react'
 import { ConfirmDialog } from '@/components/ui/Dialog'
 import CloudHistorySection from './CloudHistorySection'
+import BackupReminderCallout from './BackupReminderCallout'
+import { shouldShowBackupReminder } from '@/lib/backup-reminder'
+import type { SyncStatus } from '@/types/storage'
 
 interface DataTabProps {
   data: ReturnType<typeof useAllotment>['data']
   flushSave: ReturnType<typeof useAllotment>['flushSave']
   reload: ReturnType<typeof useAllotment>['reload']
+  updateMeta: ReturnType<typeof useAllotment>['updateMeta']
+  syncStatus: SyncStatus
   isSignedIn?: boolean
   onDeleteAccount?: () => Promise<void>
   userEmail?: string
@@ -22,12 +27,27 @@ interface DataTabProps {
 /**
  * Data tab with Transfer and Danger Zone sections.
  */
-export default function DataTab({ data, flushSave, reload, isSignedIn, onDeleteAccount, userEmail }: DataTabProps) {
+export default function DataTab({
+  data, flushSave, reload, updateMeta, syncStatus,
+  isSignedIn, onDeleteAccount, userEmail,
+}: DataTabProps) {
   const {
     handleExport, exportSuccess,
     handleImport, importError, fileInputRef, lastBackupKey, handleRestoreBackup,
     handleClear, showClearConfirm, setShowClearConfirm,
   } = useDataTransfer({ data, onDataImported: reload, flushSave })
+
+  // Wrap export so a successful download stamps lastBackupExportAt.
+  const handleExportWithStamp = useCallback(() => {
+    handleExport()
+    updateMeta({ lastBackupExportAt: new Date().toISOString() })
+  }, [handleExport, updateMeta])
+
+  const handleDismissBackupReminder = useCallback(() => {
+    updateMeta({ backupReminderDismissedAt: new Date().toISOString() })
+  }, [updateMeta])
+
+  const showBackupReminder = shouldShowBackupReminder(data?.meta, syncStatus, new Date())
 
   const [confirmDeleteAccount, setConfirmDeleteAccount] = useState(false)
   const [isDeletingAccount, setIsDeletingAccount] = useState(false)
@@ -35,6 +55,14 @@ export default function DataTab({ data, flushSave, reload, isSignedIn, onDeleteA
 
   return (
     <div className="space-y-8">
+      {showBackupReminder && (
+        <BackupReminderCallout
+          lastBackupExportAt={data?.meta.lastBackupExportAt}
+          onDownload={handleExportWithStamp}
+          onDismiss={handleDismissBackupReminder}
+        />
+      )}
+
       {/* Transfer Data Section */}
       <section data-tour="data-management">
         <div className="flex items-center gap-2 mb-2">
@@ -57,7 +85,7 @@ export default function DataTab({ data, flushSave, reload, isSignedIn, onDeleteA
             </p>
             <div className="mt-1 flex items-center gap-2">
               <button
-                onClick={handleExport}
+                onClick={handleExportWithStamp}
                 disabled={!data}
                 className="flex items-center gap-2 px-4 py-2 bg-zen-moss-600 text-white rounded-lg hover:bg-zen-moss-700 transition text-sm disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-400"
               >

--- a/src/components/settings/DataTab.tsx
+++ b/src/components/settings/DataTab.tsx
@@ -47,7 +47,7 @@ export default function DataTab({
     updateMeta({ backupReminderDismissedAt: new Date().toISOString() })
   }, [updateMeta])
 
-  const showBackupReminder = shouldShowBackupReminder(data?.meta, syncStatus, new Date())
+  const showBackupReminder = !!data && shouldShowBackupReminder(data.meta, syncStatus, new Date())
 
   const [confirmDeleteAccount, setConfirmDeleteAccount] = useState(false)
   const [isDeletingAccount, setIsDeletingAccount] = useState(false)

--- a/src/lib/backup-reminder.ts
+++ b/src/lib/backup-reminder.ts
@@ -1,0 +1,38 @@
+import type { AllotmentMeta } from '@/types/unified-allotment'
+import type { SyncStatus } from '@/types/storage'
+
+/** Days between automatic backup reminders. */
+export const BACKUP_REMINDER_INTERVAL_DAYS = 30
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function olderThanDays(iso: string | undefined, days: number, now: number): boolean {
+  if (!iso) return true
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return true
+  return now - t > days * MS_PER_DAY
+}
+
+/**
+ * Pure predicate: should the Settings backup reminder callout be shown?
+ *
+ * Rules:
+ * - Cloud-synced users (signed in with `syncStatus === 'synced'`) never see
+ *   the reminder — they have a recovery floor already.
+ * - Otherwise, show when there has been no export in the last 30 days
+ *   AND the reminder has not been dismissed in the last 30 days.
+ */
+export function shouldShowBackupReminder(
+  meta: Pick<AllotmentMeta, 'lastBackupExportAt' | 'backupReminderDismissedAt'> | null | undefined,
+  syncStatus: SyncStatus,
+  now: Date,
+): boolean {
+  if (syncStatus === 'synced') return false
+  if (!meta) return true
+  const nowMs = now.getTime()
+  const exportedRecently = !olderThanDays(meta.lastBackupExportAt, BACKUP_REMINDER_INTERVAL_DAYS, nowMs)
+  if (exportedRecently) return false
+  const dismissedRecently = !olderThanDays(meta.backupReminderDismissedAt, BACKUP_REMINDER_INTERVAL_DAYS, nowMs)
+  if (dismissedRecently) return false
+  return true
+}

--- a/src/types/unified-allotment.ts
+++ b/src/types/unified-allotment.ts
@@ -205,6 +205,17 @@ export interface AllotmentMeta {
   aiAdvisorEnabled?: boolean
   /** ISO timestamp of when the user dismissed the Aitor opt-in banner. */
   aiAdvisorPromptDismissedAt?: string
+  /**
+   * ISO timestamp of the last successful JSON backup export. Drives the
+   * Settings backup reminder. Optional — undefined means "never exported".
+   * No schema migration: consumer code treats undefined as "never".
+   */
+  lastBackupExportAt?: string
+  /**
+   * ISO timestamp of when the user last dismissed the backup reminder.
+   * Optional — undefined means "never dismissed".
+   */
+  backupReminderDismissedAt?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a yellow callout in Settings -> Data that appears when more than 30 days have passed since the last JSON export, with a Download backup button (re-using the existing export flow) and a Dismiss for 30 days button.
- Predicate decision: cloud-synced signed-in users (`syncStatus === 'synced'`) never see the reminder, since they already have a recovery floor; the reminder still shows for `disabled` / `syncing` / `error` / `offline` states. Reminder also hidden when last export OR dismissal is within the last 30 days.
- Tracks two new optional fields on `AllotmentMeta`: `lastBackupExportAt` (stamped whenever the existing export button is clicked) and `backupReminderDismissedAt` (set when dismissed). Both are optional with `undefined` meaning "never" — no schema migration required.

Surface kept to Settings only to avoid conflict with the parallel Aitor opt-in banner work landing on TodayDashboard.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` (new `shouldShowBackupReminder` predicate covers: never-exported / no cloud, exported recently, exported long ago, dismissed recently, dismissal stale, cloud-synced signed-in user, non-synced auth states, null meta, malformed timestamps)
- [ ] Manual: visit Settings -> Data while signed out with no prior export -> callout shows; click Download backup -> JSON downloads and callout disappears
- [ ] Manual: click Dismiss for 30 days -> callout disappears and stays hidden on reload
- [ ] Manual: sign in with active cloud sync -> callout never appears