### PR TITLE
feat(ai): per-user Aitor opt-in with diagnosis entry point

### DIFF
--- a/src/__tests__/components/AitorAuthGate.test.tsx
+++ b/src/__tests__/components/AitorAuthGate.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import type { AllotmentData } from '@/types/unified-allotment'
+
+// Mocks must be declared before importing the component under test.
+const useOptionalAuthMock = vi.fn()
+const useAllotmentMock = vi.fn()
+
+vi.mock('@/hooks/useOptionalAuth', () => ({
+  useOptionalAuth: () => useOptionalAuthMock(),
+}))
+
+vi.mock('@/hooks/useAllotment', () => ({
+  useAllotment: () => useAllotmentMock(),
+}))
+
+// Stub out the heavy children so we only assert on AitorAuthGate's gating logic.
+vi.mock('@/components/ai-advisor/AitorChatButton', () => ({
+  default: () => <div data-testid="aitor-chat-button" />,
+}))
+vi.mock('@/components/ai-advisor/AitorChatModal', () => ({
+  default: () => <div data-testid="aitor-chat-modal" />,
+}))
+
+import AitorAuthGate from '@/components/ai-advisor/AitorAuthGate'
+
+function dataWith(aiAdvisorEnabled: boolean | undefined): { data: Partial<AllotmentData> } {
+  return {
+    data: {
+      meta: {
+        name: 'Test',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        aiAdvisorEnabled,
+      },
+    } as Partial<AllotmentData>,
+  }
+}
+
+describe('AitorAuthGate', () => {
+  beforeEach(() => {
+    useOptionalAuthMock.mockReset()
+    useAllotmentMock.mockReset()
+  })
+
+  it('renders nothing when the user is not signed in', () => {
+    useOptionalAuthMock.mockReturnValue({ isSignedIn: false })
+    useAllotmentMock.mockReturnValue(dataWith(true))
+
+    const { container } = render(<AitorAuthGate />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing when signed in but aiAdvisorEnabled is false', () => {
+    useOptionalAuthMock.mockReturnValue({ isSignedIn: true })
+    useAllotmentMock.mockReturnValue(dataWith(false))
+
+    const { container } = render(<AitorAuthGate />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing when signed in but aiAdvisorEnabled is undefined', () => {
+    useOptionalAuthMock.mockReturnValue({ isSignedIn: true })
+    useAllotmentMock.mockReturnValue(dataWith(undefined))
+
+    const { container } = render(<AitorAuthGate />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the chat button and modal when signed in and opted in', () => {
+    useOptionalAuthMock.mockReturnValue({ isSignedIn: true })
+    useAllotmentMock.mockReturnValue(dataWith(true))
+
+    const { getByTestId } = render(<AitorAuthGate />)
+    expect(getByTestId('aitor-chat-button')).toBeInTheDocument()
+    expect(getByTestId('aitor-chat-modal')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/services/v22-migration.test.ts
+++ b/src/__tests__/services/v22-migration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the v21 -> v22 migration: per-user Aitor opt-in.
+ *
+ * The migration is a no-op data transform (both new fields are optional);
+ * it simply bumps the version field so the schema validator accepts the row.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { loadAllotmentData } from '@/services/allotment-storage'
+import { AllotmentData, CURRENT_SCHEMA_VERSION } from '@/types/unified-allotment'
+
+const TEST_CURRENT_YEAR = new Date().getFullYear()
+
+function createV21Data(overrides: Partial<AllotmentData> = {}): AllotmentData {
+  return {
+    version: 21,
+    currentYear: TEST_CURRENT_YEAR,
+    meta: {
+      name: 'Test Allotment',
+      location: 'Test Location',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    },
+    layout: { areas: [] },
+    seasons: [
+      {
+        year: TEST_CURRENT_YEAR,
+        status: 'current',
+        areas: [],
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    ],
+    customTasks: [],
+    varieties: [],
+    compost: [],
+    ...overrides,
+  }
+}
+
+describe('v21 to v22 migration: Aitor opt-in', () => {
+  beforeEach(() => {
+    vi.mocked(localStorage.getItem).mockClear()
+    vi.mocked(localStorage.setItem).mockClear()
+  })
+
+  it('bumps version to current and leaves opt-in fields undefined', () => {
+    const v21Data = createV21Data()
+    vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(v21Data))
+
+    const result = loadAllotmentData()
+
+    expect(result.success).toBe(true)
+    expect(result.data?.version).toBe(CURRENT_SCHEMA_VERSION)
+    expect(result.data?.meta.aiAdvisorEnabled).toBeUndefined()
+    expect(result.data?.meta.aiAdvisorPromptDismissedAt).toBeUndefined()
+  })
+
+  it('preserves existing meta fields during migration', () => {
+    const v21Data = createV21Data({
+      meta: {
+        name: 'My Plot',
+        location: 'Edinburgh',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        setupCompleted: true,
+      },
+    })
+    vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(v21Data))
+
+    const result = loadAllotmentData()
+
+    expect(result.success).toBe(true)
+    expect(result.data?.meta.name).toBe('My Plot')
+    expect(result.data?.meta.setupCompleted).toBe(true)
+  })
+
+  it('preserves opt-in fields when already set on v21 data', () => {
+    const v21Data = createV21Data({
+      meta: {
+        name: 'Test Allotment',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        aiAdvisorEnabled: true,
+        aiAdvisorPromptDismissedAt: '2026-05-01T00:00:00.000Z',
+      },
+    })
+    vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(v21Data))
+
+    const result = loadAllotmentData()
+
+    expect(result.success).toBe(true)
+    expect(result.data?.meta.aiAdvisorEnabled).toBe(true)
+    expect(result.data?.meta.aiAdvisorPromptDismissedAt).toBe('2026-05-01T00:00:00.000Z')
+  })
+})

--- a/src/components/ai-advisor/AitorAuthGate.tsx
+++ b/src/components/ai-advisor/AitorAuthGate.tsx
@@ -1,21 +1,25 @@
 'use client'
 
 import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+import { useAllotment } from '@/hooks/useAllotment'
 import AitorChatButton from './AitorChatButton'
 import AitorChatModal from './AitorChatModal'
 
 /**
- * Renders the floating Aitor chat button and modal only for signed-in users.
+ * Renders the floating Aitor chat button and modal only for users who have
+ * explicitly opted in.
  *
- * Aitor (the AI advisor) is gated behind Clerk authentication so we have
- * a real user identity for any future server-side fallback, and so anonymous
- * onboarding stays focused. When Clerk is not configured (e.g. local dev
- * without keys), `useOptionalAuth` returns `isSignedIn: false` and Aitor
- * stays hidden — same gate, same UI.
+ * Aitor is gated behind Clerk auth so we have a real user identity for any
+ * future server-side fallback, AND behind a per-user `meta.aiAdvisorEnabled`
+ * flag so signing in does not implicitly subscribe a user to AI features.
+ * When Clerk is not configured (e.g. local dev without keys),
+ * `useOptionalAuth` returns `isSignedIn: false` and Aitor stays hidden.
  */
 export default function AitorAuthGate() {
   const { isSignedIn } = useOptionalAuth()
+  const { data } = useAllotment()
   if (!isSignedIn) return null
+  if (data?.meta?.aiAdvisorEnabled !== true) return null
   return (
     <>
       <AitorChatButton />

--- a/src/components/ai-advisor/AitorChatButton.tsx
+++ b/src/components/ai-advisor/AitorChatButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { MessageCircle } from 'lucide-react'
+import { Camera, MessageCircle } from 'lucide-react'
 import { useAitorChat } from '@/contexts/AitorChatContext'
 import { usePathname } from 'next/navigation'
 
@@ -19,13 +19,23 @@ export default function AitorChatButton() {
   }
 
   return (
-    <button
-      onClick={() => openChat()}
-      className="fixed bottom-6 right-6 z-50 flex items-center gap-2 bg-zen-moss-600 hover:bg-zen-moss-700 text-white px-4 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 group"
-      aria-label="Ask Aitor - your gardening assistant"
-    >
-      <MessageCircle className="w-5 h-5" />
-      <span className="text-sm font-medium hidden sm:inline">Ask Aitor</span>
-    </button>
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-2">
+      <button
+        onClick={() => openChat({ initialMode: 'diagnose' })}
+        className="flex items-center gap-2 bg-zen-water-600 hover:bg-zen-water-700 text-white px-4 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 group min-h-[44px]"
+        aria-label="Diagnose a plant - upload a photo for Aitor to analyse"
+      >
+        <Camera className="w-5 h-5" aria-hidden="true" />
+        <span className="text-sm font-medium hidden sm:inline">Diagnose a plant</span>
+      </button>
+      <button
+        onClick={() => openChat()}
+        className="flex items-center gap-2 bg-zen-moss-600 hover:bg-zen-moss-700 text-white px-4 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 group min-h-[44px]"
+        aria-label="Ask Aitor - your gardening assistant"
+      >
+        <MessageCircle className="w-5 h-5" aria-hidden="true" />
+        <span className="text-sm font-medium hidden sm:inline">Ask Aitor</span>
+      </button>
+    </div>
   )
 }

--- a/src/components/ai-advisor/AitorChatModal.tsx
+++ b/src/components/ai-advisor/AitorChatModal.tsx
@@ -51,7 +51,7 @@ const imageToBase64 = (file: File): Promise<string> => {
 }
 
 export default function AitorChatModal() {
-  const { isOpen, closeChat, initialMessage, clearInitialMessage } = useAitorChat()
+  const { isOpen, closeChat, initialMessage, clearInitialMessage, initialMode, clearInitialMode } = useAitorChat()
   const [messages, setMessages] = useState<ExtendedChatMessage[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [rateLimitInfo, setRateLimitInfo] = useState({ cooldownMs: 0, remainingRequests: 5 })
@@ -84,6 +84,12 @@ export default function AitorChatModal() {
     if (!allotmentData) return ''
 
     const lines: string[] = []
+
+    // Diagnose-mode hint: focuses the model on photo-based symptom diagnosis.
+    if (initialMode === 'diagnose') {
+      lines.push('FOCUS: Focus this conversation on diagnosing plant symptoms from the user\'s photo.')
+      lines.push('')
+    }
 
     // Basic info
     lines.push(`ALLOTMENT: ${allotmentData.meta.name}`)
@@ -122,7 +128,7 @@ export default function AitorChatModal() {
     lines.push(`PERMANENT PLANTINGS: ${[...treeAreas, ...berryAreas].map(p => p.name).join(', ')}`)
 
     return lines.join('\n')
-  }, [allotmentData, currentSeason, selectedYear, getAreasByKind])
+  }, [allotmentData, currentSeason, selectedYear, getAreasByKind, initialMode])
 
   // Update rate limit state
   const updateRateLimitState = useCallback(() => {
@@ -406,7 +412,10 @@ export default function AitorChatModal() {
     <>
       <Dialog
         isOpen={isOpen}
-        onClose={closeChat}
+        onClose={() => {
+          clearInitialMode()
+          closeChat()
+        }}
         title="Ask Aitor"
         maxWidth="2xl"
         fullContent
@@ -477,6 +486,7 @@ export default function AitorChatModal() {
               onSubmit={handleSubmit}
               isLoading={isLoading}
               rateLimitInfo={rateLimitInfo}
+              autoOpenFilePicker={isOpen && initialMode === 'diagnose'}
             />
           </div>
         </div>

--- a/src/components/ai-advisor/ChatInput.tsx
+++ b/src/components/ai-advisor/ChatInput.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Send, Camera, X, Clock } from 'lucide-react'
 import Image from 'next/image'
 
@@ -13,14 +13,24 @@ interface ChatInputProps {
   onSubmit: (message: string, image?: File) => void
   isLoading: boolean
   rateLimitInfo?: RateLimitInfo
+  /** When true, auto-opens the file picker once after mount (diagnose mode). */
+  autoOpenFilePicker?: boolean
 }
 
-export default function ChatInput({ onSubmit, isLoading, rateLimitInfo }: ChatInputProps) {
+export default function ChatInput({ onSubmit, isLoading, rateLimitInfo, autoOpenFilePicker }: ChatInputProps) {
   const [input, setInput] = useState('')
   const [selectedImage, setSelectedImage] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const [validationError, setValidationError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const autoOpenedRef = useRef(false)
+
+  useEffect(() => {
+    if (autoOpenFilePicker && !autoOpenedRef.current) {
+      autoOpenedRef.current = true
+      fileInputRef.current?.click()
+    }
+  }, [autoOpenFilePicker])
 
   const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValidationError(null)

--- a/src/components/ai-advisor/ChatInput.tsx
+++ b/src/components/ai-advisor/ChatInput.tsx
@@ -23,11 +23,9 @@ export default function ChatInput({ onSubmit, isLoading, rateLimitInfo, autoOpen
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const [validationError, setValidationError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const autoOpenedRef = useRef(false)
 
   useEffect(() => {
-    if (autoOpenFilePicker && !autoOpenedRef.current) {
-      autoOpenedRef.current = true
+    if (autoOpenFilePicker) {
       fileInputRef.current?.click()
     }
   }, [autoOpenFilePicker])

--- a/src/components/ai-advisor/QuickTopics.tsx
+++ b/src/components/ai-advisor/QuickTopics.tsx
@@ -1,85 +1,71 @@
 'use client'
 
-import { useTodayData } from '@/hooks/useTodayData'
-import { generateAISuggestions, hasPersonalizedData, type AISuggestion } from '@/lib/ai-suggestions'
+import { Calendar, Camera, RotateCcw, Sprout, type LucideIcon } from 'lucide-react'
 
 interface QuickTopicsProps {
   onSelectTopic: (query: string) => void
 }
 
-function TopicButton({ suggestion, onSelect }: { suggestion: AISuggestion; onSelect: () => void }) {
-  const Icon = suggestion.icon
+interface QuickPrompt {
+  icon: LucideIcon
+  title: string
+  query: string
+  borderColor: string
+}
 
-  // Category-based styling
-  const categoryStyles: Record<AISuggestion['category'], string> = {
-    seasonal: 'border-l-amber-400',
-    harvest: 'border-l-orange-400',
-    planting: 'border-l-emerald-400',
-    maintenance: 'border-l-violet-400',
-    general: 'border-l-gray-300',
-  }
+const PROMPTS: QuickPrompt[] = [
+  {
+    icon: Calendar,
+    title: 'What can I plant in May?',
+    query: 'What can I plant in May?',
+    borderColor: 'border-l-emerald-400',
+  },
+  {
+    icon: Camera,
+    title: 'Diagnose this leaf',
+    query: 'Diagnose this leaf',
+    borderColor: 'border-l-violet-400',
+  },
+  {
+    icon: RotateCcw,
+    title: 'Plan my next rotation',
+    query: 'Plan my next rotation',
+    borderColor: 'border-l-amber-400',
+  },
+  {
+    icon: Sprout,
+    title: 'Why is my chard bolting?',
+    query: 'Why is my chard bolting?',
+    borderColor: 'border-l-orange-400',
+  },
+]
 
+function TopicButton({ prompt, onSelect }: { prompt: QuickPrompt; onSelect: () => void }) {
+  const Icon = prompt.icon
   return (
     <button
       type="button"
       onClick={onSelect}
-      className={`bg-white p-3 sm:p-4 rounded-lg shadow-md border border-l-4 ${categoryStyles[suggestion.category]} hover:shadow-lg transition text-left group min-h-[88px]`}
+      className={`bg-white p-3 sm:p-4 rounded-lg shadow-md border border-l-4 ${prompt.borderColor} hover:shadow-lg transition text-left group min-h-[88px]`}
     >
       <div className="flex items-center mb-2">
-        <Icon className="w-5 h-5 text-zen-moss-600 mr-2 group-hover:scale-110 transition-transform flex-shrink-0" />
-        <span className="font-medium text-sm sm:text-base text-gray-800">{suggestion.title}</span>
+        <Icon className="w-5 h-5 text-zen-moss-600 mr-2 group-hover:scale-110 transition-transform flex-shrink-0" aria-hidden="true" />
+        <span className="font-medium text-sm sm:text-base text-zen-ink-800">{prompt.title}</span>
       </div>
-      <p className="text-xs sm:text-sm text-gray-600 line-clamp-2">{suggestion.query}</p>
     </button>
   )
 }
 
 export default function QuickTopics({ onSelectTopic }: QuickTopicsProps) {
-  const todayData = useTodayData()
-
-  const suggestions = generateAISuggestions({
-    seasonalPhase: todayData.seasonalPhase,
-    currentMonth: todayData.currentMonth,
-    maintenanceTasks: todayData.maintenanceTasks,
-  })
-
-  const isPersonalized = hasPersonalizedData({
-    seasonalPhase: todayData.seasonalPhase,
-    currentMonth: todayData.currentMonth,
-    maintenanceTasks: todayData.maintenanceTasks,
-  })
-
-  if (todayData.isLoading) {
-    return (
-      <div className="mb-8">
-        <h2 className="text-xl font-semibold mb-4">🌿 Suggested Topics</h2>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {[1, 2, 3].map(i => (
-            <div key={i} className="bg-gray-100 rounded-lg h-24 animate-pulse" />
-          ))}
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div className="mb-8">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-semibold">
-          {isPersonalized ? '🎯 Suggested for You' : '🌿 Popular Topics'}
-        </h2>
-        {isPersonalized && (
-          <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
-            Based on your allotment
-          </span>
-        )}
-      </div>
+      <h2 className="text-xl font-semibold mb-4 text-zen-ink-800">Popular Topics</h2>
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {suggestions.map((suggestion, index) => (
+        {PROMPTS.map((prompt) => (
           <TopicButton
-            key={`${suggestion.category}-${index}`}
-            suggestion={suggestion}
-            onSelect={() => onSelectTopic(suggestion.query)}
+            key={prompt.title}
+            prompt={prompt}
+            onSelect={() => onSelectTopic(prompt.query)}
           />
         ))}
       </div>

--- a/src/components/ai-advisor/QuickTopics.tsx
+++ b/src/components/ai-advisor/QuickTopics.tsx
@@ -16,8 +16,8 @@ interface QuickPrompt {
 const PROMPTS: QuickPrompt[] = [
   {
     icon: Calendar,
-    title: 'What can I plant in May?',
-    query: 'What can I plant in May?',
+    title: 'What can I plant now?',
+    query: 'What can I plant now?',
     borderColor: 'border-l-emerald-400',
   },
   {

--- a/src/components/dashboard/AitorOptInBanner.tsx
+++ b/src/components/dashboard/AitorOptInBanner.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { Sparkles, X } from 'lucide-react'
+
+interface AitorOptInBannerProps {
+  onEnable: () => void
+  onDismiss: () => void
+}
+
+export default function AitorOptInBanner({ onEnable, onDismiss }: AitorOptInBannerProps) {
+  return (
+    <div className="zen-card p-4 bg-zen-moss-50 border border-zen-moss-100 flex items-start gap-3">
+      <Sparkles className="w-5 h-5 text-zen-moss-600 flex-shrink-0 mt-0.5" aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-zen-ink-700">
+          Try Aitor, your AI gardening companion?
+        </p>
+        <p className="text-xs text-zen-stone-500 mt-1">
+          Ask seasonal questions, plan rotations, or upload a photo for plant diagnosis. You can turn this off any time.
+        </p>
+        <div className="mt-3 flex gap-2">
+          <button
+            onClick={onEnable}
+            className="px-3 py-2 min-h-[44px] text-xs bg-zen-moss-600 hover:bg-zen-moss-700 text-white rounded-zen transition-colors"
+          >
+            Try Aitor
+          </button>
+          <button
+            onClick={onDismiss}
+            className="px-3 py-2 min-h-[44px] text-xs text-zen-stone-600 hover:text-zen-stone-800 transition-colors"
+          >
+            Maybe later
+          </button>
+        </div>
+      </div>
+      <button
+        onClick={onDismiss}
+        className="p-1 text-zen-stone-400 hover:text-zen-stone-600 transition-colors"
+        aria-label="Dismiss Aitor opt-in prompt"
+      >
+        <X className="w-4 h-4" aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/dashboard/TodayDashboard.tsx
+++ b/src/components/dashboard/TodayDashboard.tsx
@@ -12,9 +12,11 @@ import CompostAlerts from './CompostAlerts'
 import LocationPromptBanner from './LocationPromptBanner'
 import WeatherStrip from './WeatherStrip'
 import FrostWarningBanner, { FrostAffectedArea } from './FrostWarningBanner'
+import AitorOptInBanner from './AitorOptInBanner'
 import OnboardingWizard from '@/components/onboarding/OnboardingWizard'
 import PageTour from '@/components/onboarding/PageTour'
 import SignInPrompt from '@/components/auth/SignInPrompt'
+import { useOptionalAuth } from '@/hooks/useOptionalAuth'
 
 function LoadingSkeleton() {
   return (
@@ -65,7 +67,12 @@ export default function TodayDashboard() {
   const showLocationPrompt = !hasCoordinates && hasWaterTasks
 
   // Frost banner: tonight's forecast minimum + tender plantings in current season.
-  const { data } = useAllotment()
+  const { data, updateMeta } = useAllotment()
+  const { isSignedIn } = useOptionalAuth()
+  const showAitorOptIn =
+    isSignedIn &&
+    data?.meta?.aiAdvisorEnabled !== true &&
+    !data?.meta?.aiAdvisorPromptDismissedAt
   // Use local calendar day (en-CA gives YYYY-MM-DD) so the dismiss key rolls
   // over at the user's local midnight, not UTC midnight. Matches the
   // todayLocal() helper in useTodayData.ts.
@@ -143,6 +150,21 @@ export default function TodayDashboard() {
 
           {/* Quick Actions */}
           <QuickActions />
+
+          {/* One-time Aitor opt-in banner for signed-in users. */}
+          {showAitorOptIn && (
+            <AitorOptInBanner
+              onEnable={() =>
+                updateMeta({
+                  aiAdvisorEnabled: true,
+                  aiAdvisorPromptDismissedAt: new Date().toISOString(),
+                })
+              }
+              onDismiss={() =>
+                updateMeta({ aiAdvisorPromptDismissedAt: new Date().toISOString() })
+              }
+            />
+          )}
 
           {/* Optional banner: ask for location only when watering tasks exist
               and we don't yet have coordinates for rainfall lookup. */}

--- a/src/contexts/AitorChatContext.tsx
+++ b/src/contexts/AitorChatContext.tsx
@@ -2,12 +2,21 @@
 
 import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
 
+export type AitorChatMode = 'chat' | 'diagnose'
+
+interface OpenChatOptions {
+  initialMessage?: string
+  initialMode?: AitorChatMode
+}
+
 interface AitorChatContextType {
   isOpen: boolean
-  openChat: (initialMessage?: string) => void
+  openChat: (options?: OpenChatOptions | string) => void
   closeChat: () => void
   initialMessage: string | null
   clearInitialMessage: () => void
+  initialMode: AitorChatMode
+  clearInitialMode: () => void
 }
 
 const AitorChatContext = createContext<AitorChatContextType | null>(null)
@@ -15,10 +24,17 @@ const AitorChatContext = createContext<AitorChatContextType | null>(null)
 export function AitorChatProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false)
   const [initialMessage, setInitialMessage] = useState<string | null>(null)
+  const [initialMode, setInitialMode] = useState<AitorChatMode>('chat')
 
-  const openChat = useCallback((message?: string) => {
-    if (message) {
-      setInitialMessage(message)
+  const openChat = useCallback((options?: OpenChatOptions | string) => {
+    if (typeof options === 'string') {
+      setInitialMessage(options)
+      setInitialMode('chat')
+    } else if (options) {
+      if (options.initialMessage) setInitialMessage(options.initialMessage)
+      setInitialMode(options.initialMode ?? 'chat')
+    } else {
+      setInitialMode('chat')
     }
     setIsOpen(true)
   }, [])
@@ -31,6 +47,10 @@ export function AitorChatProvider({ children }: { children: ReactNode }) {
     setInitialMessage(null)
   }, [])
 
+  const clearInitialMode = useCallback(() => {
+    setInitialMode('chat')
+  }, [])
+
   return (
     <AitorChatContext.Provider
       value={{
@@ -39,6 +59,8 @@ export function AitorChatProvider({ children }: { children: ReactNode }) {
         closeChat,
         initialMessage,
         clearInitialMessage,
+        initialMode,
+        clearInitialMode,
       }}
     >
       {children}

--- a/src/services/storage-migrations.ts
+++ b/src/services/storage-migrations.ts
@@ -144,6 +144,15 @@ export function migrateSchema(data: AllotmentData): AllotmentData {
     return migrateSchema(migrated)
   }
 
+  // Version 21 -> 22: Added meta.aiAdvisorEnabled and meta.aiAdvisorPromptDismissedAt
+  // for per-user Aitor opt-in. No data transform needed — both fields are optional
+  // and default to undefined (treated as opted-out / not yet prompted).
+  if (migrated.version < 22) {
+    migrated.version = 22
+    logger.info('Schema migration complete', { from: 21, to: 22, change: 'added meta.aiAdvisorEnabled / aiAdvisorPromptDismissedAt for Aitor opt-in' })
+    return migrateSchema(migrated)
+  }
+
   migrated.version = CURRENT_SCHEMA_VERSION
   return migrated
 }

--- a/src/types/unified-allotment.ts
+++ b/src/types/unified-allotment.ts
@@ -197,6 +197,14 @@ export interface AllotmentMeta {
   createdAt: string                  // ISO date string
   updatedAt: string                  // ISO date string
   setupCompleted?: boolean           // Whether the setup wizard has been completed
+  /**
+   * Per-user opt-in for the Aitor AI advisor (v22). When undefined or false,
+   * the chat launcher stays hidden even for signed-in users. The Today
+   * dashboard shows a one-time banner that flips this on.
+   */
+  aiAdvisorEnabled?: boolean
+  /** ISO timestamp of when the user dismissed the Aitor opt-in banner. */
+  aiAdvisorPromptDismissedAt?: string
 }
 
 /**
@@ -474,7 +482,7 @@ export type VarietyUpdate = Partial<Omit<StoredVariety, 'id'>>
 // ============ STORAGE CONSTANTS ============
 
 export { STORAGE_KEY_ALLOTMENT as STORAGE_KEY } from '@/lib/storage-keys'
-export const CURRENT_SCHEMA_VERSION = 21 // Add meta.frostDates for frost-aware planning
+export const CURRENT_SCHEMA_VERSION = 22 // Add meta.aiAdvisorEnabled / aiAdvisorPromptDismissedAt for Aitor opt-in
 
 // ============ HELPER TYPES ============
 


### PR DESCRIPTION
## Summary
- Replaces the implicit "signed-in == opted-in" behaviour with an explicit per-user `meta.aiAdvisorEnabled` flag (schema v22, no-op data migration; `aiAdvisorPromptDismissedAt` added alongside).
- Adds a one-time Today-dashboard banner that flips the opt-in or records the dismissal so we don't nag.
- Adds a "Diagnose a plant" launcher next to the chat button that opens the modal in diagnose mode (auto-opens the photo picker, prepends a diagnosis-focused hint to the allotment context the model sees).
- Refreshes `QuickTopics` with four concrete starter prompts in place of the dynamic suggestion grid.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test:unit` (947 passed; new `v22-migration` and `AitorAuthGate` suites)
- [ ] Manual: signed-out user sees no Aitor UI and no banner
- [ ] Manual: signed-in opted-out user sees the banner; "Try Aitor" enables the launcher and dismisses; "Maybe later" hides it without enabling
- [ ] Manual: opted-in user sees both launchers; "Diagnose a plant" auto-opens the photo picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)