### PR TITLE
feat(allotment): collapse Boost-this-bed by default

### DIFF
--- a/src/components/allotment/BoostThisBed.tsx
+++ b/src/components/allotment/BoostThisBed.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Sparkles, Plus, Sprout } from 'lucide-react'
+import { useId, useState } from 'react'
+import { Sparkles, Plus, Sprout, ChevronRight, ChevronDown } from 'lucide-react'
 import type { Planting, StoredVariety } from '@/types/unified-allotment'
 import { getBoostSuggestions } from '@/lib/boost-suggestions'
 
@@ -17,44 +18,62 @@ export default function BoostThisBed({
   selectedYear,
   onAddSuggestion,
 }: BoostThisBedProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const listId = useId()
   const suggestions = getBoostSuggestions(plantings, varieties, selectedYear)
   if (suggestions.length === 0) return null
 
   return (
     <div className="bg-zen-moss-50 border border-zen-moss-100 rounded-zen p-3 mb-4">
-      <div className="flex items-center gap-1.5 text-xs font-medium text-zen-moss-700 mb-2">
-        <Sparkles className="w-3.5 h-3.5" />
-        Boost this bed
-      </div>
-      <ul className="space-y-1.5">
-        {suggestions.map((suggestion) => (
-          <li key={suggestion.plantId} className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => onAddSuggestion(suggestion.plantId)}
-              className="flex-1 flex items-center justify-between gap-2 text-left px-2 py-2 min-h-[44px] rounded-zen bg-white hover:bg-zen-moss-100 border border-zen-moss-100 transition"
-              title={`Pairs with ${suggestion.pairsWith.join(', ')}`}
-            >
-              <span className="flex flex-col">
-                <span className="flex items-center gap-1.5 text-sm text-zen-ink-800">
-                  <span className="font-medium">{suggestion.plantName}</span>
-                  {suggestion.hasSeed && (
-                    <span
-                      className="inline-flex items-center gap-0.5 text-xs text-zen-moss-700"
-                      title="You have seed for this"
-                    >
-                      <Sprout className="w-3 h-3" />
-                      seed
-                    </span>
-                  )}
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        aria-expanded={isExpanded}
+        aria-controls={listId}
+        className="w-full flex items-center justify-between gap-2 min-h-[44px] text-xs font-medium text-zen-moss-700 hover:text-zen-moss-800 transition-colors"
+      >
+        <span className="flex items-center gap-1.5">
+          <Sparkles className="w-3.5 h-3.5" />
+          Boost this bed
+          <span className="text-zen-stone-500 font-normal">({suggestions.length})</span>
+        </span>
+        {isExpanded ? (
+          <ChevronDown className="w-4 h-4 text-zen-moss-600" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-zen-moss-600" />
+        )}
+      </button>
+      {isExpanded && (
+        <ul id={listId} className="space-y-1.5 mt-2">
+          {suggestions.map((suggestion) => (
+            <li key={suggestion.plantId} className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => onAddSuggestion(suggestion.plantId)}
+                className="flex-1 flex items-center justify-between gap-2 text-left px-2 py-2 min-h-[44px] rounded-zen bg-white hover:bg-zen-moss-100 border border-zen-moss-100 transition"
+                title={`Pairs with ${suggestion.pairsWith.join(', ')}`}
+              >
+                <span className="flex flex-col">
+                  <span className="flex items-center gap-1.5 text-sm text-zen-ink-800">
+                    <span className="font-medium">{suggestion.plantName}</span>
+                    {suggestion.hasSeed && (
+                      <span
+                        className="inline-flex items-center gap-0.5 text-xs text-zen-moss-700"
+                        title="You have seed for this"
+                      >
+                        <Sprout className="w-3 h-3" />
+                        seed
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-xs text-zen-stone-500">{suggestion.reason}</span>
                 </span>
-                <span className="text-xs text-zen-stone-500">{suggestion.reason}</span>
-              </span>
-              <Plus className="w-4 h-4 text-zen-moss-600 flex-shrink-0" />
-            </button>
-          </li>
-        ))}
-      </ul>
+                <Plus className="w-4 h-4 text-zen-moss-600 flex-shrink-0" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/tests/boost-this-bed-collapse.spec.ts
+++ b/tests/boost-this-bed-collapse.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test'
+
+// Seeds a rotation bed containing a single Carrot planting. Carrot has
+// `enhancedCompanions` in the bundled vegetable database, so the
+// "Boost this bed" section will produce at least one suggestion.
+async function seedBedWithCarrot(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    const now = new Date().toISOString()
+    const currentYear = new Date().getFullYear()
+    const testData = {
+      version: 18,
+      meta: {
+        name: 'My Allotment',
+        location: 'Edinburgh, Scotland',
+        createdAt: now,
+        updatedAt: now,
+      },
+      layout: {
+        areas: [
+          {
+            id: 'test-bed-a',
+            name: 'Test Bed A',
+            kind: 'rotation-bed',
+            position: { x: 0, y: 0, w: 2, h: 2 },
+          },
+        ],
+      },
+      seasons: [
+        {
+          year: currentYear,
+          status: 'current',
+          areas: [
+            {
+              areaId: 'test-bed-a',
+              rotationGroup: 'roots',
+              plantings: [
+                {
+                  id: 'planting-carrot-1',
+                  plantId: 'carrot',
+                  status: 'planned',
+                },
+              ],
+              notes: [],
+            },
+          ],
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      currentYear,
+      maintenanceTasks: [],
+      varieties: [],
+      gardenEvents: [],
+    }
+    localStorage.setItem('allotment-unified-data', JSON.stringify(testData))
+    localStorage.setItem(
+      'bonnie-wee-plot-tours',
+      JSON.stringify({ disabled: true, completed: [], dismissed: [], pageVisits: {} })
+    )
+  })
+  await page.reload()
+  await page.waitForLoadState('domcontentloaded')
+  await page.locator('.animate-spin').waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {})
+  await page.locator('h1').filter({ hasText: /Plot Layout/i }).waitFor({ state: 'visible', timeout: 30000 })
+}
+
+async function openTestBed(page: import('@playwright/test').Page) {
+  const gridItem = page.locator('[class*="react-grid-item"]').filter({ hasText: 'Test Bed A' }).first()
+  const mobileItem = page.getByRole('button').filter({ hasText: 'Test Bed A' }).first()
+  const target = (await gridItem.isVisible({ timeout: 5000 }).catch(() => false))
+    ? gridItem
+    : mobileItem
+  await expect(target).toBeVisible({ timeout: 10000 })
+  await target.click()
+}
+
+test.describe('Boost this bed — collapsible', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/allotment')
+    await seedBedWithCarrot(page)
+  })
+
+  test('is collapsed by default and can be expanded and re-collapsed', async ({ page }) => {
+    await openTestBed(page)
+
+    // The toggle is rendered with the section title and chevron.
+    const toggle = page.getByRole('button', { name: /Boost this bed/i }).first()
+    await expect(toggle).toBeVisible({ timeout: 10000 })
+
+    // Default state: collapsed.
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    // Suggestion list is not in the DOM while collapsed.
+    const controlsId = await toggle.getAttribute('aria-controls')
+    expect(controlsId).toBeTruthy()
+    const list = page.locator(`#${controlsId}`)
+    await expect(list).toHaveCount(0)
+
+    // Expand: aria-expanded flips and the list appears.
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(list).toBeVisible()
+    // At least one suggestion item is rendered.
+    await expect(list.locator('li').first()).toBeVisible()
+
+    // Collapse again: list goes away.
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(list).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary
- BoostThisBed now starts collapsed and shows just the header (title, suggestion count, chevron-right). Click expands; click again collapses.
- State lives inside the component (useState), so BedDetailPanel and MobileAreaBottomSheet inherit the new behaviour with no prop changes. Zero-suggestion fallback is unchanged.
- Toggle uses the project a11y bar (`aria-expanded`, `aria-controls`, `min-h-[44px]`) and Zen design tokens — no raw Tailwind colors.

## Test plan
- [x] `npm run lint` passes.
- [x] `npm run type-check` passes.
- [x] `npx vitest run src/__tests__/lib/boost-suggestions.test.ts` (existing logic unchanged).
- [x] New e2e: `tests/boost-this-bed-collapse.spec.ts` covers default-collapsed, expand, re-collapse for a seeded carrot bed.