### PR TITLE
fix(history): stop View-changes diff dialog from re-fetching in a loop

### DIFF
--- a/src/__tests__/components/CloudHistoryDiffDialog.test.tsx
+++ b/src/__tests__/components/CloudHistoryDiffDialog.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import CloudHistoryDiffDialog from '@/components/settings/CloudHistoryDiffDialog'
+
+const mockFetchHistorySnapshot = vi.fn()
+vi.mock('@/lib/supabase/sync', () => ({
+  fetchHistorySnapshot: (...args: unknown[]) => mockFetchHistorySnapshot(...args),
+}))
+
+vi.mock('@/services/allotment-storage', () => ({
+  loadAllotmentData: () => ({
+    success: true,
+    data: { version: 22, meta: {}, layout: { areas: [] }, seasons: [], varieties: [] },
+  }),
+}))
+
+vi.mock('@/components/ui/Dialog', () => ({
+  default: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div data-testid="dialog">{children}</div> : null,
+}))
+
+const baseSnapshot = {
+  version: 21,
+  meta: { name: 'Test', updatedAt: '2026-04-01T12:00:00Z' },
+  layout: { areas: [{ id: 'a1', name: 'Bed A', kind: 'rotation-bed' }] },
+  seasons: [],
+  varieties: [{ id: 'v1', name: 'Tomato' }],
+} as unknown as Parameters<typeof CloudHistoryDiffDialog>[0]['archivedAt'] extends string
+  ? import('@/types/unified-allotment').AllotmentData
+  : never
+
+describe('CloudHistoryDiffDialog — load loop regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchHistorySnapshot.mockResolvedValue(baseSnapshot)
+  })
+
+  it('runs the diff load exactly once even when onDiffComputed is a new function each render', async () => {
+    const computed: Array<unknown> = []
+    const getToken = vi.fn().mockResolvedValue('test-token')
+
+    function Harness() {
+      // Inline arrow → fresh reference on every parent render. Without the
+      // ref-based callback in the dialog, this produced an infinite reload
+      // loop ("View changes" stuck on the spinner).
+      return (
+        <CloudHistoryDiffDialog
+          isOpen={true}
+          onClose={() => undefined}
+          baseId={1}
+          newerId={undefined}
+          archivedAt="2026-05-09T12:00:00Z"
+          getToken={getToken}
+          userId="user-123"
+          onDiffComputed={(d) => {
+            computed.push(d)
+          }}
+        />
+      )
+    }
+
+    const { rerender } = render(<Harness />)
+
+    // Wait for the initial load + first diff computation to settle.
+    await waitFor(() => {
+      expect(computed.length).toBeGreaterThanOrEqual(1)
+    })
+
+    // Force several parent rerenders. With the bug, each rerender would
+    // trigger a fresh load + onDiffComputed call. With the fix (callback
+    // ref + callback removed from effect deps), the load stays at 1.
+    for (let i = 0; i < 5; i++) {
+      rerender(<Harness />)
+      await Promise.resolve()
+    }
+
+    // The base snapshot fetch should have happened exactly once.
+    expect(mockFetchHistorySnapshot).toHaveBeenCalledTimes(1)
+    // And the callback should have fired exactly once.
+    expect(computed.length).toBe(1)
+  })
+})

--- a/src/components/settings/CloudHistoryDiffDialog.tsx
+++ b/src/components/settings/CloudHistoryDiffDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AlertTriangle, Loader2 } from 'lucide-react'
 import Dialog from '@/components/ui/Dialog'
 import { fetchHistorySnapshot } from '@/lib/supabase/sync'
@@ -52,6 +52,17 @@ export default function CloudHistoryDiffDialog({
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [diff, setDiff] = useState<AllotmentDiff | null>(null)
+
+  // Hold the latest onDiffComputed in a ref so the load effect can call the
+  // freshest callback without needing it as a dep. Parents typically pass an
+  // inline arrow that's recreated every render — including it in deps would
+  // refire the effect after each setDiff → parent setState → rerender →
+  // fresh callback ref → loop, which is what made "View changes" appear
+  // stuck on a permanent loading spinner.
+  const onDiffComputedRef = useRef(onDiffComputed)
+  useEffect(() => {
+    onDiffComputedRef.current = onDiffComputed
+  }, [onDiffComputed])
 
   useEffect(() => {
     if (!isOpen) {
@@ -109,7 +120,7 @@ export default function CloudHistoryDiffDialog({
 
         const computed = diffAllotment(base, comparedAgainst)
         setDiff(computed)
-        onDiffComputed?.(computed)
+        onDiffComputedRef.current?.(computed)
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Failed to load snapshot')
@@ -123,7 +134,7 @@ export default function CloudHistoryDiffDialog({
     return () => {
       cancelled = true
     }
-  }, [isOpen, baseId, newerId, getToken, userId, onDiffComputed])
+  }, [isOpen, baseId, newerId, getToken, userId])
 
   return (
     <Dialog


### PR DESCRIPTION
## Summary

The "View changes" dialog the user added in #340 got stuck on a permanent loading spinner. Root cause: `CloudHistoryDiffDialog`'s load effect kept `onDiffComputed` in its dep array, but the parent (`CloudHistorySection.tsx:209`) passes an inline arrow that's recreated on every render. Each diff load fired the callback → parent setState → parent rerender → new callback ref → effect refires → fetch again → loop.

Fix: hold the latest `onDiffComputed` in a ref inside the dialog and drop it from the effect deps. The load now runs exactly once per `(isOpen, baseId, newerId, getToken, userId)` change regardless of parent re-render churn. Single-file fix in the dialog, defensive against any future parent that passes an unstable callback.

## Test plan

- [x] New regression test in `src/__tests__/components/CloudHistoryDiffDialog.test.tsx` — five parent rerenders trigger exactly one `fetchHistorySnapshot` call and one `onDiffComputed` invocation
- [x] `npm run lint` clean
- [x] `npm run type-check` clean
- [ ] Manual verification post-merge: open Settings → Data → Cloud history → click "View changes" on any row → spinner clears within ~1s and the diff renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)