### PR TITLE
fix(today): open Aitor chat when user clicks Try Aitor

### DIFF
--- a/src/components/dashboard/TodayDashboard.tsx
+++ b/src/components/dashboard/TodayDashboard.tsx
@@ -17,6 +17,7 @@ import OnboardingWizard from '@/components/onboarding/OnboardingWizard'
 import PageTour from '@/components/onboarding/PageTour'
 import SignInPrompt from '@/components/auth/SignInPrompt'
 import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+import { useAitorChat } from '@/contexts/AitorChatContext'
 
 function LoadingSkeleton() {
   return (
@@ -69,6 +70,7 @@ export default function TodayDashboard() {
   // Frost banner: tonight's forecast minimum + tender plantings in current season.
   const { data, updateMeta } = useAllotment()
   const { isSignedIn } = useOptionalAuth()
+  const { openChat } = useAitorChat()
   const showAitorOptIn =
     isSignedIn &&
     data?.meta?.aiAdvisorEnabled !== true &&
@@ -154,12 +156,13 @@ export default function TodayDashboard() {
           {/* One-time Aitor opt-in banner for signed-in users. */}
           {showAitorOptIn && (
             <AitorOptInBanner
-              onEnable={() =>
+              onEnable={() => {
                 updateMeta({
                   aiAdvisorEnabled: true,
                   aiAdvisorPromptDismissedAt: new Date().toISOString(),
                 })
-              }
+                openChat()
+              }}
               onDismiss={() =>
                 updateMeta({ aiAdvisorPromptDismissedAt: new Date().toISOString() })
               }


### PR DESCRIPTION
## Summary
- Banner's "Try Aitor" button only flipped `meta.aiAdvisorEnabled` / `aiAdvisorPromptDismissedAt`; the chat never opened, so the click felt like a no-op (the floating launcher at `bottom-6 right-6` is easy to miss on a long Today page).
- Wire the banner's `onEnable` to also call `openChat()` so the label matches the behaviour.

## Test plan
- [ ] `npm run dev`, sign in, land on Today, click **Try Aitor** → chat modal opens and banner is gone on next render
- [ ] Click **Maybe later** → banner dismisses without opening chat; floating launcher does not appear (opt-in flag still off)
- [ ] Reload after **Try Aitor** → banner stays gone, floating "Ask Aitor" / "Diagnose a plant" buttons appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)