### PR TITLE
fix(ai): unblock free-tier Gemini + Turn off Aitor from the chat

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -77,6 +77,27 @@ export default function SettingsPage() {
                       Signed-in users get a free monthly quota; add your own OpenAI key below for unlimited use.
                     </p>
 
+                    <div className="flex items-center justify-between gap-3 mb-4 p-3 rounded-md bg-zen-stone-50 border border-zen-stone-200">
+                      <div className="text-sm text-zen-ink-700">
+                        <p className="font-medium">Aitor chat</p>
+                        <p className="text-xs text-zen-stone-500 mt-0.5">
+                          {data?.meta?.aiAdvisorEnabled
+                            ? 'Currently on. Floating chat launcher is visible on every page.'
+                            : 'Currently off. Turn on to use Aitor.'}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => updateMeta({ aiAdvisorEnabled: !data?.meta?.aiAdvisorEnabled })}
+                        className={`px-3 py-2 min-h-[44px] text-sm rounded-zen transition-colors shrink-0 ${
+                          data?.meta?.aiAdvisorEnabled
+                            ? 'bg-zen-stone-200 hover:bg-zen-stone-300 text-zen-ink-700'
+                            : 'bg-zen-moss-600 hover:bg-zen-moss-700 text-white'
+                        }`}
+                      >
+                        {data?.meta?.aiAdvisorEnabled ? 'Turn off' : 'Turn on'}
+                      </button>
+                    </div>
+
                     <div className="mb-4">
                       <AiQuotaSection hasOwnToken={!!token} />
                     </div>

--- a/src/components/ai-advisor/AitorChatModal.tsx
+++ b/src/components/ai-advisor/AitorChatModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { Leaf } from 'lucide-react'
+import { Leaf, PowerOff } from 'lucide-react'
 import type { ChatMessage as ChatMessageType } from '@/types/api'
 
 // Extracted hooks
@@ -70,7 +70,13 @@ export default function AitorChatModal() {
 
   // Load allotment data for context
   const allotment = useAllotment()
-  const { data: allotmentData, currentSeason, selectedYear, getAreasByKind, reload: reloadAllotment } = allotment
+  const { data: allotmentData, currentSeason, selectedYear, getAreasByKind, reload: reloadAllotment, updateMeta } = allotment
+
+  const handleDisableAitor = useCallback(() => {
+    updateMeta({ aiAdvisorEnabled: false })
+    clearInitialMode()
+    closeChat()
+  }, [updateMeta, clearInitialMode, closeChat])
 
   // Scroll to bottom when new messages arrive
   useEffect(() => {
@@ -189,10 +195,9 @@ export default function AitorChatModal() {
     updateRateLimitState()
 
     try {
-      // Check if token is provided
-      if (!token) {
-        throw new Error('Please configure your OpenAI API key in Settings to use Aitor')
-      }
+      // No early-throw on empty token: signed-in users hit the server-side
+      // free-tier Gemini path when no BYO key is set. The /api/ai-advisor
+      // route returns a friendly error if the free tier itself is unavailable.
 
       // Prepare enhanced message with location context
       let enhancedQuery = query
@@ -427,17 +432,28 @@ export default function AitorChatModal() {
         <div className="flex flex-col h-[70vh] md:h-[600px]">
           {/* Header info */}
           <div className="px-4 py-3 border-b border-zen-stone-100 bg-zen-moss-50/50 shrink-0">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Leaf className="w-4 h-4 text-zen-moss-600" />
-                <span className="text-sm text-zen-moss-700">Your gardening companion</span>
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 min-w-0">
+                <Leaf className="w-4 h-4 text-zen-moss-600 shrink-0" />
+                <span className="text-sm text-zen-moss-700 truncate">Your gardening companion</span>
               </div>
-              <LocationStatus
-                userLocation={userLocation}
-                locationError={locationError}
-                onRetry={detectUserLocation}
-                isDetecting={isDetecting}
-              />
+              <div className="flex items-center gap-2 shrink-0">
+                <LocationStatus
+                  userLocation={userLocation}
+                  locationError={locationError}
+                  onRetry={detectUserLocation}
+                  isDetecting={isDetecting}
+                />
+                <button
+                  onClick={handleDisableAitor}
+                  className="flex items-center gap-1 text-xs text-zen-stone-500 hover:text-zen-kitsune-600 transition-colors px-2 py-1 min-h-[44px] md:min-h-0"
+                  aria-label="Turn off Aitor — you can re-enable it from Settings"
+                  title="Turn off Aitor (re-enable from Settings)"
+                >
+                  <PowerOff className="w-3.5 h-3.5" aria-hidden="true" />
+                  <span className="hidden sm:inline">Turn off</span>
+                </button>
+              </div>
             </div>
           </div>
 

--- a/src/lib/openai-client.ts
+++ b/src/lib/openai-client.ts
@@ -59,6 +59,7 @@ export interface OpenAIToolCall {
 }
 
 export interface OpenAIClientOptions {
+  /** OpenAI API key. Empty string routes through the server-side free-tier (Gemini). */
   apiToken: string
   message: string
   messages?: IncomingMessage[]
@@ -172,12 +173,18 @@ Your goal is to help every gardener succeed, whether they're just starting their
 export async function callOpenAI(options: OpenAIClientOptions): Promise<OpenAIResponse> {
   // Try API route first (works in local dev)
   try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    // Only forward the BYO key when the user has actually provided one — an
+    // empty header would block the server from falling through to the
+    // free-tier Gemini path.
+    if (options.apiToken) {
+      headers['x-openai-token'] = options.apiToken
+    }
     const response = await fetch('/api/ai-advisor', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-openai-token': options.apiToken
-      },
+      headers,
       body: JSON.stringify({
         message: options.message,
         messages: options.messages,
@@ -253,7 +260,11 @@ Available tools:
 async function callOpenAIDirect(options: OpenAIClientOptions): Promise<OpenAIResponse> {
   const { apiToken, message, messages = [], image, allotmentContext, enableTools, tools } = options
 
-  // Validate token format
+  // Direct OpenAI calls require a BYO key (the server-side free tier is
+  // unavailable in static deployments).
+  if (!apiToken) {
+    throw new Error('OpenAI API key is required for this deployment. Add one in Settings → AI & Location.')
+  }
   const tokenPattern = /^[a-zA-Z0-9\-_]{20,}$/
   if (!tokenPattern.test(apiToken)) {
     throw new Error('Invalid OpenAI API token format. Token should be at least 20 characters long and contain only letters, numbers, dashes, and underscores.')


### PR DESCRIPTION
## Summary
- Drop the \`!token\` early-throw in \`AitorChatModal\` so the request actually reaches \`/api/ai-advisor\` when the user has no BYO OpenAI key — the server already routes to the free-tier Gemini path in that case. Also omit the \`x-openai-token\` header in \`openai-client.ts\` when no token is set; the static-deployment \`callOpenAIDirect\` fallback still requires a key and now says so plainly.
- Add a "Turn off" button in the chat modal header that flips \`meta.aiAdvisorEnabled = false\` and closes the chat.
- Mirror that as a Turn on / Turn off toggle in **Settings → AI & Location** so users can re-enable without poking localStorage.

## Test plan
- [ ] Sign in without setting an OpenAI key → open Aitor → ask a question → response comes back from the free tier (or a friendly quota / config error from the server, not the "Getting Started" config-error wall)
- [ ] Click "Turn off" in the chat header → floating launcher disappears; banner does not reappear
- [ ] Settings → AI & Location → Turn on → floating launcher reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)