### PR TITLE
fix(sql): revoke EXECUTE on archive trigger fn from anon/authenticated

### DIFF
--- a/sql/002-allotment-history.sql
+++ b/sql/002-allotment-history.sql
@@ -54,17 +54,6 @@ $$;
 -- function in place and the existing trigger picks up the new body
 -- automatically — no need to drop and recreate the trigger.
 
--- Lock down direct callers. The function is only intended to fire via the
--- BEFORE UPDATE trigger on `allotments`, not as a PostgREST RPC. Triggers
--- run with the table owner's privileges regardless of the function ACL,
--- so revoking EXECUTE here does NOT break the trigger — it only stops the
--- function from being reachable at /rest/v1/rpc/archive_allotment_before_update.
--- If you've already deployed the function without these revokes, re-run just
--- the REVOKE statements below on the existing database.
-REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM anon;
-REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM authenticated;
-
 CREATE TRIGGER trg_archive_allotment_before_update
   BEFORE UPDATE ON allotments
   FOR EACH ROW

--- a/sql/002-allotment-history.sql
+++ b/sql/002-allotment-history.sql
@@ -54,6 +54,17 @@ $$;
 -- function in place and the existing trigger picks up the new body
 -- automatically — no need to drop and recreate the trigger.
 
+-- Lock down direct callers. The function is only intended to fire via the
+-- BEFORE UPDATE trigger on `allotments`, not as a PostgREST RPC. Triggers
+-- run with the table owner's privileges regardless of the function ACL,
+-- so revoking EXECUTE here does NOT break the trigger — it only stops the
+-- function from being reachable at /rest/v1/rpc/archive_allotment_before_update.
+-- If you've already deployed the function without these revokes, re-run just
+-- the REVOKE statements below on the existing database.
+REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM authenticated;
+
 CREATE TRIGGER trg_archive_allotment_before_update
   BEFORE UPDATE ON allotments
   FOR EACH ROW

--- a/sql/004-revoke-rpc-permissions.sql
+++ b/sql/004-revoke-rpc-permissions.sql
@@ -1,0 +1,17 @@
+-- Bonnie Wee Plot: revoke PostgREST RPC surface on archive trigger function
+-- Run this in the Supabase SQL Editor against any project that has already
+-- deployed sql/002-allotment-history.sql.
+--
+-- Background: `public.archive_allotment_before_update()` is SECURITY DEFINER
+-- (it has to be, to insert into `allotment_history` past RLS). The function
+-- is only meant to fire via the BEFORE UPDATE trigger on `allotments`, but
+-- by default Supabase exposes any function in the `public` schema as a
+-- PostgREST RPC at `/rest/v1/rpc/<name>`. The Supabase security advisor
+-- flags this (lints 0028 + 0029).
+--
+-- Triggers run with the table owner's privileges regardless of the function
+-- ACL, so revoking EXECUTE from PUBLIC / anon / authenticated does NOT break
+-- the trigger — it only closes the RPC surface.
+
+REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update()
+  FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
## Summary
- The Supabase security advisor flagged `public.archive_allotment_before_update()` (lints [0028](https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable) and [0029](https://supabase.com/docs/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable)): it's `SECURITY DEFINER` and reachable as a PostgREST RPC at `/rest/v1/rpc/archive_allotment_before_update` by both `anon` and `authenticated`. It was only ever meant to fire via the `BEFORE UPDATE` trigger on `allotments`.
- Adds `REVOKE EXECUTE` from `PUBLIC`, `anon`, and `authenticated` to the function's deployment script. Triggers run with the table owner's privileges regardless of the function ACL, so the trigger keeps working — only the RPC surface closes.

## Why SECURITY DEFINER stays
The function inserts into `allotment_history`, which has RLS allowing users only to SELECT/DELETE their own rows (no INSERT policy). `SECURITY DEFINER` is the documented way to let the trigger bypass that — switching to `SECURITY INVOKER` would break the audit insert. The right fix is restricting *who can call the function*, not how it runs.

## Applying to the live DB
After merge, run just the three `REVOKE EXECUTE` statements in the Supabase SQL Editor against the production project (`tjgxszrzhumzgmtizmqr`). The rest of `sql/002-allotment-history.sql` is already deployed and untouched.

```sql
REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM PUBLIC;
REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM anon;
REVOKE EXECUTE ON FUNCTION public.archive_allotment_before_update() FROM authenticated;
```

## Test plan
- [ ] After applying to prod, re-run the Supabase security advisor and confirm both lints are gone.
- [ ] Verify the BEFORE UPDATE trigger still archives by saving an allotment and checking a new `allotment_history` row appears.
- [ ] Confirm `POST /rest/v1/rpc/archive_allotment_before_update` returns 401/403 (or "not exposed") instead of executing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)