### PR TITLE
spike(yjs): ADR 027 Step 2 first cut — SyncedStore PoC (not for merge)

### DIFF
--- a/docs/adrs/027-sync-revisit.md
+++ b/docs/adrs/027-sync-revisit.md
@@ -42,6 +42,22 @@ The first step is this ADR (in flight). Subsequent steps live on a feature branc
 
 Step two converts `AllotmentData` to a Yjs document on a spike branch. The 192-entry vegetable database is static and stays as TypeScript modules — only mutable user state (`meta`, `seasons`, `varieties`, `customTasks`, `maintenanceTasks`, `gardenEvents`, `compost`) moves into the `Y.Doc`. The top-level shape maps to a `Y.Map` for `meta`, `Y.Array` for `seasons`, and so on. Rough sizing: a few days of work, not hours, mostly because every consumer of `setData` needs to learn to write through the Yjs APIs instead of replacing the root object. The spike should also evaluate a proxy wrapper such as `valtio/yjs` or `synced-store`, which let callers keep the existing immutable-style read/write idiom on top of Yjs and could cut the consumer refactor surface significantly if the developer experience holds up.
 
+### Step 2 first cut (2026-05-12, branch `spike/yjs-allotment`)
+
+A proof-of-concept landed in `src/lib/yjs-spike/allotment-yjs.ts` with 9 passing unit tests in `src/__tests__/lib/yjs-spike/`. Key decisions out of the cut:
+
+The proxy-wrapper question is resolved in favour of **SyncedStore** (`@syncedstore/core@^0.6`). The valtio-yjs alternative is explicitly self-described as alpha ("the experiment is finished, now it's in alpha") and would not be acceptable for a migration that touches every user's data. SyncedStore is production-tested via BlockNote, has a clean shape API, and its `getYjsDoc()` escape hatch keeps the raw Yjs surface available where needed.
+
+SyncedStore's shape validator imposes one constraint worth documenting up front: top-level entries must be exactly `{}`, `[]`, `"xml"`, or `"text"` — nested initializers throw `Root Object initializer must always be {}`. The legacy `AllotmentData.layout.areas` wrapper is therefore collapsed away in the Yjs shape (`areas` lifts to the top level) and reconstructed at the serialization boundary. The same constraint forces top-level primitives (`version`, `currentYear`) into a nested `state` Y.Map. Neither change is user-visible — the legacy JSON shape is preserved across the hydrate / serialize round-trip.
+
+`undefined` values must be dropped before assignment — Yjs cannot represent `undefined` and SyncedStore is inconsistent about whether it throws or silently drops. The `assignDefined` helper in the PoC walks the source object and skips undefined fields; the same discipline will apply to every write site in the Step 3 hook.
+
+Concurrent-edit semantics are confirmed in tests: two doc instances editing different plantings in the same bed merge cleanly; two doc instances editing the same field (an area name) converge to a deterministic single value. This is the headline win that the LWW machinery in `useSyncedStorage` cannot deliver.
+
+First binary-size measurement on a small fixture (one bed with 2 plantings, one tree, 2 varieties, one compost pile): JSON 2146B, Yjs binary 2594B, ratio 1.21. The Yjs payload is *larger* than the JSON at this size — CRDT metadata is a fixed overhead that only amortises away on bigger documents. The cost-line risk the ADR enumerates remains open until measured on a realistic multi-season fixture; the small-doc data point is a cautionary one for users who are barely past the onboarding wizard.
+
+Not addressed in this cut: integration with `useAllotment`, `y-indexeddb` persistence, Cloudflare Durable Object transport, Clerk JWT verification inside a Worker, and the dual-write migration. Step 3 picks up the integration; Steps 4–5 unchanged from the original outline.
+
 Step three replaces `useSyncedStorage` with a `useYjsDoc` hook. The `usePersistedStorage` semantics stay (local cache via `y-indexeddb` instead of raw localStorage) so the offline-first guarantee is preserved.
 
 Step four migrates live users. A one-shot import reads each user's current `allotments.data` JSONB row, hydrates a Yjs doc from it, and snapshots the binary state into a new `BYTEA` column (e.g. `allotments.yjs_state`) or a dedicated `allotment_yjs` table — `JSONB` cannot hold raw binary, so reusing `allotments.data` directly is not an option. The migration should run as a dual-write phase: keep updating both the legacy JSONB and the new Yjs binary for a short window so the cut-over is reversible per user if a decoding bug surfaces. The `allotment_history` table from #332 is the safety net during the migration — every user has at least one recovery point predating the migration.

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,6 @@
 # Current Plan
 
-Last updated: 2026-05-12 (Aitor free-tier client bug fixed in PR #351; ADR 027 Yjs spike Step 2 is the next deliberate work)
+Last updated: 2026-05-12 (ADR 027 Yjs spike Step 2 first cut on branch `spike/yjs-allotment`; Step 3 hook integration is the next deliberate work)
 
 ## What's Been Completed
 
@@ -341,9 +341,17 @@ The opt-in banner's "Try Aitor" button used to only flip `meta.aiAdvisorEnabled`
 
 After PR #345 added the server-side Gemini free tier, clicking Try Aitor still threw "Please configure your OpenAI API key in Settings" because two client-side guards bailed before the request reached `/api/ai-advisor`. PR #351 dropped the `!token` early-throw in `AitorChatModal.tsx`, wrapped the `x-openai-token` header in an `if (options.apiToken)` check inside `openai-client.ts`, and kept the `tokenPattern` validator only in the static-deployment `callOpenAIDirect` fallback (which genuinely needs a BYO key because GitHub Pages can't reach the Gemini path). Signed-in users without a BYO key now hit Gemini cleanly; the modal's quota-exceeded (429) and config-error branches still match the failure modes they were written for, while any other server error (including the "JWT template missing" path) falls through to the generic "Temporary Connection Issue" message.
 
-### Up Next: ADR 027 Yjs spike, Step 2
+### ADR 027 Yjs spike Step 2 — First cut shipped (branch `spike/yjs-allotment`)
 
-With the Aitor free-tier path working end-to-end and no other open backlog, the next deliberate piece of work is Step 2 of the spike outlined in `docs/adrs/027-sync-revisit.md`: convert `AllotmentData` to a Yjs document on a feature branch, keeping the 192-entry vegetable database as TypeScript modules and moving only mutable user state (`meta`, `seasons`, `varieties`, `customTasks`, `maintenanceTasks`, `gardenEvents`, `compost`) into the `Y.Doc`. The ADR also flagged evaluating a proxy wrapper (`valtio/yjs` or `synced-store`) early in this step to see whether the immutable-style read/write idiom can be preserved on top of Yjs. Rough sizing: a few days of work, not hours, because every consumer of `setData` learns to write through Yjs APIs. Steps 3-5 (replace `useSyncedStorage`, migrate live users, retire the LWW machinery) are gated on Step 2 producing the cost/latency/auth measurements the ADR's risk section enumerates.
+A proof-of-concept conversion of `AllotmentData` to a Yjs document landed on the spike branch on 2026-05-12. `src/lib/yjs-spike/allotment-yjs.ts` defines the top-level shape, a `hydrateFromJson` helper that seeds from an existing `AllotmentData` snapshot inside a single Yjs transaction, a `serializeToJson` mirror, and `encodeDocState` / `decodeDocState` for the BYTEA round-trip the migration step will need. 9 unit tests in `src/__tests__/lib/yjs-spike/allotment-yjs.test.ts` cover hydrate-serialize round-trip, proxy mutations, binary encoding, and the two CRDT-semantics cases (disjoint edits and same-field convergence).
+
+Proxy-wrapper decision: **SyncedStore** (`@syncedstore/core@^0.6`) over valtio-yjs. valtio-yjs is self-described as alpha; SyncedStore is production-tested in BlockNote and has the clean `shape` API plus a `getYjsDoc()` escape hatch. Two shape constraints worth flagging: top-level entries must be empty `{}` / `[]` (the validator throws otherwise), so `AllotmentData.layout.areas` is hoisted to a top-level `areas` Y.Array and `version` / `currentYear` are nested inside a `state` Y.Map. Neither change is user-visible — the legacy JSON shape is reconstructed at the serialization boundary. The other constraint: `undefined` values must be dropped before assignment (Yjs has no `undefined`), enforced by the `assignDefined` helper.
+
+First cost-line measurement: on a small fixture (one bed with 2 plantings, one tree, 2 varieties, one compost pile, ~2.1KB JSON), the Yjs binary is 2.6KB — a 1.21x ratio *larger* than JSON. CRDT metadata is a fixed overhead that only amortises away on bigger documents. The cost-line risk in the ADR remains open until measured on a realistic multi-season fixture.
+
+### Up Next: ADR 027 Yjs spike Step 3 — replace `useSyncedStorage` with `useYjsDoc`
+
+Step 3 is the integration cut: wire the SyncedStore shape from Step 2 into the existing `useAllotment` → `useAllotmentData` → `useSyncedStorage` → `usePersistedStorage` chain. The target is a new `useYjsDoc` hook that preserves the `data: AllotmentData | null` read API (callers of `useAllotment` should see no shape change) while routing every write through SyncedStore's proxy. `y-indexeddb` replaces raw localStorage for offline persistence; the Cloudflare Durable Object transport is deferred to Step 4 (the migration step) so Step 3 can be reviewed and merged independently. Open question Step 3 needs to answer: whether every consumer of `setData` in `useAllotmentAreas`, `useAllotmentPlantings`, `useAllotmentVarieties`, and the other domain hooks can be ported by replacing the immutable update with an in-place mutation through the proxy, or whether a thin `withDraft(store, fn)` wrapper (Immer-style) is needed to keep the existing code shape. Steps 4–5 (migrate live users, retire the LWW machinery) are unchanged from the ADR outline.
 
 ### Research-Driven Improvements: Backlog
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@sentry/nextjs": "^10.52.0",
         "@serwist/next": "^9.5.11",
         "@supabase/supabase-js": "^2.105.4",
+        "@syncedstore/core": "^0.6.0",
         "@upstash/redis": "^1.38.0",
         "driver.js": "^1.4.0",
         "html5-qrcode": "^2.3.8",
@@ -25,6 +26,8 @@
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "web-vitals": "^5.2.0",
+        "y-indexeddb": "^9.0.12",
+        "yjs": "^13.6.30",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -2183,6 +2186,12 @@
         "module-details-from-path": "^1.0.4"
       }
     },
+    "node_modules/@reactivedata/reactive": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@reactivedata/reactive/-/reactive-0.2.2.tgz",
+      "integrity": "sha512-KnINM/Sng25QAv6sHkJO9q/XyslLegCF5jTsTSVu+AouY3uZDVf4Am99xNCqsfqFZFvnTBBDvCsHNdvTVGvPEA==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -3563,6 +3572,28 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@syncedstore/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@syncedstore/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-6TtjEoYJsceYi8u1oRecXwbbLmjHaU0S7HvVfOaEdDfphZLGm/faVuA2fpazqc28F0yIFGvYzvPEBUJn9vqRNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactivedata/reactive": "^0.2.0",
+        "@syncedstore/yjs-reactive-bindings": "^0.6.0"
+      },
+      "peerDependencies": {
+        "yjs": "^13.5.13"
+      }
+    },
+    "node_modules/@syncedstore/yjs-reactive-bindings": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@syncedstore/yjs-reactive-bindings/-/yjs-reactive-bindings-0.6.0.tgz",
+      "integrity": "sha512-VF78h0J4iOt79YU9d6j5E6bFKu7WXYuiI2ue9ZnA+T4SNVn8viRvg0AHm3NqHzudZZUgYT3dpnbv1/ZmU7yPZQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "yjs": "^13.5.13"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -8077,6 +8108,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -8363,6 +8404,27 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lightningcss": {
@@ -13627,6 +13689,26 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y-indexeddb": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -13647,6 +13729,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.30",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
+      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@sentry/nextjs": "^10.52.0",
     "@serwist/next": "^9.5.11",
     "@supabase/supabase-js": "^2.105.4",
+    "@syncedstore/core": "^0.6.0",
     "@upstash/redis": "^1.38.0",
     "driver.js": "^1.4.0",
     "html5-qrcode": "^2.3.8",
@@ -56,6 +57,8 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "web-vitals": "^5.2.0",
+    "y-indexeddb": "^9.0.12",
+    "yjs": "^13.6.30",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/__tests__/lib/yjs-spike/allotment-yjs.test.ts
+++ b/src/__tests__/lib/yjs-spike/allotment-yjs.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
+import {
+  createAllotmentDoc,
+  hydrateFromJson,
+  serializeToJson,
+  encodeDocState,
+  decodeDocState,
+} from '@/lib/yjs-spike/allotment-yjs'
+import type { AllotmentData } from '@/types/unified-allotment'
+
+function makeFixture(): AllotmentData {
+  return {
+    version: 22,
+    currentYear: 2026,
+    meta: {
+      name: 'Test Allotment',
+      location: 'Edinburgh',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2026-05-12T10:00:00.000Z',
+      coordinates: { latitude: 55.9533, longitude: -3.1883 },
+      frostDates: {
+        lastSpring: '2026-05-15',
+        firstAutumn: '2026-10-31',
+        fetchedAt: '2026-05-01T00:00:00.000Z',
+      },
+      aiAdvisorEnabled: true,
+    },
+    layout: {
+      areas: [
+        {
+          id: 'bed-a',
+          name: 'Bed A',
+          kind: 'rotation-bed',
+          canHavePlantings: true,
+          rotationGroup: 'legumes',
+          gridPosition: { x: 0, y: 0, w: 2, h: 1 },
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'apple-north',
+          name: 'North Apple',
+          kind: 'tree',
+          canHavePlantings: false,
+          primaryPlant: {
+            plantId: 'apple',
+            variety: 'Bramley',
+            plantedYear: 2020,
+            status: 'productive',
+          },
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+    },
+    seasons: [
+      {
+        year: 2026,
+        status: 'current',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-05-12T10:00:00.000Z',
+        areas: [
+          {
+            areaId: 'bed-a',
+            rotationGroup: 'legumes',
+            plantings: [
+              {
+                id: 'planting-1',
+                plantId: 'peas',
+                varietyName: 'Kelvedon Wonder',
+                sowDate: '2026-04-01',
+                sowMethod: 'outdoor',
+                status: 'active',
+              },
+              {
+                id: 'planting-2',
+                plantId: 'broad-beans',
+                sowDate: '2026-03-15',
+                sowMethod: 'outdoor',
+                status: 'active',
+              },
+            ],
+            notes: [
+              {
+                id: 'note-1',
+                content: 'Watch for slugs',
+                type: 'warning',
+                createdAt: '2026-04-02T00:00:00.000Z',
+                updatedAt: '2026-04-02T00:00:00.000Z',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    customTasks: [
+      {
+        id: 'task-1',
+        description: 'Order tomato seeds',
+        completed: false,
+        createdAt: '2026-01-10T00:00:00.000Z',
+      },
+    ],
+    maintenanceTasks: [
+      {
+        id: 'maint-1',
+        areaId: 'apple-north',
+        type: 'prune',
+        month: 1,
+        description: 'Winter prune',
+      },
+    ],
+    gardenEvents: [],
+    varieties: [
+      {
+        id: 'var-1',
+        plantId: 'peas',
+        name: 'Kelvedon Wonder',
+        supplier: 'Thompson & Morgan',
+        seedsByYear: { 2026: 'have', 2025: 'had' },
+      },
+      {
+        id: 'var-2',
+        plantId: 'tomato',
+        name: 'Gardener’s Delight',
+        seedsByYear: { 2026: 'ordered' },
+      },
+    ],
+    compost: [
+      {
+        id: 'pile-1',
+        name: 'Bay 1',
+        systemType: 'cold-compost',
+        status: 'active',
+        startDate: '2026-02-01',
+        inputs: [
+          {
+            id: 'input-1',
+            date: '2026-02-01',
+            material: 'Kitchen scraps',
+            type: 'green',
+          },
+        ],
+        events: [],
+        createdAt: '2026-02-01T00:00:00.000Z',
+        updatedAt: '2026-02-01T00:00:00.000Z',
+      },
+    ],
+  }
+}
+
+describe('yjs-spike: allotment-yjs', () => {
+  describe('hydrate + serialize round-trip', () => {
+    it('preserves the full AllotmentData shape', () => {
+      const original = makeFixture()
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, original)
+
+      const result = serializeToJson(store)
+
+      expect(result).toEqual(original)
+    })
+
+    it('drops undefined fields without throwing', () => {
+      const original: AllotmentData = {
+        ...makeFixture(),
+        // Optional meta fields left undefined — must not blow up the hydrate path
+        meta: {
+          name: 'Minimal',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      }
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, original)
+
+      const result = serializeToJson(store)
+      expect(result.meta).toEqual(original.meta)
+      expect(result.meta.coordinates).toBeUndefined()
+    })
+  })
+
+  describe('mutations through the proxy', () => {
+    it('reflects a new planting added via proxy mutation', () => {
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, makeFixture())
+
+      store.seasons[0].areas[0].plantings.push({
+        id: 'planting-3',
+        plantId: 'carrot',
+        sowDate: '2026-05-01',
+        sowMethod: 'outdoor',
+        status: 'active',
+      })
+
+      const result = serializeToJson(store)
+      expect(result.seasons[0].areas[0].plantings).toHaveLength(3)
+      expect(result.seasons[0].areas[0].plantings[2].plantId).toBe('carrot')
+    })
+
+    it('reflects a variety seedsByYear update', () => {
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, makeFixture())
+
+      store.varieties[1].seedsByYear[2026] = 'have'
+
+      const result = serializeToJson(store)
+      expect(result.varieties[1].seedsByYear[2026]).toBe('have')
+    })
+
+    it('reflects an area name rename', () => {
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, makeFixture())
+
+      store.areas[0].name = 'Bed A — peas + beans'
+
+      const result = serializeToJson(store)
+      expect(result.layout.areas[0].name).toBe('Bed A — peas + beans')
+    })
+  })
+
+  describe('binary state encoding', () => {
+    it('round-trips through encodeDocState / decodeDocState', () => {
+      const original = makeFixture()
+      const { store: src, doc: srcDoc } = createAllotmentDoc()
+      hydrateFromJson(src, original)
+
+      const update = encodeDocState(srcDoc)
+      expect(update).toBeInstanceOf(Uint8Array)
+      expect(update.length).toBeGreaterThan(0)
+
+      const { store: dst } = decodeDocState(update)
+      const result = serializeToJson(dst)
+      expect(result).toEqual(original)
+    })
+
+    it('reports a binary size noticeably smaller than the JSON', () => {
+      // Smoke test for the cost line ADR 027 is worried about. We log
+      // the ratio rather than asserting a bound — the spike just needs
+      // a first-look number.
+      const original = makeFixture()
+      const { store, doc } = createAllotmentDoc()
+      hydrateFromJson(store, original)
+
+      const binarySize = encodeDocState(doc).length
+      const jsonSize = new TextEncoder().encode(JSON.stringify(original)).length
+
+      console.log(
+        `[yjs-spike] fixture sizes — JSON: ${jsonSize}B, Yjs binary: ${binarySize}B, ratio: ${(
+          binarySize / jsonSize
+        ).toFixed(2)}`,
+      )
+      // Sanity floor — we just want a non-empty encoding.
+      expect(binarySize).toBeGreaterThan(0)
+    })
+  })
+
+  describe('CRDT semantics — the headline win', () => {
+    it('merges concurrent edits on different plantings without conflict', () => {
+      const original = makeFixture()
+      const { store: storeA, doc: docA } = createAllotmentDoc()
+      hydrateFromJson(storeA, original)
+
+      // Snapshot the doc and clone it to a second instance — simulates
+      // two devices that have synced the same baseline.
+      const baseline = encodeDocState(docA)
+      const { store: storeB, doc: docB } = decodeDocState(baseline)
+
+      // Device A renames Bed A. Device B adds a planting to Bed A.
+      // Pre-CRDT this would be a conflict requiring user resolution;
+      // here both should land.
+      storeA.areas[0].name = 'Bed A — renamed by A'
+      storeB.seasons[0].areas[0].plantings.push({
+        id: 'planting-3',
+        plantId: 'lettuce',
+        sowDate: '2026-05-01',
+        sowMethod: 'outdoor',
+        status: 'active',
+      })
+
+      // Cross-apply each side's updates to the other.
+      const updateFromA = Y.encodeStateAsUpdate(docA)
+      const updateFromB = Y.encodeStateAsUpdate(docB)
+      Y.applyUpdate(docB, updateFromA)
+      Y.applyUpdate(docA, updateFromB)
+
+      const resultA = serializeToJson(storeA)
+      const resultB = serializeToJson(storeB)
+
+      expect(resultA).toEqual(resultB)
+      expect(resultA.layout.areas[0].name).toBe('Bed A — renamed by A')
+      expect(resultA.seasons[0].areas[0].plantings).toHaveLength(3)
+      expect(resultA.seasons[0].areas[0].plantings[2].plantId).toBe('lettuce')
+    })
+
+    it('handles concurrent edits to the same field via last-writer-wins on the Y.Map', () => {
+      const original = makeFixture()
+      const { store: storeA, doc: docA } = createAllotmentDoc()
+      hydrateFromJson(storeA, original)
+      const baseline = encodeDocState(docA)
+      const { store: storeB, doc: docB } = decodeDocState(baseline)
+
+      // Same field, two writers. Yjs resolves at the Y.Map level by
+      // origin/clock; either value can win but both docs must converge.
+      storeA.areas[0].name = 'A-name'
+      storeB.areas[0].name = 'B-name'
+
+      Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA))
+      Y.applyUpdate(docA, Y.encodeStateAsUpdate(docB))
+
+      const resultA = serializeToJson(storeA)
+      const resultB = serializeToJson(storeB)
+
+      expect(resultA.layout.areas[0].name).toEqual(
+        resultB.layout.areas[0].name,
+      )
+      expect(['A-name', 'B-name']).toContain(resultA.layout.areas[0].name)
+    })
+  })
+})

--- a/src/__tests__/lib/yjs-spike/allotment-yjs.test.ts
+++ b/src/__tests__/lib/yjs-spike/allotment-yjs.test.ts
@@ -160,6 +160,79 @@ describe('yjs-spike: allotment-yjs', () => {
       expect(result).toEqual(original)
     })
 
+    it('is idempotent — re-hydrating with the same data does not duplicate', () => {
+      const original = makeFixture()
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, original)
+      hydrateFromJson(store, original)
+
+      const result = serializeToJson(store)
+      expect(result).toEqual(original)
+    })
+
+    it('replaces rather than appends when re-hydrating with different data', () => {
+      const first = makeFixture()
+      const second: AllotmentData = {
+        ...first,
+        layout: {
+          areas: [
+            {
+              id: 'bed-z',
+              name: 'New Layout — Bed Z',
+              kind: 'rotation-bed',
+              canHavePlantings: true,
+              createdAt: '2026-06-01T00:00:00.000Z',
+            },
+          ],
+        },
+        seasons: [],
+        varieties: [],
+        compost: [],
+      }
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, first)
+      hydrateFromJson(store, second)
+
+      const result = serializeToJson(store)
+      expect(result.layout.areas).toHaveLength(1)
+      expect(result.layout.areas[0].id).toBe('bed-z')
+      expect(result.seasons).toHaveLength(0)
+      expect(result.varieties).toHaveLength(0)
+    })
+
+    it('normalises optional top-level undefined arrays to empty arrays', () => {
+      // SyncedStore cannot distinguish "field never set" from "field
+      // is an empty array" once hydrate runs — both leave a 0-length
+      // Y.Array. The canonical serialized form is the empty-array
+      // case, matching how the rest of the codebase treats these
+      // fields (`data.gardenEvents ?? []`). Asymmetric round-trip
+      // when the original input had these fields undefined.
+      const minimal: AllotmentData = {
+        version: 22,
+        currentYear: 2026,
+        meta: {
+          name: 'Minimal',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        layout: { areas: [] },
+        seasons: [],
+        varieties: [],
+        // customTasks, maintenanceTasks, gardenEvents, compost left undefined
+      }
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, minimal)
+
+      const result = serializeToJson(store)
+      expect(result.customTasks).toEqual([])
+      expect(result.maintenanceTasks).toEqual([])
+      expect(result.gardenEvents).toEqual([])
+      expect(result.compost).toEqual([])
+      expect(result.seasons).toEqual([])
+      expect(result.varieties).toEqual([])
+      expect(result.layout.areas).toEqual([])
+    })
+
     it('drops undefined fields without throwing', () => {
       const original: AllotmentData = {
         ...makeFixture(),
@@ -233,10 +306,13 @@ describe('yjs-spike: allotment-yjs', () => {
       expect(result).toEqual(original)
     })
 
-    it('reports a binary size noticeably smaller than the JSON', () => {
-      // Smoke test for the cost line ADR 027 is worried about. We log
-      // the ratio rather than asserting a bound — the spike just needs
-      // a first-look number.
+    it('logs the binary-to-JSON size ratio (cost-line smoke test)', () => {
+      // Data point for the cost-line risk in ADR 027. The fixture is
+      // small (~2 KB) so the Yjs binary is expected to be larger than
+      // the JSON here — CRDT metadata is a fixed overhead that only
+      // amortises away on bigger documents. We log the ratio rather
+      // than asserting a bound; a realistic multi-season fixture is
+      // tracked separately.
       const original = makeFixture()
       const { store, doc } = createAllotmentDoc()
       hydrateFromJson(store, original)

--- a/src/__tests__/lib/yjs-spike/allotment-yjs.test.ts
+++ b/src/__tests__/lib/yjs-spike/allotment-yjs.test.ts
@@ -200,6 +200,41 @@ describe('yjs-spike: allotment-yjs', () => {
       expect(result.varieties).toHaveLength(0)
     })
 
+    it('clears meta keys absent from the new input on re-hydrate', () => {
+      // Re-hydration must reset stale meta fields, not preserve them.
+      // assignDefined skips undefined source values, so an explicit
+      // clear of the meta Y.Map is required for the missing-key case.
+      const withRichMeta: AllotmentData = {
+        ...makeFixture(),
+        meta: {
+          name: 'Edinburgh Allotment',
+          location: 'Edinburgh',
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2026-05-12T00:00:00.000Z',
+          aiAdvisorEnabled: true,
+          coordinates: { latitude: 55.95, longitude: -3.18 },
+        },
+      }
+      const withMinimalMeta: AllotmentData = {
+        ...withRichMeta,
+        meta: {
+          name: 'Renamed',
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2026-05-13T00:00:00.000Z',
+        },
+      }
+
+      const { store } = createAllotmentDoc()
+      hydrateFromJson(store, withRichMeta)
+      hydrateFromJson(store, withMinimalMeta)
+
+      const result = serializeToJson(store)
+      expect(result.meta.name).toBe('Renamed')
+      expect(result.meta.aiAdvisorEnabled).toBeUndefined()
+      expect(result.meta.coordinates).toBeUndefined()
+      expect(result.meta.location).toBeUndefined()
+    })
+
     it('normalises optional top-level undefined arrays to empty arrays', () => {
       // SyncedStore cannot distinguish "field never set" from "field
       // is an empty array" once hydrate runs — both leave a 0-length

--- a/src/lib/yjs-spike/allotment-yjs.ts
+++ b/src/lib/yjs-spike/allotment-yjs.ts
@@ -101,8 +101,13 @@ export function hydrateFromJson(
 
   doc.transact(() => {
     // Clear top-level collections so re-hydration replaces rather than
-    // appends. The state / meta maps are overwritten field-by-field
-    // below so they do not need explicit clearing.
+    // appends. `meta` is also cleared key-by-key: assignDefined skips
+    // undefined values, so without an explicit clear, fields present in
+    // the previous hydrate that are absent in the new input would
+    // silently persist (a hydrate of a backup without `aiAdvisorEnabled`
+    // should leave the proxy without that field, not preserve a stale
+    // `true`). `state` has a closed set of fields all written below, so
+    // it does not need clearing.
     store.areas.splice(0, store.areas.length)
     store.seasons.splice(0, store.seasons.length)
     store.customTasks.splice(0, store.customTasks.length)
@@ -110,6 +115,9 @@ export function hydrateFromJson(
     store.gardenEvents.splice(0, store.gardenEvents.length)
     store.varieties.splice(0, store.varieties.length)
     store.compost.splice(0, store.compost.length)
+    for (const key of Object.keys(store.meta)) {
+      delete (store.meta as unknown as Record<string, unknown>)[key]
+    }
 
     // Top-level primitives go into the `state` map.
     store.state.currentYear = data.currentYear

--- a/src/lib/yjs-spike/allotment-yjs.ts
+++ b/src/lib/yjs-spike/allotment-yjs.ts
@@ -1,0 +1,228 @@
+/**
+ * Yjs spike (ADR 027 Step 2)
+ *
+ * Maps the mutable parts of AllotmentData onto a Yjs document via the
+ * SyncedStore proxy wrapper. The 192-entry vegetable database stays in
+ * TypeScript modules and is not in scope for this file.
+ *
+ * Scope of this file: shape definition, doc creation, hydration from an
+ * existing AllotmentData JSON snapshot, and serialization back to plain
+ * AllotmentData JSON. Consumers of the existing useAllotment API should
+ * be able to read the resulting shape with no destructuring changes;
+ * writes change from "replace the root object" to "mutate the proxy in
+ * place".
+ *
+ * Not yet covered: useAllotmentData / useAllotment integration, the
+ * useYjsDoc hook (Step 3), live-user migration (Step 4).
+ */
+
+import * as Y from 'yjs'
+import { syncedStore, getYjsDoc } from '@syncedstore/core'
+import type {
+  AllotmentData,
+  AllotmentMeta,
+  Area,
+  SeasonRecord,
+  CustomTask,
+  MaintenanceTask,
+  GardenEvent,
+  StoredVariety,
+} from '@/types/unified-allotment'
+import type { CompostPile } from '@/types/compost'
+
+/**
+ * Top-level shape of the collaborative document.
+ *
+ * SyncedStore's shape API only accepts empty `{}` / `[]` (plus `"xml"` /
+ * `"text"`) at the top level — the runtime initializer must be empty
+ * and only the TypeScript cast carries the shape. Two consequences for
+ * the legacy AllotmentData mapping: the schema version and the active
+ * year live inside a `state` Y.Map rather than as bare primitives, and
+ * the legacy `layout.areas` is hoisted to a top-level `areas` Y.Array
+ * (the `layout` wrapper is reconstructed by serializeToJson on the way
+ * back out).
+ */
+export interface AllotmentStoreShape {
+  state: AllotmentState
+  meta: AllotmentMeta
+  areas: Area[]
+  seasons: SeasonRecord[]
+  customTasks: CustomTask[]
+  maintenanceTasks: MaintenanceTask[]
+  gardenEvents: GardenEvent[]
+  varieties: StoredVariety[]
+  compost: CompostPile[]
+}
+
+export interface AllotmentState {
+  currentYear: number
+  schemaVersion: number
+}
+
+/**
+ * Create an empty Yjs-backed allotment store. Caller can pass an
+ * existing Y.Doc (used for migration / multi-doc scenarios) or let one
+ * be created.
+ */
+export function createAllotmentDoc(doc: Y.Doc = new Y.Doc()): {
+  store: AllotmentStoreShape
+  doc: Y.Doc
+} {
+  const store = syncedStore(
+    {
+      state: {} as AllotmentState,
+      meta: {} as AllotmentMeta,
+      areas: [] as Area[],
+      seasons: [] as SeasonRecord[],
+      customTasks: [] as CustomTask[],
+      maintenanceTasks: [] as MaintenanceTask[],
+      gardenEvents: [] as GardenEvent[],
+      varieties: [] as StoredVariety[],
+      compost: [] as CompostPile[],
+    },
+    doc,
+  ) as unknown as AllotmentStoreShape
+
+  return { store, doc }
+}
+
+/**
+ * Hydrate a freshly-created store from an existing AllotmentData JSON
+ * snapshot. Must run inside a single Yjs transaction so all the bulk
+ * inserts emit one update rather than dozens. Idempotent for the
+ * "starting from empty" case; calling on a populated store will append.
+ */
+export function hydrateFromJson(
+  store: AllotmentStoreShape,
+  data: AllotmentData,
+): void {
+  const doc = getYjsDoc(store)
+
+  doc.transact(() => {
+    // Top-level primitives go into the `state` map.
+    store.state.currentYear = data.currentYear
+    store.state.schemaVersion = data.version
+
+    // meta: copy field-by-field so undefined props are dropped (Yjs
+    // does not store undefined; assigning it can throw).
+    assignDefined(store.meta, data.meta)
+
+    // Areas: deep-clone each area into a fresh plain object so
+    // SyncedStore expands it into a Y.Map. The legacy `layout.areas`
+    // wrapper is collapsed away — `serializeToJson` puts it back.
+    for (const area of data.layout.areas) {
+      store.areas.push(cloneJson(area) as Area)
+    }
+
+    for (const season of data.seasons) {
+      store.seasons.push(cloneJson(season) as SeasonRecord)
+    }
+
+    for (const task of data.customTasks ?? []) {
+      store.customTasks.push(cloneJson(task) as CustomTask)
+    }
+
+    for (const task of data.maintenanceTasks ?? []) {
+      store.maintenanceTasks.push(cloneJson(task) as MaintenanceTask)
+    }
+
+    for (const event of data.gardenEvents ?? []) {
+      store.gardenEvents.push(cloneJson(event) as GardenEvent)
+    }
+
+    for (const variety of data.varieties) {
+      store.varieties.push(cloneJson(variety) as StoredVariety)
+    }
+
+    for (const pile of data.compost ?? []) {
+      store.compost.push(cloneJson(pile) as CompostPile)
+    }
+  })
+}
+
+/**
+ * Serialize a populated store back into an AllotmentData JSON object.
+ * Used for export, debugging, and the dual-write phase of the live-user
+ * migration. The output matches the in-memory shape of the legacy
+ * localStorage / Supabase JSONB representation byte-for-byte modulo
+ * field ordering and dropped-undefined fields.
+ */
+export function serializeToJson(store: AllotmentStoreShape): AllotmentData {
+  // SyncedStore proxies are JSON-stringify-friendly, so a parse/stringify
+  // round-trip is the lazy and correct way to detach the snapshot from
+  // the live document.
+  const snapshot = JSON.parse(JSON.stringify(store)) as AllotmentStoreShape
+
+  return {
+    version: snapshot.state.schemaVersion,
+    currentYear: snapshot.state.currentYear,
+    meta: snapshot.meta,
+    layout: { areas: snapshot.areas },
+    seasons: snapshot.seasons,
+    customTasks: snapshot.customTasks,
+    maintenanceTasks: snapshot.maintenanceTasks,
+    gardenEvents: snapshot.gardenEvents,
+    varieties: snapshot.varieties,
+    compost: snapshot.compost,
+  }
+}
+
+/**
+ * Encode the document as a Yjs binary update suitable for storage in a
+ * BYTEA column. Step 4 of ADR 027 will use this to populate
+ * `allotments.yjs_state` during the dual-write migration.
+ */
+export function encodeDocState(doc: Y.Doc): Uint8Array {
+  return Y.encodeStateAsUpdate(doc)
+}
+
+/**
+ * Decode a Yjs binary update into a new document. Mirror of
+ * encodeDocState — together they're the persistence round-trip.
+ */
+export function decodeDocState(update: Uint8Array): {
+  store: AllotmentStoreShape
+  doc: Y.Doc
+} {
+  const doc = new Y.Doc()
+  const { store } = createAllotmentDoc(doc)
+  Y.applyUpdate(doc, update)
+  return { store, doc }
+}
+
+// ============ internals ============
+
+/**
+ * Assign a source object's defined-only fields into a Yjs-backed target
+ * object. Skips `undefined` values — Yjs cannot represent undefined and
+ * SyncedStore will throw or silently lose them depending on the path.
+ */
+function assignDefined<T extends object>(target: T, source: T): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue
+    // SyncedStore expands plain object values into Y.Maps. Clone first
+    // so we don't accidentally share a reference with the source.
+    ;(target as Record<string, unknown>)[key] =
+      isPlainObject(value) || Array.isArray(value) ? cloneJson(value) : value
+  }
+}
+
+/**
+ * Plain structural clone via JSON. We already serialize ISO date strings
+ * everywhere and the codebase doesn't use Date / Map / Set instances in
+ * AllotmentData, so the cheap round-trip is safe. If this stops being
+ * true (e.g. a future field stores a Date object) this helper is the
+ * place to upgrade to a structured clone.
+ */
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}

--- a/src/lib/yjs-spike/allotment-yjs.ts
+++ b/src/lib/yjs-spike/allotment-yjs.ts
@@ -87,10 +87,11 @@ export function createAllotmentDoc(doc: Y.Doc = new Y.Doc()): {
 }
 
 /**
- * Hydrate a freshly-created store from an existing AllotmentData JSON
- * snapshot. Must run inside a single Yjs transaction so all the bulk
- * inserts emit one update rather than dozens. Idempotent for the
- * "starting from empty" case; calling on a populated store will append.
+ * Hydrate a store from an existing AllotmentData JSON snapshot. Clears
+ * the existing collections first so a re-hydrate produces the same
+ * result as a hydrate of an empty store — calling this twice with the
+ * same input is a no-op rather than producing duplicates. Runs inside a
+ * single Yjs transaction so all the bulk inserts emit one update.
  */
 export function hydrateFromJson(
   store: AllotmentStoreShape,
@@ -99,6 +100,17 @@ export function hydrateFromJson(
   const doc = getYjsDoc(store)
 
   doc.transact(() => {
+    // Clear top-level collections so re-hydration replaces rather than
+    // appends. The state / meta maps are overwritten field-by-field
+    // below so they do not need explicit clearing.
+    store.areas.splice(0, store.areas.length)
+    store.seasons.splice(0, store.seasons.length)
+    store.customTasks.splice(0, store.customTasks.length)
+    store.maintenanceTasks.splice(0, store.maintenanceTasks.length)
+    store.gardenEvents.splice(0, store.gardenEvents.length)
+    store.varieties.splice(0, store.varieties.length)
+    store.compost.splice(0, store.compost.length)
+
     // Top-level primitives go into the `state` map.
     store.state.currentYear = data.currentYear
     store.state.schemaVersion = data.version
@@ -151,6 +163,15 @@ export function serializeToJson(store: AllotmentStoreShape): AllotmentData {
   // SyncedStore proxies are JSON-stringify-friendly, so a parse/stringify
   // round-trip is the lazy and correct way to detach the snapshot from
   // the live document.
+  //
+  // Asymmetry to know: optional top-level arrays in the legacy
+  // AllotmentData shape (`customTasks`, `maintenanceTasks`,
+  // `gardenEvents`, `compost`) are always emitted here, even when
+  // empty. SyncedStore cannot distinguish "field never set" from
+  // "field is an empty array" once hydrate has run — both leave a
+  // zero-length Y.Array — so the canonical serialized form normalises
+  // to the empty-array case. This matches how the rest of the
+  // codebase treats these fields (`data.gardenEvents ?? []`).
   const snapshot = JSON.parse(JSON.stringify(store)) as AllotmentStoreShape
 
   return {


### PR DESCRIPTION
## Summary
- First cut of ADR 027 Step 2: maps `AllotmentData` onto a Yjs document via SyncedStore in `src/lib/yjs-spike/allotment-yjs.ts`, with `hydrateFromJson` / `serializeToJson` helpers and binary `encodeDocState` / `decodeDocState` for the BYTEA round-trip the migration step will need.
- 9 unit tests in `src/__tests__/lib/yjs-spike/allotment-yjs.test.ts` cover hydrate-serialize round-trip, in-place proxy mutations, binary encoding, and the two CRDT-semantics cases (disjoint edits merge; same-field edits converge).
- Updates `docs/adrs/027-sync-revisit.md` with the Step 2 findings and `docs/plans/current-plan.md` to hand off to Step 3. Spike branch stays open — Steps 3–5 land on top before any merge to `main`.

### Why SyncedStore over valtio-yjs

valtio-yjs is self-described as alpha ("the experiment is finished, now it's in alpha"), which is the wrong place to anchor a migration that touches every user's data. SyncedStore is production-tested in BlockNote, has a clean shape API, and exposes a `getYjsDoc()` escape hatch when the raw Yjs surface is needed. Consumers of `useAllotment` should be able to keep reading `data` as a normal `AllotmentData`; only the write sites learn to mutate the proxy in place instead of replacing the root object.

### Shape constraints worth knowing now

SyncedStore's top-level shape validator only accepts empty `{}`, `[]`, `"xml"`, or `"text"` — nested initializers throw `Root Object initializer must always be {}`. Two consequences applied in this cut: the legacy `layout.areas` wrapper is collapsed (areas lift to a top-level Y.Array; the wrapper is reconstructed at the serialization boundary), and `version` / `currentYear` live inside a nested `state` Y.Map rather than as bare primitives. Neither is user-visible. Separately, `undefined` values must be dropped before assignment — Yjs has no `undefined`, and SyncedStore is inconsistent about whether it throws or silently drops. The `assignDefined` helper enforces this on the hydrate path; Step 3 needs the same discipline on every write site.

### First cost-line measurement

On a small fixture (one bed, 2 plantings, one tree, 2 varieties, one compost pile, ~2.1KB JSON), Yjs binary is **2.6KB — a 1.21x ratio *larger* than JSON**. CRDT metadata is a fixed overhead that only amortises away on bigger documents. The ADR's cost-line risk remains open until measured on a realistic multi-season fixture; flagging it now so the conversation includes the small-doc data point.

## Test plan
- [ ] `npm run test:unit -- src/__tests__/lib/yjs-spike/` — 9 tests pass.
- [ ] `npm run type-check` — clean.
- [ ] `npm run lint` — clean.
- [ ] Full suite `npm run test:unit` still green (1035 passing locally on this branch).
- [ ] This PR is for review only — do not merge. Step 3 (replace `useSyncedStorage` with `useYjsDoc`) lands on top before anything reaches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)