### PR TITLE
docs: mark ADR 027 Yjs Step 2 shipped, point at Step 3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,10 @@ The Supabase client module (`src/lib/supabase/client.ts`) provides `createAnonCl
 
 Environment: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`. A Clerk JWT template named "supabase" must be created in the Clerk Dashboard (JWT Templates > New template > Supabase preset). The template claims should be `{ "aud": "authenticated", "role": "authenticated", "email": "{{user.primary_email_address}}" }` — do not include `sub` as it is a reserved claim that Clerk sets automatically to the user ID. The signing key must be the Supabase JWT Secret (Project Settings > API > JWT Secret), algorithm HS256. The RLS policies in `sql/001-allotments.sql` use `auth.jwt() ->> 'sub'` to match rows to users.
 
+### Yjs Sync Spike (ADR 027)
+
+`src/lib/yjs-spike/allotment-yjs.ts` is a proof-of-concept that maps `AllotmentData` onto a Yjs document via SyncedStore (`@syncedstore/core`). It exports `createAllotmentDoc`, `hydrateFromJson`, `serializeToJson`, and `encodeDocState` / `decodeDocState` for the eventual BYTEA round-trip. The module is **not wired into `useAllotment` yet** — Step 2 of ADR 027 ships the shape, hydrate/serialize, and CRDT-merge tests in isolation; Step 3 will replace `useSyncedStorage` with a `useYjsDoc` hook. Treat this directory as exploratory until that integration lands.
+
 ### GDPR Compliance
 
 `GET /api/account` exports user data as JSON download. `DELETE /api/account` deletes the Supabase row. Both require Clerk authentication. The Settings Data tab provides UI for export and account deletion in the Danger Zone section.

--- a/docs/adrs/027-sync-revisit.md
+++ b/docs/adrs/027-sync-revisit.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (spike not yet started). Supersedes the cloud-sync portion of ADR 024 once accepted; the share/receive flow described there remains.
+Accepted, spike in flight (Step 1 ADR + Step 2 PoC merged in PR #364 on 2026-05-13; Steps 3–5 outstanding). Supersedes the cloud-sync portion of ADR 024 once Step 5 retires the LWW machinery; the share/receive flow described there remains.
 
 ## Date
 
@@ -42,15 +42,17 @@ The first step is this ADR (in flight). Subsequent steps live on a feature branc
 
 Step two converts `AllotmentData` to a Yjs document on a spike branch. The 192-entry vegetable database is static and stays as TypeScript modules — only mutable user state (`meta`, `seasons`, `varieties`, `customTasks`, `maintenanceTasks`, `gardenEvents`, `compost`) moves into the `Y.Doc`. The top-level shape maps to a `Y.Map` for `meta`, `Y.Array` for `seasons`, and so on. Rough sizing: a few days of work, not hours, mostly because every consumer of `setData` needs to learn to write through the Yjs APIs instead of replacing the root object. The spike should also evaluate a proxy wrapper such as `valtio/yjs` or `synced-store`, which let callers keep the existing immutable-style read/write idiom on top of Yjs and could cut the consumer refactor surface significantly if the developer experience holds up.
 
-### Step 2 first cut (2026-05-12, branch `spike/yjs-allotment`)
+### Step 2 shipped (2026-05-13, PR #364 `8b28818`)
 
-A proof-of-concept landed in `src/lib/yjs-spike/allotment-yjs.ts` with 9 passing unit tests in `src/__tests__/lib/yjs-spike/`. Key decisions out of the cut:
+A proof-of-concept landed on `main` in `src/lib/yjs-spike/allotment-yjs.ts` with 13 passing unit tests in `src/__tests__/lib/yjs-spike/`. Key decisions out of the cut:
 
 The proxy-wrapper question is resolved in favour of **SyncedStore** (`@syncedstore/core@^0.6`). The valtio-yjs alternative is explicitly self-described as alpha ("the experiment is finished, now it's in alpha") and would not be acceptable for a migration that touches every user's data. SyncedStore is production-tested via BlockNote, has a clean shape API, and its `getYjsDoc()` escape hatch keeps the raw Yjs surface available where needed.
 
 SyncedStore's shape validator imposes one constraint worth documenting up front: top-level entries must be exactly `{}`, `[]`, `"xml"`, or `"text"` — nested initializers throw `Root Object initializer must always be {}`. The legacy `AllotmentData.layout.areas` wrapper is therefore collapsed away in the Yjs shape (`areas` lifts to the top level) and reconstructed at the serialization boundary. The same constraint forces top-level primitives (`version`, `currentYear`) into a nested `state` Y.Map. Neither change is user-visible — the legacy JSON shape is preserved across the hydrate / serialize round-trip.
 
 `undefined` values must be dropped before assignment — Yjs cannot represent `undefined` and SyncedStore is inconsistent about whether it throws or silently drops. The `assignDefined` helper in the PoC walks the source object and skips undefined fields; the same discipline will apply to every write site in the Step 3 hook.
+
+Two correctness gotchas were found during review and now have tests. First, re-hydration has to clear *every* mutable container, not just the top-level Y.Arrays: the `meta` Y.Map needs an explicit key-by-key delete pass before `assignDefined` runs, otherwise a hydrate from a backup with fewer fields silently keeps the previous run's `aiAdvisorEnabled` / `coordinates` / etc. Second, SyncedStore cannot distinguish "field never set" from "empty array" once hydrate has run — both leave a zero-length Y.Array — so the canonical `serializeToJson` output normalises optional top-level arrays (`customTasks`, `maintenanceTasks`, `gardenEvents`, `compost`) to `[]` regardless of which shape the input had. Both behaviours are documented inline in `allotment-yjs.ts` and asserted by tests; Step 3 will need to thread the same discipline through every domain-hook write site.
 
 Concurrent-edit semantics are confirmed in tests: two doc instances editing different plantings in the same bed merge cleanly; two doc instances editing the same field (an area name) converge to a deterministic single value. This is the headline win that the LWW machinery in `useSyncedStorage` cannot deliver.
 

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,6 @@
 # Current Plan
 
-Last updated: 2026-05-12 (ADR 027 Yjs spike Step 2 first cut on branch `spike/yjs-allotment`; Step 3 hook integration is the next deliberate work)
+Last updated: 2026-05-13 (ADR 027 Yjs spike Step 2 merged in PR #364; Step 3 hook integration is the next deliberate work)
 
 ## What's Been Completed
 
@@ -341,11 +341,13 @@ The opt-in banner's "Try Aitor" button used to only flip `meta.aiAdvisorEnabled`
 
 After PR #345 added the server-side Gemini free tier, clicking Try Aitor still threw "Please configure your OpenAI API key in Settings" because two client-side guards bailed before the request reached `/api/ai-advisor`. PR #351 dropped the `!token` early-throw in `AitorChatModal.tsx`, wrapped the `x-openai-token` header in an `if (options.apiToken)` check inside `openai-client.ts`, and kept the `tokenPattern` validator only in the static-deployment `callOpenAIDirect` fallback (which genuinely needs a BYO key because GitHub Pages can't reach the Gemini path). Signed-in users without a BYO key now hit Gemini cleanly; the modal's quota-exceeded (429) and config-error branches still match the failure modes they were written for, while any other server error (including the "JWT template missing" path) falls through to the generic "Temporary Connection Issue" message.
 
-### ADR 027 Yjs spike Step 2 — First cut shipped (branch `spike/yjs-allotment`)
+### ADR 027 Yjs spike Step 2 — Shipped (PR #364, `8b28818`)
 
-A proof-of-concept conversion of `AllotmentData` to a Yjs document landed on the spike branch on 2026-05-12. `src/lib/yjs-spike/allotment-yjs.ts` defines the top-level shape, a `hydrateFromJson` helper that seeds from an existing `AllotmentData` snapshot inside a single Yjs transaction, a `serializeToJson` mirror, and `encodeDocState` / `decodeDocState` for the BYTEA round-trip the migration step will need. 9 unit tests in `src/__tests__/lib/yjs-spike/allotment-yjs.test.ts` cover hydrate-serialize round-trip, proxy mutations, binary encoding, and the two CRDT-semantics cases (disjoint edits and same-field convergence).
+A proof-of-concept conversion of `AllotmentData` to a Yjs document landed on `main` on 2026-05-13. `src/lib/yjs-spike/allotment-yjs.ts` defines the top-level shape, a `hydrateFromJson` helper that seeds from an existing `AllotmentData` snapshot inside a single Yjs transaction, a `serializeToJson` mirror, and `encodeDocState` / `decodeDocState` for the BYTEA round-trip the migration step will need. 13 unit tests in `src/__tests__/lib/yjs-spike/allotment-yjs.test.ts` cover hydrate-serialize round-trip, idempotent re-hydration, replace-on-different-data semantics, meta-key-clear on re-hydrate, optional-array normalisation, proxy mutations, binary encoding, and the two CRDT-semantics cases (disjoint edits and same-field convergence).
 
 Proxy-wrapper decision: **SyncedStore** (`@syncedstore/core@^0.6`) over valtio-yjs. valtio-yjs is self-described as alpha; SyncedStore is production-tested in BlockNote and has the clean `shape` API plus a `getYjsDoc()` escape hatch. Two shape constraints worth flagging: top-level entries must be empty `{}` / `[]` (the validator throws otherwise), so `AllotmentData.layout.areas` is hoisted to a top-level `areas` Y.Array and `version` / `currentYear` are nested inside a `state` Y.Map. Neither change is user-visible — the legacy JSON shape is reconstructed at the serialization boundary. The other constraint: `undefined` values must be dropped before assignment (Yjs has no `undefined`), enforced by the `assignDefined` helper.
+
+Two correctness gotchas surfaced during review and are now covered by tests. First, `hydrateFromJson` has to clear the top-level Y.Arrays *and* the `meta` Y.Map before repopulating — without the clears, a second hydrate from a backup with fewer fields silently keeps stale data (the first-round Gemini review caught the array case; the second-round self-review caught the matching meta case). Second, SyncedStore cannot distinguish "field never set" from "empty array" once hydrate has run, so the canonical `serializeToJson` output normalises optional top-level arrays to `[]`. Both behaviours are documented inline and asserted by tests.
 
 First cost-line measurement: on a small fixture (one bed with 2 plantings, one tree, 2 varieties, one compost pile, ~2.1KB JSON), the Yjs binary is 2.6KB — a 1.21x ratio *larger* than JSON. CRDT metadata is a fixed overhead that only amortises away on bigger documents. The cost-line risk in the ADR remains open until measured on a realistic multi-season fixture.
 


### PR DESCRIPTION
## Summary
- `docs/plans/current-plan.md`: header line updated to today; Step 2 section now reflects that PR #364 merged (\`8b28818\`), the two correctness gotchas surfaced during review (meta-clear on re-hydrate, optional-array normalisation), and the bumped 13-test count.
- `docs/adrs/027-sync-revisit.md`: status flipped from "Proposed (spike not yet started)" to "Accepted, spike in flight (Steps 3–5 outstanding)"; Step 2 section rewritten to capture the round-1 and round-2 findings as design constraints that Step 3 has to honour at every domain-hook write site.
- `CLAUDE.md`: added a "Yjs Sync Spike (ADR 027)" subsection so future sessions know `src/lib/yjs-spike/` is exploratory and not wired into `useAllotment` yet.

## Test plan
- [ ] Skim the diff to confirm the wording matches your intent.
- [ ] No code changes; docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)