### PR TITLE
feat: simplify allotment + Aitor UX, lazy-mount chat, concise replies

### DIFF
--- a/src/__tests__/components/AitorAuthGate.test.tsx
+++ b/src/__tests__/components/AitorAuthGate.test.tsx
@@ -5,6 +5,7 @@ import type { AllotmentData } from '@/types/unified-allotment'
 // Mocks must be declared before importing the component under test.
 const useOptionalAuthMock = vi.fn()
 const useAllotmentMock = vi.fn()
+const useAitorChatMock = vi.fn()
 
 vi.mock('@/hooks/useOptionalAuth', () => ({
   useOptionalAuth: () => useOptionalAuthMock(),
@@ -14,6 +15,10 @@ vi.mock('@/hooks/useAllotment', () => ({
   useAllotment: () => useAllotmentMock(),
 }))
 
+vi.mock('@/contexts/AitorChatContext', () => ({
+  useAitorChat: () => useAitorChatMock(),
+}))
+
 // Stub out the heavy children so we only assert on AitorAuthGate's gating logic.
 vi.mock('@/components/ai-advisor/AitorChatButton', () => ({
   default: () => <div data-testid="aitor-chat-button" />,
@@ -21,6 +26,34 @@ vi.mock('@/components/ai-advisor/AitorChatButton', () => ({
 vi.mock('@/components/ai-advisor/AitorChatModal', () => ({
   default: () => <div data-testid="aitor-chat-modal" />,
 }))
+
+// next/dynamic resolves the loader asynchronously which would defer rendering
+// past our synchronous assertions. Mock it to kick off the loader, capture
+// the resolved default export, and re-render via state when ready.
+vi.mock('next/dynamic', async () => {
+  const React = await import('react')
+  type DynamicLoader = () => Promise<{ default: React.ComponentType<Record<string, unknown>> }>
+  return {
+    __esModule: true,
+    default: (loader: DynamicLoader) => {
+      const loaderPromise = loader()
+      const DynamicStub = (props: Record<string, unknown>) => {
+        const [Loaded, setLoaded] = React.useState<React.ComponentType<Record<string, unknown>> | null>(null)
+        React.useEffect(() => {
+          let cancelled = false
+          loaderPromise.then((mod) => {
+            if (!cancelled) setLoaded(() => mod.default)
+          })
+          return () => {
+            cancelled = true
+          }
+        }, [])
+        return Loaded ? React.createElement(Loaded, props) : null
+      }
+      return DynamicStub
+    },
+  }
+})
 
 import AitorAuthGate from '@/components/ai-advisor/AitorAuthGate'
 
@@ -37,10 +70,16 @@ function dataWith(aiAdvisorEnabled: boolean | undefined): { data: Partial<Allotm
   }
 }
 
+function chatState(partial: Partial<{ isOpen: boolean; isMinimized: boolean }>) {
+  return { isOpen: false, isMinimized: false, ...partial }
+}
+
 describe('AitorAuthGate', () => {
   beforeEach(() => {
     useOptionalAuthMock.mockReset()
     useAllotmentMock.mockReset()
+    useAitorChatMock.mockReset()
+    useAitorChatMock.mockReturnValue(chatState({}))
   })
 
   it('renders nothing when the user is not signed in', () => {
@@ -67,12 +106,32 @@ describe('AitorAuthGate', () => {
     expect(container.innerHTML).toBe('')
   })
 
-  it('renders the chat button and modal when signed in and opted in', () => {
+  it('renders only the launcher button when opted in and chat is closed', () => {
     useOptionalAuthMock.mockReturnValue({ isSignedIn: true })
     useAllotmentMock.mockReturnValue(dataWith(true))
+    useAitorChatMock.mockReturnValue(chatState({ isOpen: false, isMinimized: false }))
 
-    const { getByTestId } = render(<AitorAuthGate />)
+    const { getByTestId, queryByTestId } = render(<AitorAuthGate />)
     expect(getByTestId('aitor-chat-button')).toBeInTheDocument()
-    expect(getByTestId('aitor-chat-modal')).toBeInTheDocument()
+    expect(queryByTestId('aitor-chat-modal')).not.toBeInTheDocument()
+  })
+
+  it('mounts the modal when the chat is open', async () => {
+    useOptionalAuthMock.mockReturnValue({ isSignedIn: true })
+    useAllotmentMock.mockReturnValue(dataWith(true))
+    useAitorChatMock.mockReturnValue(chatState({ isOpen: true }))
+
+    const { findByTestId, getByTestId } = render(<AitorAuthGate />)
+    expect(getByTestId('aitor-chat-button')).toBeInTheDocument()
+    expect(await findByTestId('aitor-chat-modal')).toBeInTheDocument()
+  })
+
+  it('keeps the modal mounted while minimized', async () => {
+    useOptionalAuthMock.mockReturnValue({ isSignedIn: true })
+    useAllotmentMock.mockReturnValue(dataWith(true))
+    useAitorChatMock.mockReturnValue(chatState({ isOpen: true, isMinimized: true }))
+
+    const { findByTestId } = render(<AitorAuthGate />)
+    expect(await findByTestId('aitor-chat-modal')).toBeInTheDocument()
   })
 })

--- a/src/__tests__/components/AllotmentGrid.test.tsx
+++ b/src/__tests__/components/AllotmentGrid.test.tsx
@@ -218,24 +218,6 @@ describe('AllotmentGrid Component', () => {
       })
     })
 
-    it('shows reset button only in editing mode', async () => {
-      render(
-        <AllotmentGrid
-          areas={createTestAreas()}
-          selectedYear={2024}
-        />
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByRole('button', { name: /reset layout/i })).not.toBeInTheDocument()
-      })
-
-      await userEvent.click(screen.getByRole('button', { name: /unlock to edit/i }))
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /reset layout/i })).toBeInTheDocument()
-      })
-    })
   })
 
   describe('Item selection', () => {
@@ -644,33 +626,6 @@ describe('AllotmentGrid Component', () => {
       await waitFor(() => {
         expect(screen.queryByRole('status')).not.toBeInTheDocument()
       })
-    })
-  })
-
-  describe('Position changes', () => {
-    it('calls onPositionChange when reset button is clicked', async () => {
-      const areas = createTestAreas()
-
-      render(
-        <AllotmentGrid
-          areas={areas}
-          selectedYear={2024}
-          onPositionChange={mockOnPositionChange}
-        />
-      )
-
-      // Enable editing mode
-      await userEvent.click(screen.getByRole('button', { name: /unlock to edit/i }))
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /reset layout/i })).toBeInTheDocument()
-      })
-
-      // Click reset
-      await userEvent.click(screen.getByRole('button', { name: /reset layout/i }))
-
-      // Should call onPositionChange for each area
-      expect(mockOnPositionChange).toHaveBeenCalled()
     })
   })
 

--- a/src/app/api/ai-advisor/route.ts
+++ b/src/app/api/ai-advisor/route.ts
@@ -100,24 +100,22 @@ When analyzing plant photos, examine:
 
 Provide specific, actionable diagnosis and treatment recommendations based on visual observations.
 
-🌿 COMMUNICATION STYLE:
-- Warm, encouraging, and knowledgeable tone
-- Practical, step-by-step guidance
-- Focus on sustainable and organic methods
-- Consider resource constraints of home gardeners
-- Adapt advice to experience level (beginner to advanced)
-- Always introduce yourself as "Aitor" when first meeting users
-- When analyzing photos, describe what you observe before giving advice
+🌿 COMMUNICATION STYLE — read carefully, the user has explicitly asked for concise replies:
+- Keep responses short and chat-like. Aim for 2–4 sentences. Treat this as a text conversation, not an essay.
+- No preamble. Do NOT introduce yourself ("Hello! I'm Aitor…"), do NOT name the user's allotment back to them, do NOT restate the question. Answer directly.
+- No filler ("Great question!", "I'd love to help!", "Feel free to ask…"). No closing sign-off ("Aitor's Tip", "Happy growing!").
+- Match the user's depth. A quick question gets a quick answer. Only expand into structured, multi-section explanations when the user asks for detail ("explain more", "step by step", "why").
+- Use bullet points sparingly — only when listing 3+ genuinely discrete items. Prefer flowing prose for everything else.
+- Reference the user's allotment data only when it changes the answer.
+- Ask one clarifying question only if it would meaningfully change your answer; otherwise just give your best answer.
+- Photo replies: name what you see in one short sentence, then give the action. Skip the lecture.
 
 🌿 APPROACH:
-- Ask clarifying questions about location, current conditions, and experience level
-- Provide specific, actionable recommendations
-- Explain the 'why' behind gardening practices
-- Suggest timing for tasks and activities
-- Offer alternatives for different budgets and skill levels
-- When photos are provided, give detailed visual analysis first, then comprehensive treatment advice
+- Lead with the answer or recommendation. Add explanation only if needed for the user to act.
+- Default to organic / low-resource methods, but don't moralise about it.
+- When photos are provided, identify the issue, then give the fix.
 
-Your goal is to help every gardener succeed, whether they're just starting their first vegetable patch or managing an established allotment plot.`
+Your goal: help the gardener and let them get back to gardening.`
 }
 
 type Provider = 'openai-byo' | 'openai-server' | 'gemini-server'

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useAllotment } from '@/hooks/useAllotment'
 import { useApiToken } from '@/hooks/useSessionStorage'
 import { useLocation } from '@/hooks/useLocation'
-import { Shield, MapPin, Leaf, Database, HelpCircle } from 'lucide-react'
+import { MapPin, Leaf, Database, HelpCircle } from 'lucide-react'
 import { useOptionalAuth } from '@/hooks/useOptionalAuth'
 import LocationStatus from '@/components/ai-advisor/LocationStatus'
 import DataTab from '@/components/settings/DataTab'
@@ -56,8 +56,12 @@ export default function SettingsPage() {
       </div>
 
       <div className="zen-card p-6" data-tour="settings-tabs">
+        {/* key remounts Tabs once Clerk auth resolves so `defaultTab` picks up
+            the correct landing tab. Tabs only reads defaultTab on initial
+            useState; without the remount, signed-in users would stay on Data. */}
         <Tabs
-          defaultTab="data"
+          key={isSignedIn ? 'signed-in' : 'signed-out'}
+          defaultTab={isSignedIn ? 'ai-location' : 'data'}
           tabs={[
             ...(isSignedIn ? [{
               id: 'ai-location',
@@ -116,7 +120,7 @@ export default function SettingsPage() {
                             onPaste={handlePaste}
                             placeholder="sk-..."
                             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
-                            aria-describedby="token-help-text token-privacy-notice"
+                            aria-describedby="token-help-text"
                             autoComplete="off"
                           />
                         </div>
@@ -133,18 +137,6 @@ export default function SettingsPage() {
                               Get one here
                             </a>
                           </p>
-                        </div>
-                      </div>
-
-                      <div id="token-privacy-notice" className="bg-yellow-50 border border-yellow-200 rounded-md p-3" role="note">
-                        <div className="flex items-start">
-                          <Shield className="w-4 h-4 text-yellow-600 mt-0.5 flex-shrink-0" aria-hidden="true" />
-                          <div className="ml-2">
-                            <p className="text-sm text-yellow-800">
-                              <strong>Privacy Notice:</strong> Your token is stored only in your browser session and never saved permanently.
-                              It&apos;s sent securely to OpenAI only when making requests.
-                            </p>
-                          </div>
                         </div>
                       </div>
 

--- a/src/components/ai-advisor/AitorAuthGate.tsx
+++ b/src/components/ai-advisor/AitorAuthGate.tsx
@@ -1,9 +1,19 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { useOptionalAuth } from '@/hooks/useOptionalAuth'
 import { useAllotment } from '@/hooks/useAllotment'
+import { useAitorChat } from '@/contexts/AitorChatContext'
 import AitorChatButton from './AitorChatButton'
-import AitorChatModal from './AitorChatModal'
+
+// Lazy-load the heavy modal. It owns useAllotment/useApiToken/useLocation and a
+// hefty allotmentContext useMemo — none of which should run until the user
+// actually opens the chat. ssr:false avoids hydration overhead for a
+// client-only feature.
+const AitorChatModal = dynamic(() => import('./AitorChatModal'), {
+  ssr: false,
+  loading: () => null,
+})
 
 /**
  * Renders the floating Aitor chat button and modal only for users who have
@@ -14,16 +24,22 @@ import AitorChatModal from './AitorChatModal'
  * flag so signing in does not implicitly subscribe a user to AI features.
  * When Clerk is not configured (e.g. local dev without keys),
  * `useOptionalAuth` returns `isSignedIn: false` and Aitor stays hidden.
+ *
+ * Performance: the modal is only mounted while the chat is open or minimized.
+ * Minimized counts as "still mounted" so the conversation state survives the
+ * user shrinking the chat to a pill and restoring it later.
  */
 export default function AitorAuthGate() {
   const { isSignedIn } = useOptionalAuth()
   const { data } = useAllotment()
+  const { isOpen, isMinimized } = useAitorChat()
   if (!isSignedIn) return null
   if (data?.meta?.aiAdvisorEnabled !== true) return null
+  const modalActive = isOpen || isMinimized
   return (
     <>
       <AitorChatButton />
-      <AitorChatModal />
+      {modalActive && <AitorChatModal />}
     </>
   )
 }

--- a/src/components/ai-advisor/AitorAuthGate.tsx
+++ b/src/components/ai-advisor/AitorAuthGate.tsx
@@ -9,10 +9,20 @@ import AitorChatButton from './AitorChatButton'
 // Lazy-load the heavy modal. It owns useAllotment/useApiToken/useLocation and a
 // hefty allotmentContext useMemo — none of which should run until the user
 // actually opens the chat. ssr:false avoids hydration overhead for a
-// client-only feature.
+// client-only feature. The launcher disappears the moment the user clicks
+// "Ask Aitor"; render a small spinner in the same corner so slow-network
+// users see visual continuity until the dialog appears.
 const AitorChatModal = dynamic(() => import('./AitorChatModal'), {
   ssr: false,
-  loading: () => null,
+  loading: () => (
+    <div
+      className="fixed bottom-6 right-6 z-50 flex items-center justify-center w-12 h-12 bg-zen-moss-600 rounded-full shadow-lg"
+      role="status"
+      aria-label="Loading Aitor chat"
+    >
+      <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+    </div>
+  ),
 })
 
 /**

--- a/src/components/ai-advisor/AitorChatButton.tsx
+++ b/src/components/ai-advisor/AitorChatButton.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { Camera, MessageCircle } from 'lucide-react'
+import { MessageCircle } from 'lucide-react'
 import { useAitorChat } from '@/contexts/AitorChatContext'
 import { usePathname } from 'next/navigation'
 
 export default function AitorChatButton() {
-  const { openChat, isOpen } = useAitorChat()
+  const { openChat, isOpen, isMinimized } = useAitorChat()
   const pathname = usePathname()
 
   // Don't show on the AI advisor page itself (to avoid confusion)
@@ -13,29 +13,20 @@ export default function AitorChatButton() {
     return null
   }
 
-  // Don't show when modal is already open
-  if (isOpen) {
+  // Don't double-stack with the open dialog or the minimized pill (both render
+  // their own fixed-bottom-right surface).
+  if (isOpen || isMinimized) {
     return null
   }
 
   return (
-    <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-2">
-      <button
-        onClick={() => openChat({ initialMode: 'diagnose' })}
-        className="flex items-center gap-2 bg-zen-water-600 hover:bg-zen-water-700 text-white px-4 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 group min-h-[44px]"
-        aria-label="Diagnose a plant - upload a photo for Aitor to analyse"
-      >
-        <Camera className="w-5 h-5" aria-hidden="true" />
-        <span className="text-sm font-medium hidden sm:inline">Diagnose a plant</span>
-      </button>
-      <button
-        onClick={() => openChat()}
-        className="flex items-center gap-2 bg-zen-moss-600 hover:bg-zen-moss-700 text-white px-4 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 group min-h-[44px]"
-        aria-label="Ask Aitor - your gardening assistant"
-      >
-        <MessageCircle className="w-5 h-5" aria-hidden="true" />
-        <span className="text-sm font-medium hidden sm:inline">Ask Aitor</span>
-      </button>
-    </div>
+    <button
+      onClick={() => openChat()}
+      className="fixed bottom-6 right-6 z-50 flex items-center gap-2 bg-zen-moss-600 hover:bg-zen-moss-700 text-white px-4 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 group min-h-[44px]"
+      aria-label="Ask Aitor - your gardening assistant"
+    >
+      <MessageCircle className="w-5 h-5" aria-hidden="true" />
+      <span className="text-sm font-medium hidden sm:inline">Ask Aitor</span>
+    </button>
   )
 }

--- a/src/components/ai-advisor/AitorChatModal.tsx
+++ b/src/components/ai-advisor/AitorChatModal.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { Leaf, PowerOff } from 'lucide-react'
-import type { ChatMessage as ChatMessageType } from '@/types/api'
+import { Leaf, Minus, PowerOff } from 'lucide-react'
 
 // Extracted hooks
 import { useLocation } from '@/hooks/useLocation'
 import { useApiToken } from '@/hooks/useSessionStorage'
 import { useAllotment } from '@/hooks/useAllotment'
-import { useAitorChat } from '@/contexts/AitorChatContext'
+import { useAitorChat, type ExtendedChatMessage } from '@/contexts/AitorChatContext'
 
 // Rate limiting
 import { aiRateLimiter, formatCooldown } from '@/lib/rate-limiter'
@@ -32,9 +31,6 @@ import ChatInput from '@/components/ai-advisor/ChatInput'
 import { ToolCallConfirmation } from '@/components/ai-advisor/ToolCallConfirmation'
 import { Toast, ToastType } from '@/components/ui/Toast'
 import Dialog from '@/components/ui/Dialog'
-
-// Extended message type with image support
-type ExtendedChatMessage = ChatMessageType & { image?: string }
 
 // Vercel caps request bodies at ~4.5 MB; an unprocessed phone photo as base64
 // blows past that and the route handler never runs (FUNCTION_PAYLOAD_TOO_LARGE).
@@ -88,8 +84,17 @@ const imageToBase64 = (file: Blob): Promise<string> => {
 }
 
 export default function AitorChatModal() {
-  const { isOpen, closeChat, initialMessage, clearInitialMessage, initialMode, clearInitialMode } = useAitorChat()
-  const [messages, setMessages] = useState<ExtendedChatMessage[]>([])
+  const {
+    isOpen,
+    isMinimized,
+    closeChat,
+    minimizeChat,
+    restoreChat,
+    initialMessage,
+    clearInitialMessage,
+    messages,
+    setMessages,
+  } = useAitorChat()
   const [isLoading, setIsLoading] = useState(false)
   const [rateLimitInfo, setRateLimitInfo] = useState({ cooldownMs: 0, remainingRequests: 5 })
   const messagesContainerRef = useRef<HTMLDivElement>(null)
@@ -111,9 +116,8 @@ export default function AitorChatModal() {
 
   const handleDisableAitor = useCallback(() => {
     updateMeta({ aiAdvisorEnabled: false })
-    clearInitialMode()
     closeChat()
-  }, [updateMeta, clearInitialMode, closeChat])
+  }, [updateMeta, closeChat])
 
   // Scroll to bottom when new messages arrive
   useEffect(() => {
@@ -127,12 +131,6 @@ export default function AitorChatModal() {
     if (!allotmentData) return ''
 
     const lines: string[] = []
-
-    // Diagnose-mode hint: focuses the model on photo-based symptom diagnosis.
-    if (initialMode === 'diagnose') {
-      lines.push('FOCUS: Focus this conversation on diagnosing plant symptoms from the user\'s photo.')
-      lines.push('')
-    }
 
     // Basic info
     lines.push(`ALLOTMENT: ${allotmentData.meta.name}`)
@@ -171,7 +169,7 @@ export default function AitorChatModal() {
     lines.push(`PERMANENT PLANTINGS: ${[...treeAreas, ...berryAreas].map(p => p.name).join(', ')}`)
 
     return lines.join('\n')
-  }, [allotmentData, currentSeason, selectedYear, getAreasByKind, initialMode])
+  }, [allotmentData, currentSeason, selectedYear, getAreasByKind])
 
   // Update rate limit state
   const updateRateLimitState = useCallback(() => {
@@ -338,7 +336,7 @@ export default function AitorChatModal() {
     } finally {
       setIsLoading(false)
     }
-  }, [messages, token, userLocation, allotmentData, allotmentContext, updateRateLimitState])
+  }, [messages, token, userLocation, allotmentData, allotmentContext, updateRateLimitState, setMessages])
 
   // Handle initial message from context
   useEffect(() => {
@@ -452,16 +450,13 @@ export default function AitorChatModal() {
       setPendingToolCalls(null)
       setIsExecutingTools(false)
     }
-  }, [pendingToolCalls, allotmentData, selectedYear, reloadAllotment])
+  }, [pendingToolCalls, allotmentData, selectedYear, reloadAllotment, setMessages])
 
   return (
     <>
       <Dialog
-        isOpen={isOpen}
-        onClose={() => {
-          clearInitialMode()
-          closeChat()
-        }}
+        isOpen={isOpen && !isMinimized}
+        onClose={closeChat}
         title="Ask Aitor"
         maxWidth="2xl"
         fullContent
@@ -482,6 +477,15 @@ export default function AitorChatModal() {
                   onRetry={detectUserLocation}
                   isDetecting={isDetecting}
                 />
+                <button
+                  onClick={minimizeChat}
+                  className="flex items-center gap-1 text-xs text-zen-stone-500 hover:text-zen-moss-600 transition-colors px-2 py-1 min-h-[44px] md:min-h-0"
+                  aria-label="Minimize Aitor — keep conversation in a pill"
+                  title="Minimize (keeps your conversation)"
+                >
+                  <Minus className="w-3.5 h-3.5" aria-hidden="true" />
+                  <span className="hidden sm:inline">Minimize</span>
+                </button>
                 <button
                   onClick={handleDisableAitor}
                   className="flex items-center gap-1 text-xs text-zen-stone-500 hover:text-zen-kitsune-600 transition-colors px-2 py-1 min-h-[44px] md:min-h-0"
@@ -543,11 +547,27 @@ export default function AitorChatModal() {
               onSubmit={handleSubmit}
               isLoading={isLoading}
               rateLimitInfo={rateLimitInfo}
-              autoOpenFilePicker={isOpen && initialMode === 'diagnose'}
             />
           </div>
         </div>
       </Dialog>
+
+      {/* Minimized pill — replaces the launcher visually while the chat is
+          shrunk. The modal component instance stays mounted (see AitorAuthGate),
+          so `messages` survives a minimize/restore cycle. */}
+      {isMinimized && (
+        <button
+          onClick={restoreChat}
+          className="fixed bottom-6 right-6 z-50 flex items-center gap-2 bg-zen-moss-600 hover:bg-zen-moss-700 text-white px-4 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 min-h-[44px]"
+          aria-label={`Restore Aitor chat (${messages.length} message${messages.length === 1 ? '' : 's'})`}
+          title="Restore Aitor chat"
+        >
+          <Leaf className="w-5 h-5" aria-hidden="true" />
+          <span className="text-sm font-medium">
+            Aitor • {messages.length} msg{messages.length === 1 ? '' : 's'}
+          </span>
+        </button>
+      )}
 
       {/* Toast notification for tool execution feedback */}
       {toast && (

--- a/src/components/ai-advisor/ChatInput.tsx
+++ b/src/components/ai-advisor/ChatInput.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { Send, Camera, X, Clock } from 'lucide-react'
 import Image from 'next/image'
 
@@ -13,22 +13,14 @@ interface ChatInputProps {
   onSubmit: (message: string, image?: File) => void
   isLoading: boolean
   rateLimitInfo?: RateLimitInfo
-  /** When true, auto-opens the file picker once after mount (diagnose mode). */
-  autoOpenFilePicker?: boolean
 }
 
-export default function ChatInput({ onSubmit, isLoading, rateLimitInfo, autoOpenFilePicker }: ChatInputProps) {
+export default function ChatInput({ onSubmit, isLoading, rateLimitInfo }: ChatInputProps) {
   const [input, setInput] = useState('')
   const [selectedImage, setSelectedImage] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const [validationError, setValidationError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    if (autoOpenFilePicker) {
-      fileInputRef.current?.click()
-    }
-  }, [autoOpenFilePicker])
 
   const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValidationError(null)

--- a/src/components/ai-advisor/TokenSettings.tsx
+++ b/src/components/ai-advisor/TokenSettings.tsx
@@ -64,7 +64,7 @@ export default function TokenSettings({
               onKeyDown={handleKeyDown}
               placeholder="Paste your API key here"
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-zen-water-500 focus:border-transparent select-none"
-              aria-describedby="token-help-text token-privacy-notice"
+              aria-describedby="token-help-text"
               autoComplete="off"
             />
           </div>
@@ -81,20 +81,6 @@ export default function TokenSettings({
                 Get one here
               </a>
             </p>
-          </div>
-        </div>
-
-        <div id="token-privacy-notice" className="bg-yellow-50 border border-yellow-200 rounded-md p-3" role="note">
-          <div className="flex items-start">
-            <div className="flex-shrink-0">
-              <Shield className="w-4 h-4 text-yellow-600 mt-0.5" aria-hidden="true" />
-            </div>
-            <div className="ml-2">
-              <p className="text-sm text-yellow-800">
-                <strong>Privacy Notice:</strong> Your token is stored only in your browser session and never saved permanently.
-                It&apos;s sent securely to OpenAI only when making requests.
-              </p>
-            </div>
           </div>
         </div>
 

--- a/src/components/allotment/AllotmentGrid.tsx
+++ b/src/components/allotment/AllotmentGrid.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import ReactGridLayout from 'react-grid-layout'
-import { Lock, Unlock, RotateCcw, Move, Plus } from 'lucide-react'
+import { Lock, Unlock, Move, Plus } from 'lucide-react'
 import {
   DEFAULT_GRID_LAYOUT,
   GridItemConfig
@@ -207,25 +207,6 @@ export default function AllotmentGrid({ onItemSelect, selectedItemRef, getPlanti
     }
   }, [isEditing, items, onPositionChange])
 
-  // Reset to Area default positions (v14: resets AreaSeason positions to Area.gridPosition)
-  const handleReset = useCallback(() => {
-    if (!visibleAreas) {
-      setItems(DEFAULT_GRID_LAYOUT)
-      return
-    }
-
-    // Reuse shared Area -> GridItemConfig mapping, using Area.gridPosition defaults (no areaSeasons)
-    const resetConfig = areasToGridConfig(visibleAreas, undefined)
-    setItems(resetConfig)
-
-    // Update each position via callback
-    if (onPositionChange) {
-      for (const item of resetConfig) {
-        onPositionChange(item.i, { x: item.x, y: item.y, w: item.w, h: item.h })
-      }
-    }
-  }, [visibleAreas, onPositionChange])
-
   // Handle item click - convert grid item to AllotmentItemRef
   const handleItemClick = useCallback((item: GridItemConfig) => {
     if (!onItemSelect) return
@@ -407,14 +388,6 @@ export default function AllotmentGrid({ onItemSelect, selectedItemRef, getPlanti
                 <span className="sm:hidden">Add</span>
               </button>
             )}
-            <button
-              onClick={handleReset}
-              aria-label="Reset layout to default"
-              className="flex items-center gap-1.5 sm:gap-2 px-2.5 sm:px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium bg-zen-kitsune-100 text-zen-kitsune-600 hover:bg-zen-kitsune-200 transition min-h-[44px]"
-            >
-              <RotateCcw className="w-3.5 h-3.5 sm:w-4 sm:h-4" aria-hidden="true" />
-              <span className="hidden sm:inline">Reset</span>
-            </button>
             <button
               onClick={() => setIsEditing(false)}
               aria-label="Lock layout"

--- a/src/contexts/AitorChatContext.tsx
+++ b/src/contexts/AitorChatContext.tsx
@@ -1,66 +1,85 @@
 'use client'
 
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ReactNode,
+  Dispatch,
+  SetStateAction,
+} from 'react'
+import type { ChatMessage as ChatMessageType } from '@/types/api'
 
-export type AitorChatMode = 'chat' | 'diagnose'
+export type ExtendedChatMessage = ChatMessageType & { image?: string }
 
 interface OpenChatOptions {
   initialMessage?: string
-  initialMode?: AitorChatMode
 }
 
 interface AitorChatContextType {
   isOpen: boolean
+  isMinimized: boolean
   openChat: (options?: OpenChatOptions | string) => void
   closeChat: () => void
+  minimizeChat: () => void
+  restoreChat: () => void
   initialMessage: string | null
   clearInitialMessage: () => void
-  initialMode: AitorChatMode
-  clearInitialMode: () => void
+  // Lifted out of the modal so close→reopen does not drop conversation
+  // history when AitorAuthGate unmounts the modal.
+  messages: ExtendedChatMessage[]
+  setMessages: Dispatch<SetStateAction<ExtendedChatMessage[]>>
 }
 
 const AitorChatContext = createContext<AitorChatContextType | null>(null)
 
 export function AitorChatProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false)
+  const [isMinimized, setIsMinimized] = useState(false)
   const [initialMessage, setInitialMessage] = useState<string | null>(null)
-  const [initialMode, setInitialMode] = useState<AitorChatMode>('chat')
+  const [messages, setMessages] = useState<ExtendedChatMessage[]>([])
 
   const openChat = useCallback((options?: OpenChatOptions | string) => {
     if (typeof options === 'string') {
       setInitialMessage(options)
-      setInitialMode('chat')
-    } else if (options) {
-      if (options.initialMessage) setInitialMessage(options.initialMessage)
-      setInitialMode(options.initialMode ?? 'chat')
-    } else {
-      setInitialMode('chat')
+    } else if (options?.initialMessage) {
+      setInitialMessage(options.initialMessage)
     }
+    setIsMinimized(false)
     setIsOpen(true)
   }, [])
 
   const closeChat = useCallback(() => {
     setIsOpen(false)
+    setIsMinimized(false)
+  }, [])
+
+  const minimizeChat = useCallback(() => {
+    setIsMinimized(true)
+  }, [])
+
+  const restoreChat = useCallback(() => {
+    setIsMinimized(false)
   }, [])
 
   const clearInitialMessage = useCallback(() => {
     setInitialMessage(null)
   }, [])
 
-  const clearInitialMode = useCallback(() => {
-    setInitialMode('chat')
-  }, [])
-
   return (
     <AitorChatContext.Provider
       value={{
         isOpen,
+        isMinimized,
         openChat,
         closeChat,
+        minimizeChat,
+        restoreChat,
         initialMessage,
         clearInitialMessage,
-        initialMode,
-        clearInitialMode,
+        messages,
+        setMessages,
       }}
     >
       {children}

--- a/src/lib/openai-client.ts
+++ b/src/lib/openai-client.ts
@@ -146,24 +146,22 @@ When analyzing plant photos, examine:
 
 Provide specific, actionable diagnosis and treatment recommendations based on visual observations.
 
-🌿 COMMUNICATION STYLE:
-- Warm, encouraging, and knowledgeable tone
-- Practical, step-by-step guidance
-- Focus on sustainable and organic methods
-- Consider resource constraints of home gardeners
-- Adapt advice to experience level (beginner to advanced)
-- Always introduce yourself as "Aitor" when first meeting users
-- When analyzing photos, describe what you observe before giving advice
+🌿 COMMUNICATION STYLE — read carefully, the user has explicitly asked for concise replies:
+- Keep responses short and chat-like. Aim for 2–4 sentences. Treat this as a text conversation, not an essay.
+- No preamble. Do NOT introduce yourself ("Hello! I'm Aitor…"), do NOT name the user's allotment back to them, do NOT restate the question. Answer directly.
+- No filler ("Great question!", "I'd love to help!", "Feel free to ask…"). No closing sign-off ("Aitor's Tip", "Happy growing!").
+- Match the user's depth. A quick question gets a quick answer. Only expand into structured, multi-section explanations when the user asks for detail ("explain more", "step by step", "why").
+- Use bullet points sparingly — only when listing 3+ genuinely discrete items. Prefer flowing prose for everything else.
+- Reference the user's allotment data only when it changes the answer.
+- Ask one clarifying question only if it would meaningfully change your answer; otherwise just give your best answer.
+- Photo replies: name what you see in one short sentence, then give the action. Skip the lecture.
 
 🌿 APPROACH:
-- Ask clarifying questions about location, current conditions, and experience level
-- Provide specific, actionable recommendations
-- Explain the 'why' behind gardening practices
-- Suggest timing for tasks and activities
-- Offer alternatives for different budgets and skill levels
-- When photos are provided, give detailed visual analysis first, then comprehensive treatment advice
+- Lead with the answer or recommendation. Add explanation only if needed for the user to act.
+- Default to organic / low-resource methods, but don't moralise about it.
+- When photos are provided, identify the issue, then give the fix.
 
-Your goal is to help every gardener succeed, whether they're just starting their first vegetable patch or managing an established allotment plot.`
+Your goal: help the gardener and let them get back to gardening.`
 }
 
 /**


### PR DESCRIPTION
## Summary

Multi-persona parallel work on the allotment + AI advisor surface, then debated by two reviewer agents (Sam — UX skeptic; Cleo — architecture critic). Their blockers are resolved in this PR.

- **Allotment grid**: removed the `Reset` toolbar button (reshuffled layout on misclick).
- **Settings**: removed the OpenAI token *Privacy Notice* block. Settings now opens on **AI & Location** for signed-in users (uses a `key` remount to survive Clerk's async auth — Sam caught this race).
- **Floating buttons**: merged *Diagnose a plant* + *Ask Aitor* into a single launcher; photo upload still works from inside the chat.
- **Chat performance**: `AitorChatModal` is now lazy-mounted via `next/dynamic` and only rendered while the chat is open or minimized. Previously its `useAllotment` / `useApiToken` / `useLocation` hooks and the heavy `allotmentContext` `useMemo` ran on every parent re-render (parent is the root layout), which the user reported as "extremely slow".
- **Minimize**: a `Minimize` button shrinks the dialog to a fixed-corner pill. The conversation state survives because the gate keeps the modal mounted while `isOpen || isMinimized`.
- **Aitor tone**: tightened the system prompt in both `route.ts` and `openai-client.ts` to discourage essay-style answers (no self-introduction, no preamble, 2–4 sentence default, prose over multi-section structure).

### Reviewer fixes also addressed
- Cleo's blocker: `vi.mock('@/components/ai-advisor/AitorChatModal')` was being bypassed by `next/dynamic`'s async loader. Added a `next/dynamic` mock so the stub resolves and assertions stay stable.
- Sam's blocker: `defaultTab` is only read on initial mount, so Clerk resolving signed-in after mount stranded users on Data. Fixed via `key={isSignedIn ? 'signed-in' : 'signed-out'}`.
- Empty `describe('Position changes', () => {})` block removed (Vitest fails empty suites).
- `AitorChatButton` now also short-circuits on `isMinimized` so the launcher and the minimized pill can never co-exist in the same corner.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit` — 60 files, 1039 passing
- [ ] Manual: open `/settings` while signed in, confirm AI tab is selected
- [ ] Manual: open Aitor, minimize → click pill → conversation restored
- [ ] Manual: ask "Why is my chard bolting?" and confirm the reply is short (no "Hello, I'm Aitor…" preamble, no "Aitor's Tip" sign-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)