### PR TITLE
feat: clicking a planting's name opens the plant info dialog

### DIFF
--- a/src/__tests__/components/PlantingCard.test.tsx
+++ b/src/__tests__/components/PlantingCard.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for PlantingCard component.
+ *
+ * Covers the plant-name-as-button affordance: when `onPlantInfo` is provided
+ * and the planting maps to a known vegetable, the plant name renders as a
+ * button that opens the plant info dialog without triggering the card's
+ * own `onClick` (planting detail dialog).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PlantingCard from '@/components/allotment/PlantingCard'
+import type { Planting } from '@/types/unified-allotment'
+import type { Vegetable } from '@/types/garden-planner'
+
+const mockTomato: Vegetable = {
+  id: 'tomato',
+  name: 'Tomato',
+  category: 'solanaceae',
+  description: 'A juicy fruiting vegetable',
+  botanicalName: 'Solanum lycopersicum',
+  planting: {
+    sowIndoorsMonths: [2, 3, 4],
+    sowOutdoorsMonths: [],
+    transplantMonths: [5, 6],
+    harvestMonths: [7, 8, 9, 10],
+    daysToHarvest: { min: 60, max: 85 },
+  },
+  care: {
+    sun: 'full-sun',
+    water: 'moderate',
+    spacing: { between: 45, rows: 60 },
+    depth: 1,
+    difficulty: 'intermediate',
+    tips: [],
+  },
+  enhancedCompanions: [],
+  enhancedAvoid: [],
+}
+
+vi.mock('@/lib/vegetable-database', () => ({
+  getVegetableById: (id: string) => (id === 'tomato' ? mockTomato : undefined),
+}))
+
+vi.mock('@/lib/companion-utils', () => ({
+  getCompanionStatusForPlanting: () => ({ goods: [], bads: [] }),
+}))
+
+function makePlanting(overrides: Partial<Planting> = {}): Planting {
+  return {
+    id: 'p1',
+    plantId: 'tomato',
+    ...overrides,
+  }
+}
+
+describe('PlantingCard', () => {
+  it('renders the plant name as a button when onPlantInfo is provided', () => {
+    const onPlantInfo = vi.fn()
+    const onUpdate = vi.fn()
+
+    render(
+      <PlantingCard
+        planting={makePlanting()}
+        onUpdate={onUpdate}
+        onPlantInfo={onPlantInfo}
+      />
+    )
+
+    const nameButton = screen.getByRole('button', { name: /info about tomato/i })
+    expect(nameButton).toBeInTheDocument()
+    expect(nameButton).toHaveTextContent('Tomato')
+  })
+
+  it('clicking the plant name calls onPlantInfo and does not bubble to the card onClick', async () => {
+    const user = userEvent.setup()
+    const onPlantInfo = vi.fn()
+    const onClick = vi.fn()
+    const onUpdate = vi.fn()
+
+    render(
+      <PlantingCard
+        planting={makePlanting()}
+        onUpdate={onUpdate}
+        onPlantInfo={onPlantInfo}
+        onClick={onClick}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /info about tomato/i }))
+
+    expect(onPlantInfo).toHaveBeenCalledTimes(1)
+    expect(onPlantInfo).toHaveBeenCalledWith('tomato')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('renders the plant name as plain text when onPlantInfo is not provided', () => {
+    const onUpdate = vi.fn()
+
+    render(<PlantingCard planting={makePlanting()} onUpdate={onUpdate} />)
+
+    expect(
+      screen.queryByRole('button', { name: /info about tomato/i })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('Tomato')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/components/PlantingCard.test.tsx
+++ b/src/__tests__/components/PlantingCard.test.tsx
@@ -95,6 +95,29 @@ describe('PlantingCard', () => {
     expect(onClick).not.toHaveBeenCalled()
   })
 
+  it('pressing Enter on the plant name calls onPlantInfo and does not bubble to the card onClick', async () => {
+    const user = userEvent.setup()
+    const onPlantInfo = vi.fn()
+    const onClick = vi.fn()
+    const onUpdate = vi.fn()
+
+    render(
+      <PlantingCard
+        planting={makePlanting()}
+        onUpdate={onUpdate}
+        onPlantInfo={onPlantInfo}
+        onClick={onClick}
+      />
+    )
+
+    const nameButton = screen.getByRole('button', { name: /info about tomato/i })
+    nameButton.focus()
+    await user.keyboard('{Enter}')
+
+    expect(onPlantInfo).toHaveBeenCalledTimes(1)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
   it('renders the plant name as plain text when onPlantInfo is not provided', () => {
     const onUpdate = vi.fn()
 

--- a/src/components/allotment/PlantingCard.tsx
+++ b/src/components/allotment/PlantingCard.tsx
@@ -71,6 +71,7 @@ export default function PlantingCard({
                   e.stopPropagation()
                   onPlantInfo(planting.plantId)
                 }}
+                onKeyDown={(e) => e.stopPropagation()}
                 className="font-medium text-zen-ink-800 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-zen-moss-500 focus-visible:ring-offset-1 rounded-sm bg-transparent p-0 text-left"
                 aria-label={`Info about ${veg.name}`}
                 title={`About ${veg.name}`}

--- a/src/components/allotment/PlantingCard.tsx
+++ b/src/components/allotment/PlantingCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import { AlertTriangle, Check, Droplets, Sun, ArrowRight, Calendar, Info } from 'lucide-react'
+import { AlertTriangle, Check, Droplets, Sun, ArrowRight, Calendar } from 'lucide-react'
 import { getVegetableById } from '@/lib/vegetable-database'
 import { getCompanionStatusForPlanting } from '@/lib/companion-utils'
 import { getCrossYearDisplayInfo } from '@/lib/date-calculator'
@@ -64,22 +64,23 @@ export default function PlantingCard({
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className="font-medium text-zen-ink-800">
-              {veg?.name || planting.plantId}
-            </span>
-            {onPlantInfo && veg && (
+            {onPlantInfo && veg ? (
               <button
                 type="button"
                 onClick={(e) => {
                   e.stopPropagation()
                   onPlantInfo(planting.plantId)
                 }}
-                className="p-1 text-zen-stone-400 hover:text-zen-moss-600 transition-colors rounded-zen"
+                className="font-medium text-zen-ink-800 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-zen-moss-500 focus-visible:ring-offset-1 rounded-sm bg-transparent p-0 text-left"
                 aria-label={`Info about ${veg.name}`}
                 title={`About ${veg.name}`}
               >
-                <Info className="w-3.5 h-3.5" />
+                {veg.name}
               </button>
+            ) : (
+              <span className="font-medium text-zen-ink-800">
+                {veg?.name || planting.plantId}
+              </span>
             )}
             <span
               className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full ${getPhaseColors(phaseInfo.color)}`}


### PR DESCRIPTION
## Summary
- Plant name in `PlantingCard` is now a button that opens the existing `PlantSummaryDialog` (the calendar + sun/water/spacing/depth panel).
- Removes the small `(i)` info icon — the name itself is now the discoverable affordance. Card click still opens the planting detail dialog; the name button stops propagation.

## Test plan
- [x] `npm run type-check`, `npm run lint`, `npm run test:unit` all pass
- [ ] Manual check: in BedDetailPanel and MobileAreaBottomSheet, clicking the plant name opens PlantSummaryDialog; clicking elsewhere on the card still opens the planting detail dialog