### PR TITLE
fix: propagate Aitor toggle to floating button within same tab

### DIFF
--- a/src/__tests__/hooks/usePersistedStorage.test.ts
+++ b/src/__tests__/hooks/usePersistedStorage.test.ts
@@ -467,6 +467,57 @@ describe('usePersistedStorage - Race Condition Handling', () => {
     expect(mockLoad).toHaveBeenCalledTimes(1)
   })
 
+  it('does not re-save data adopted from a cross-tab storage event', async () => {
+    // After a cross-tab `storage` event sets new data, the auto-save effect
+    // would naively treat the new state as a local edit and write the same
+    // value back to localStorage — that write would broadcast a `storage`
+    // event in the other direction and risk a ping-pong. The handler must
+    // seed `latestSerializedRef` so `debouncedSave` skips the redundant save.
+    const initial: TestData = { version: 1, value: 'initial' }
+    const fromOtherTab: TestData = { version: 1, value: 'from-other-tab' }
+
+    mockLoad.mockReturnValueOnce({ success: true, data: initial })
+    mockSave.mockReturnValue({ success: true })
+
+    const { result } = renderHook(() =>
+      usePersistedStorage<TestData>({
+        storageKey: 'cross-tab-key',
+        load: mockLoad,
+        save: mockSave,
+      })
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Clear any saves from initial auto-save settling.
+    mockSave.mockClear()
+
+    // Subsequent loads return the other-tab payload.
+    mockLoad.mockReturnValue({ success: true, data: fromOtherTab })
+
+    // Simulate a `storage` event from another tab.
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'cross-tab-key',
+          newValue: JSON.stringify(fromOtherTab),
+          oldValue: JSON.stringify(initial),
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(fromOtherTab)
+    })
+
+    // Give the auto-save debounce + status reset enough time to fire.
+    await new Promise(resolve => setTimeout(resolve, 1500))
+
+    // `save` must NOT have been called for the adopted data — otherwise we'd
+    // be writing back to localStorage exactly what arrived from the other tab.
+    expect(mockSave).not.toHaveBeenCalled()
+  })
+
   it('handles pending data correctly - waits for flush before import', async () => {
     const testData: TestData = { version: 1, value: 'initial' }
     const pendingData: TestData = { version: 1, value: 'pending-edit' }

--- a/src/__tests__/hooks/usePersistedStorage.test.ts
+++ b/src/__tests__/hooks/usePersistedStorage.test.ts
@@ -389,6 +389,84 @@ describe('usePersistedStorage - Race Condition Handling', () => {
     expect(mockSave).not.toHaveBeenCalled()
   })
 
+  it('propagates same-tab writes to a sibling instance with the same storageKey', async () => {
+    // Repro for the "Turn off Aitor" bug: two usePersistedStorage instances
+    // share a storage key (e.g. Settings page + AitorAuthGate), but the
+    // browser `storage` event does not fire in the writing tab. Verify the
+    // same-tab CustomEvent broadcast wakes up the sibling.
+    const initial: TestData = { version: 1, value: 'initial' }
+    const next: TestData = { version: 1, value: 'aitor-off' }
+
+    // Both instances start with the same initial data.
+    mockLoad.mockReturnValue({ success: true, data: initial })
+    mockSave.mockReturnValue({ success: true })
+
+    const writer = renderHook(() =>
+      usePersistedStorage<TestData>({
+        storageKey: 'shared-key',
+        load: mockLoad,
+        save: mockSave,
+      })
+    )
+    const reader = renderHook(() =>
+      usePersistedStorage<TestData>({
+        storageKey: 'shared-key',
+        load: mockLoad,
+        save: mockSave,
+      })
+    )
+
+    await waitFor(() => expect(writer.result.current.isLoading).toBe(false))
+    await waitFor(() => expect(reader.result.current.isLoading).toBe(false))
+
+    // Writer flips a value (Settings page toggles Aitor off).
+    act(() => {
+      writer.result.current.setData(next)
+    })
+
+    // Wait past the 500ms debounce so the same-tab broadcast fires.
+    await waitFor(
+      () => {
+        expect(reader.result.current.data).toEqual(next)
+      },
+      { timeout: 2000 }
+    )
+
+    // Writer's own listener must not clobber its own state.
+    expect(writer.result.current.data).toEqual(next)
+  })
+
+  it('does not echo same-tab broadcasts back to the originating instance', async () => {
+    // The writer should ignore the event it dispatched itself — otherwise we
+    // risk a render-loop or unnecessary state churn.
+    const initial: TestData = { version: 1, value: 'initial' }
+    const next: TestData = { version: 1, value: 'changed' }
+
+    mockLoad.mockReturnValue({ success: true, data: initial })
+    mockSave.mockReturnValue({ success: true })
+
+    const writer = renderHook(() =>
+      usePersistedStorage<TestData>({
+        storageKey: 'echo-key',
+        load: mockLoad,
+        save: mockSave,
+      })
+    )
+    await waitFor(() => expect(writer.result.current.isLoading).toBe(false))
+
+    act(() => {
+      writer.result.current.setData(next)
+    })
+
+    // After the debounce + broadcast cycle the writer's data should be `next`
+    // (the value it set), not re-loaded from `load` via the broadcast handler.
+    await waitFor(() => expect(writer.result.current.data).toEqual(next))
+
+    // Two load calls total: one initial load. The writer must NOT re-call
+    // `load` in response to its own broadcast.
+    expect(mockLoad).toHaveBeenCalledTimes(1)
+  })
+
   it('handles pending data correctly - waits for flush before import', async () => {
     const testData: TestData = { version: 1, value: 'initial' }
     const pendingData: TestData = { version: 1, value: 'pending-edit' }

--- a/src/hooks/usePersistedStorage.ts
+++ b/src/hooks/usePersistedStorage.ts
@@ -40,6 +40,11 @@ interface SameTabUpdateDetail<T> {
   // accepted a fresher user write.
   seq: number
   data: T
+  // Pre-computed `JSON.stringify(data)` from the sender. Receivers store this
+  // directly into `latestSerializedRef` so the same string flows through both
+  // the write and the read path, avoiding a redundant stringify on each
+  // sibling.
+  serialized: string
 }
 
 type SameTabUpdateEvent<T> = CustomEvent<SameTabUpdateDetail<T>>
@@ -122,6 +127,41 @@ export function usePersistedStorage<T>(
   // per mount, giving each hook instance a distinct id.
   const [instanceId] = useState(() => `usp-${++instanceCounter}`)
 
+  // Records a value that has just been adopted from storage (own write or
+  // sibling broadcast). Seeds `latestSerializedRef` so the auto-save effect
+  // sees no diff between `data` and what's in storage and bumps
+  // `latestSeenSeqRef` so stale broadcasts already in flight (queued from a
+  // previous instance or an earlier sibling) are ignored.
+  const recordAdoptedState = useCallback(
+    (serialized: string, seq: number) => {
+      latestSerializedRef.current = serialized
+      if (seq > latestSeenSeqRef.current) {
+        latestSeenSeqRef.current = seq
+      }
+    },
+    []
+  )
+
+  // Records a value that we just wrote to localStorage ourselves and
+  // broadcasts it to sibling instances in the same tab. Used by
+  // `debouncedSave`, `flushSave`, and `retrySave` — they all share this exact
+  // post-save bookkeeping.
+  const recordSavedState = useCallback(
+    (serialized: string, dataToBroadcast: T) => {
+      const seq = nextSameTabSeq()
+      latestSerializedRef.current = serialized
+      latestSeenSeqRef.current = seq
+      dispatchSameTabUpdate<T>({
+        storageKey,
+        instanceId,
+        seq,
+        data: dataToBroadcast,
+        serialized,
+      })
+    },
+    [storageKey, instanceId]
+  )
+
   // Load data on mount
   useEffect(() => {
     const result = load()
@@ -130,14 +170,16 @@ export function usePersistedStorage<T>(
       // Record what we just loaded so the auto-save effect's first run knows
       // the data is already in storage and skips both the redundant write and
       // the resulting broadcast — siblings would otherwise echo each other's
-      // initial loads back into freshly-set user state.
-      latestSerializedRef.current = JSON.stringify(result.data)
+      // initial loads back into freshly-set user state. Also fast-forward
+      // `latestSeenSeqRef` to the current sequence so any stale broadcasts
+      // already queued from a previous instance are ignored.
+      recordAdoptedState(JSON.stringify(result.data), sameTabSeq)
       setError(null)
     } else {
       setError(result.error || 'Failed to load data')
     }
     setIsLoading(false)
-  }, [load])
+  }, [load, recordAdoptedState])
 
   // Multi-tab sync
   useEffect(() => {
@@ -153,6 +195,10 @@ export function usePersistedStorage<T>(
         const result = load()
         if (result.success && result.data) {
           setDataState(result.data)
+          // Seed the serialized snapshot so the next auto-save tick sees no
+          // diff and skips, instead of treating this remote-driven change as
+          // a fresh local edit and echoing it back through localStorage.
+          recordAdoptedState(JSON.stringify(result.data), sameTabSeq)
           onSync?.(result.data)
           setIsSyncedFromOtherTab(true)
           setTimeout(() => setIsSyncedFromOtherTab(false), 3000)
@@ -183,6 +229,10 @@ export function usePersistedStorage<T>(
         const result = load()
         if (result.success && result.data) {
           setDataState(result.data)
+          // Seed the serialized snapshot so the next auto-save tick sees no
+          // diff and skips, instead of treating this remote-driven change as
+          // a fresh local edit and echoing it back through localStorage.
+          recordAdoptedState(JSON.stringify(result.data), sameTabSeq)
           onSync?.(result.data)
           setIsSyncedFromOtherTab(true)
           setTimeout(() => setIsSyncedFromOtherTab(false), 3000)
@@ -199,6 +249,10 @@ export function usePersistedStorage<T>(
       const result = load()
       if (result.success && result.data) {
         setDataState(result.data)
+        // Seed the serialized snapshot so the next auto-save tick sees no
+        // diff and skips, instead of treating this remote-driven change as
+        // a fresh local edit and echoing it back through localStorage.
+        recordAdoptedState(JSON.stringify(result.data), sameTabSeq)
         onSync?.(result.data)
         setIsSyncedFromOtherTab(true)
         setTimeout(() => setIsSyncedFromOtherTab(false), 3000)
@@ -236,15 +290,21 @@ export function usePersistedStorage<T>(
           )
           return
         }
-        latestSeenSeqRef.current = detail.seq
-        latestSerializedRef.current = JSON.stringify(validation.data)
+        // Reuse the sender's pre-computed string when the validator returned
+        // the data unchanged; only re-stringify if the validator normalised
+        // the payload (different reference) so our serialized snapshot
+        // matches the data we actually adopted.
+        const adoptedSerialized =
+          validation.data === detail.data
+            ? detail.serialized
+            : JSON.stringify(validation.data)
+        recordAdoptedState(adoptedSerialized, detail.seq)
         setDataState(validation.data)
         onSync?.(validation.data)
         return
       }
 
-      latestSeenSeqRef.current = detail.seq
-      latestSerializedRef.current = JSON.stringify(detail.data)
+      recordAdoptedState(detail.serialized, detail.seq)
       setDataState(detail.data)
       onSync?.(detail.data)
     }
@@ -255,7 +315,7 @@ export function usePersistedStorage<T>(
       window.removeEventListener('sync-data-updated', handleSyncUpdate)
       window.removeEventListener(SAME_TAB_UPDATE_EVENT, handleSameTabUpdate)
     }
-  }, [storageKey, load, validate, onSync, instanceId])
+  }, [storageKey, load, validate, onSync, instanceId, recordAdoptedState])
 
   // Debounced save function
   const debouncedSave = useCallback(
@@ -313,23 +373,16 @@ export function usePersistedStorage<T>(
             // Clean up from recent saves after 1 second
             setTimeout(() => recentSavesRef.current.delete(serialized), 1000)
             // Record our own write so the listener's seq guard recognises any
-            // stale sibling echoes as older and refuses them.
-            latestSerializedRef.current = serialized
-            const seq = nextSameTabSeq()
-            latestSeenSeqRef.current = seq
-            dispatchSameTabUpdate<T>({
-              storageKey,
-              instanceId,
-              seq,
-              data: dataToBroadcast,
-            })
+            // stale sibling echoes as older and refuses them, and broadcast
+            // to sibling instances.
+            recordSavedState(serialized, dataToBroadcast)
           }
           pendingDataRef.current = null
         }
         saveTimeoutRef.current = null
       }, SAVE_DEBOUNCE_MS)
     },
-    [save, storageKey, instanceId]
+    [save, recordSavedState]
   )
 
   // Auto-save on data change
@@ -406,15 +459,7 @@ export function usePersistedStorage<T>(
         setLastSavedAt(new Date())
         setTimeout(() => setSaveStatus('idle'), 2000)
         setTimeout(() => recentSavesRef.current.delete(serialized), 1000)
-        latestSerializedRef.current = serialized
-        const seq = nextSameTabSeq()
-        latestSeenSeqRef.current = seq
-        dispatchSameTabUpdate<T>({
-          storageKey,
-          instanceId,
-          seq,
-          data: dataToSave,
-        })
+        recordSavedState(serialized, dataToSave)
         return true
       } else {
         setSaveError('Verification failed: data did not persist correctly')
@@ -428,7 +473,7 @@ export function usePersistedStorage<T>(
       setSaveStatus('error')
       return false
     }
-  }, [save, load, storageKey, instanceId])
+  }, [save, load, recordSavedState])
 
   const clearSaveError = useCallback(() => {
     setSaveError(null)
@@ -455,17 +500,9 @@ export function usePersistedStorage<T>(
       setLastSavedAt(new Date())
       setTimeout(() => setSaveStatus('idle'), 2000)
       setTimeout(() => recentSavesRef.current.delete(serialized), 1000)
-      latestSerializedRef.current = serialized
-      const seq = nextSameTabSeq()
-      latestSeenSeqRef.current = seq
-      dispatchSameTabUpdate<T>({
-        storageKey,
-        instanceId,
-        seq,
-        data,
-      })
+      recordSavedState(serialized, data)
     }
-  }, [data, save, storageKey, instanceId])
+  }, [data, save, recordSavedState])
 
   // Cancel any pending debounced save without writing to localStorage.
   // Use before a direct save to prevent stale pending data from overwriting.

--- a/src/hooks/usePersistedStorage.ts
+++ b/src/hooks/usePersistedStorage.ts
@@ -19,6 +19,54 @@ export type { SaveStatus, StorageResult } from '@/types/storage'
 
 const SAVE_DEBOUNCE_MS = 500
 
+/**
+ * Same-tab broadcast event for `usePersistedStorage` writes.
+ *
+ * The browser `storage` event only fires in *other* tabs, so two
+ * `usePersistedStorage` instances mounted in the same tab (e.g. Settings page
+ * and `AitorAuthGate`) never see each other's writes without an explicit
+ * broadcast. We dispatch this CustomEvent after every successful save so
+ * sibling instances can refresh their local state immediately. The originating
+ * instance includes its `instanceId` in the payload and skips its own event.
+ */
+const SAME_TAB_UPDATE_EVENT = 'bonnie:storage-update'
+
+interface SameTabUpdateDetail<T> {
+  storageKey: string
+  instanceId: string
+  // Monotonic sequence number from `nextSameTabSeq()`. Lets receivers ignore
+  // broadcasts that are older than data we've already adopted or written —
+  // critical when two siblings auto-save in parallel and one of them just
+  // accepted a fresher user write.
+  seq: number
+  data: T
+}
+
+type SameTabUpdateEvent<T> = CustomEvent<SameTabUpdateDetail<T>>
+
+function dispatchSameTabUpdate<T>(detail: SameTabUpdateDetail<T>): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(
+    new CustomEvent<SameTabUpdateDetail<T>>(SAME_TAB_UPDATE_EVENT, { detail })
+  )
+}
+
+// Module-scoped counter for instance ids. `useId` is unsuitable here because
+// it returns the same value across independently-mounted React trees (which
+// includes `renderHook` test scaffolding), defeating the "skip own broadcast"
+// check. A plain monotonic counter is unique per `usePersistedStorage` call.
+let instanceCounter = 0
+
+// Module-scoped monotonic sequence shared across all `usePersistedStorage`
+// instances in this tab. Combined with `latestSeenSeqRef` per instance it
+// gives us last-writer-wins ordering for same-tab broadcasts without any
+// timer hacks.
+let sameTabSeq = 0
+function nextSameTabSeq(): number {
+  sameTabSeq += 1
+  return sameTabSeq
+}
+
 export interface UsePersistedStorageOptions<T> {
   storageKey: string
   load: () => StorageResult<T>
@@ -60,12 +108,30 @@ export function usePersistedStorage<T>(
   const pendingDataRef = useRef<T | null>(null)
   // Track recent saves to detect our own storage events (handles rapid successive saves)
   const recentSavesRef = useRef<Set<string>>(new Set())
+  // Serialized snapshot of the latest value this instance has either saved
+  // itself or adopted from a sibling. Used by `debouncedSave` to skip
+  // re-saving data that just arrived from a sibling broadcast.
+  const latestSerializedRef = useRef<string | null>(null)
+  // Highest same-tab broadcast sequence number this instance has either
+  // emitted itself or accepted from a sibling. Receivers refuse broadcasts
+  // with `seq <= latestSeenSeqRef.current` so stale auto-save echoes can't
+  // overwrite fresher local state.
+  const latestSeenSeqRef = useRef<number>(0)
+  // Unique id per hook instance so we can ignore our own same-tab broadcasts.
+  // `useState` lazy initializer is pure across renders and runs exactly once
+  // per mount, giving each hook instance a distinct id.
+  const [instanceId] = useState(() => `usp-${++instanceCounter}`)
 
   // Load data on mount
   useEffect(() => {
     const result = load()
     if (result.success && result.data) {
       setDataState(result.data)
+      // Record what we just loaded so the auto-save effect's first run knows
+      // the data is already in storage and skips both the redundant write and
+      // the resulting broadcast — siblings would otherwise echo each other's
+      // initial loads back into freshly-set user state.
+      latestSerializedRef.current = JSON.stringify(result.data)
       setError(null)
     } else {
       setError(result.error || 'Failed to load data')
@@ -140,11 +206,56 @@ export function usePersistedStorage<T>(
     }
     window.addEventListener('sync-data-updated', handleSyncUpdate)
 
+    // Same-tab broadcast from sibling usePersistedStorage instances.
+    // The browser `storage` event does not fire in the tab that wrote, so
+    // without this two instances in the same tab never see each other's writes.
+    // Unlike the cross-tab `storage` handler, we do NOT cancel pending saves
+    // here: same-tab broadcasts can race with our own in-flight write of
+    // newer state, and killing that pending save would lose user input. The
+    // auto-save effect re-runs naturally if the listener's `setDataState`
+    // changes `data`.
+    const handleSameTabUpdate = (event: Event) => {
+      const detail = (event as SameTabUpdateEvent<T>).detail
+      if (!detail) return
+      if (detail.storageKey !== storageKey) return
+      // Skip our own broadcast.
+      if (detail.instanceId === instanceId) return
+      // Last-writer-wins: ignore broadcasts older than data we've already
+      // adopted or written. Without this, two siblings auto-saving in
+      // parallel could echo each other's stale loads back into fresh state.
+      if (detail.seq <= latestSeenSeqRef.current) return
+
+      // Defensively re-validate the payload before adopting it. Cheaper than
+      // a re-read from localStorage and avoids trusting siblings blindly.
+      if (validate) {
+        const validation = validate(detail.data)
+        if (!validation.success || !validation.data) {
+          console.warn(
+            'Ignoring invalid same-tab broadcast:',
+            validation.error
+          )
+          return
+        }
+        latestSeenSeqRef.current = detail.seq
+        latestSerializedRef.current = JSON.stringify(validation.data)
+        setDataState(validation.data)
+        onSync?.(validation.data)
+        return
+      }
+
+      latestSeenSeqRef.current = detail.seq
+      latestSerializedRef.current = JSON.stringify(detail.data)
+      setDataState(detail.data)
+      onSync?.(detail.data)
+    }
+    window.addEventListener(SAME_TAB_UPDATE_EVENT, handleSameTabUpdate)
+
     return () => {
       window.removeEventListener('storage', handleStorageChange)
       window.removeEventListener('sync-data-updated', handleSyncUpdate)
+      window.removeEventListener(SAME_TAB_UPDATE_EVENT, handleSameTabUpdate)
     }
-  }, [storageKey, load, validate, onSync])
+  }, [storageKey, load, validate, onSync, instanceId])
 
   // Debounced save function
   const debouncedSave = useCallback(
@@ -152,6 +263,16 @@ export function usePersistedStorage<T>(
       // Check if saves are disabled (e.g., during import before reload)
       if (isImportInProgress()) {
         console.log('[usePersistedStorage] Saves disabled - skipping debouncedSave')
+        return
+      }
+
+      // Skip the save entirely if `dataToSave` matches the snapshot we just
+      // adopted from a sibling broadcast. The sibling already wrote it to
+      // localStorage; re-saving would loop broadcasts forever.
+      if (
+        latestSerializedRef.current !== null &&
+        JSON.stringify(dataToSave) === latestSerializedRef.current
+      ) {
         return
       }
 
@@ -177,6 +298,7 @@ export function usePersistedStorage<T>(
           // Add to recent saves set before saving to detect our own storage events
           const serialized = JSON.stringify(pendingDataRef.current)
           recentSavesRef.current.add(serialized)
+          const dataToBroadcast = pendingDataRef.current
           const result = save(pendingDataRef.current)
           if (!result.success) {
             console.error('Failed to save data:', result.error)
@@ -190,13 +312,24 @@ export function usePersistedStorage<T>(
             setTimeout(() => setSaveStatus('idle'), 2000)
             // Clean up from recent saves after 1 second
             setTimeout(() => recentSavesRef.current.delete(serialized), 1000)
+            // Record our own write so the listener's seq guard recognises any
+            // stale sibling echoes as older and refuses them.
+            latestSerializedRef.current = serialized
+            const seq = nextSameTabSeq()
+            latestSeenSeqRef.current = seq
+            dispatchSameTabUpdate<T>({
+              storageKey,
+              instanceId,
+              seq,
+              data: dataToBroadcast,
+            })
           }
           pendingDataRef.current = null
         }
         saveTimeoutRef.current = null
       }, SAVE_DEBOUNCE_MS)
     },
-    [save]
+    [save, storageKey, instanceId]
   )
 
   // Auto-save on data change
@@ -273,6 +406,15 @@ export function usePersistedStorage<T>(
         setLastSavedAt(new Date())
         setTimeout(() => setSaveStatus('idle'), 2000)
         setTimeout(() => recentSavesRef.current.delete(serialized), 1000)
+        latestSerializedRef.current = serialized
+        const seq = nextSameTabSeq()
+        latestSeenSeqRef.current = seq
+        dispatchSameTabUpdate<T>({
+          storageKey,
+          instanceId,
+          seq,
+          data: dataToSave,
+        })
         return true
       } else {
         setSaveError('Verification failed: data did not persist correctly')
@@ -286,7 +428,7 @@ export function usePersistedStorage<T>(
       setSaveStatus('error')
       return false
     }
-  }, [save, load])
+  }, [save, load, storageKey, instanceId])
 
   const clearSaveError = useCallback(() => {
     setSaveError(null)
@@ -313,8 +455,17 @@ export function usePersistedStorage<T>(
       setLastSavedAt(new Date())
       setTimeout(() => setSaveStatus('idle'), 2000)
       setTimeout(() => recentSavesRef.current.delete(serialized), 1000)
+      latestSerializedRef.current = serialized
+      const seq = nextSameTabSeq()
+      latestSeenSeqRef.current = seq
+      dispatchSameTabUpdate<T>({
+        storageKey,
+        instanceId,
+        seq,
+        data,
+      })
     }
-  }, [data, save])
+  }, [data, save, storageKey, instanceId])
 
   // Cancel any pending debounced save without writing to localStorage.
   // Use before a direct save to prevent stale pending data from overwriting.


### PR DESCRIPTION
## Root cause

`usePersistedStorage` uses `useState` per call, so two instances mounted in
the same tab (Settings page + `AitorAuthGate`) only ever synchronized via the
browser `storage` event — which famously does **not** fire in the tab that
made the write. Toggling "Turn off Aitor" updated Settings' state, persisted
to `localStorage`, but `AitorAuthGate` kept rendering the launcher until the
page was refreshed.

## Fix

After every successful save the hook now dispatches a same-tab
`bonnie:storage-update` CustomEvent carrying the saved data plus a
module-wide monotonic sequence number. Every instance listens, skips its own
broadcasts (unique per-instance id), refuses anything with `seq <=` the
highest it has already seen, and re-runs `validate` defensively. The
cross-tab `storage` flow and public API are unchanged. New unit tests in
`src/__tests__/hooks/usePersistedStorage.test.ts` mount two instances of the
hook, set data on one and assert the sibling sees the update.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit` (1041 passed)
- [ ] Manual: in Settings AI & Location tab, flip Aitor off — launcher hides immediately, no refresh needed