### PR TITLE
feat(yjs): Step 3 PR-B.2 — port useCompost to two-branch methods (closes the spec-inventory gap)

### DIFF
--- a/src/__tests__/hooks/allotment-path-parity.test.ts
+++ b/src/__tests__/hooks/allotment-path-parity.test.ts
@@ -25,9 +25,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act, waitFor, type RenderHookResult } from '@testing-library/react'
 import { STORAGE_KEY } from '@/types/unified-allotment'
 import type { AllotmentData } from '@/types/unified-allotment'
+import type { CompostData } from '@/types/compost'
 import type { UseAllotmentReturn } from '@/hooks/useAllotment'
+import type { UseCompostReturn } from '@/hooks/useCompost'
 
 type AllotmentHookResult = RenderHookResult<UseAllotmentReturn, unknown>
+type CompostHookResult = RenderHookResult<UseCompostReturn, unknown>
 
 // Deterministic `generateId`. Each call returns the next ID from a
 // shared counter so legacy and Yjs paths produce identical IDs given
@@ -194,6 +197,46 @@ async function importUseAllotmentWithFlag(useYjsStorage: boolean) {
 }
 
 /**
+ * Mount `useCompost` with the chosen flag value. Same module-reset
+ * dance as `importUseAllotmentWithFlag` because both hooks compose
+ * `useAllotmentData`, which reads the flag at module load. PR-B.2 ports
+ * `useCompost` to the same two-branch pattern as the seven hooks PR-B
+ * shipped; this helper drives the parity test that holds the contract.
+ */
+async function importUseCompostWithFlag(useYjsStorage: boolean) {
+  vi.resetModules()
+  vi.doMock('@/config/release-visibility', () => ({
+    SHOW_ROTATION_SUGGESTIONS: false,
+    SHOW_ADVANCED_AREA_FIELDS: false,
+    SHOW_CARE_LOGS: true,
+    SHOW_UNDERPLANTINGS: false,
+    USE_YJS_STORAGE: useYjsStorage,
+  }))
+  vi.doMock('@/lib/utils/id', () => ({
+    generateId: (prefix?: string) => {
+      idCounter++
+      return prefix ? `${prefix}-${idCounter}` : `id-${idCounter}`
+    },
+    slugify: (text: string) =>
+      text.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-'),
+    generateSlugId: (name: string, existingIds: Set<string>) => {
+      const baseSlug = name.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')
+      if (!existingIds.has(baseSlug)) return baseSlug
+      let counter = 2
+      while (existingIds.has(`${baseSlug}-${counter}`)) counter++
+      return `${baseSlug}-${counter}`
+    },
+  }))
+  vi.doMock('@/lib/utils', async () => {
+    const id = await import('@/lib/utils/id')
+    const debounce = await import('@/lib/utils/debounce')
+    return { ...id, ...debounce }
+  })
+  const mod = await import('@/hooks/useCompost')
+  return mod.useCompost
+}
+
+/**
  * Strip volatile fields from a snapshot so the parity comparison
  * focuses on data-shape equivalence. Both paths re-stamp
  * `meta.updatedAt` and `season.updatedAt` on every write; while the
@@ -212,6 +255,21 @@ function stripVolatile(snapshot: AllotmentData | null): unknown {
   for (const season of clone.seasons || []) {
     delete (season as Partial<typeof season>).updatedAt
   }
+  return clone
+}
+
+/**
+ * Strip volatile fields from a `CompostData` snapshot. The top-level
+ * `updatedAt` is derived from `AllotmentData.meta.updatedAt` and is
+ * volatile across paths for the same reason `stripVolatile` strips
+ * `meta.updatedAt`. Pile-level `createdAt`/`updatedAt` stay — those
+ * are the contract of the compost mutations and should match exactly
+ * under the frozen clock.
+ */
+function stripVolatileCompost(snapshot: CompostData | null): unknown {
+  if (!snapshot) return snapshot
+  const clone = JSON.parse(JSON.stringify(snapshot)) as CompostData
+  delete (clone as Partial<CompostData>).updatedAt
   return clone
 }
 
@@ -292,6 +350,69 @@ async function runScript(hook: AllotmentHookResult): Promise<unknown[]> {
     })
   })
   snapshots.push(stripVolatile(hook.result.current.data))
+
+  return snapshots
+}
+
+/**
+ * Scripted compost mutation sequence (PR-B.2). Runs against a mounted
+ * `useCompost` and captures the public `data` snapshot after each step.
+ * Coverage:
+ *   - `addPile` (most common write path; also exercises `withoutUndefined`
+ *     because `NewCompostPile` carries optional `notes`).
+ *   - `addInput` (per-pile array push, updates `pile.updatedAt`).
+ *   - `addEvent` (parallel to addInput but on the events collection).
+ *   - `updatePile` (uses `assignDefined` for partial patch + bumps `updatedAt`).
+ *   - `removeInput` (per-pile array splice).
+ */
+async function runCompostScript(hook: CompostHookResult): Promise<unknown[]> {
+  const snapshots: unknown[] = []
+
+  // Step 1: Add a pile (most common write path).
+  await act(async () => {
+    hook.result.current.addPile({
+      name: 'Bay 1',
+      systemType: 'hot-compost',
+      status: 'active',
+      startDate: '2026-05-01',
+    })
+  })
+  snapshots.push(stripVolatileCompost(hook.result.current.data))
+
+  // Step 2: Add an input to the new pile (uses the pile's ID assigned
+  // in step 1 — both paths share the deterministic generateId so the
+  // ID is `pile-1`).
+  await act(async () => {
+    hook.result.current.addInput('pile-1', {
+      date: '2026-05-02',
+      material: 'Kitchen scraps',
+      type: 'green',
+    })
+  })
+  snapshots.push(stripVolatileCompost(hook.result.current.data))
+
+  // Step 3: Add a turn event.
+  await act(async () => {
+    hook.result.current.addEvent('pile-1', {
+      date: '2026-05-10',
+      type: 'turn',
+      notes: 'First turn',
+    })
+  })
+  snapshots.push(stripVolatileCompost(hook.result.current.data))
+
+  // Step 4: Update the pile to 'maturing' (partial patch — exercises
+  // `assignDefined` on the Yjs branch).
+  await act(async () => {
+    hook.result.current.updatePile('pile-1', { status: 'maturing' })
+  })
+  snapshots.push(stripVolatileCompost(hook.result.current.data))
+
+  // Step 5: Remove the input added in step 2.
+  await act(async () => {
+    hook.result.current.removeInput('pile-1', 'input-2')
+  })
+  snapshots.push(stripVolatileCompost(hook.result.current.data))
 
   return snapshots
 }
@@ -399,6 +520,63 @@ describe('useAllotment path parity', () => {
 
     // Assert the unported-site warning never surfaced for any of the
     // eight scripted mutations.
+    const unportedWarnings = warnSpy.mock.calls.filter(call =>
+      typeof call[0] === 'string' &&
+      call[0].includes('unported domain-hook call site'),
+    )
+    expect(unportedWarnings).toEqual([])
+
+    warnSpy.mockRestore()
+    yjsHook.unmount()
+
+    // --- Compare ---
+    expect(yjsSnapshots).toHaveLength(legacySnapshots.length)
+    for (let i = 0; i < legacySnapshots.length; i++) {
+      expect(yjsSnapshots[i]).toEqual(legacySnapshots[i])
+    }
+  }, 30_000)
+
+  it('useCompost legacy and Yjs paths produce equivalent snapshots after each scripted mutation', async () => {
+    // PR-B.2 closes the spec-inventory gap left by PR-B: `useCompost`
+    // calls `setData` from `useAllotmentData` and needs the same
+    // two-branch treatment as the seven hooks PR-B ported. This test
+    // runs a scripted compost-only mutation sequence against both flag
+    // states and asserts snapshot equality.
+
+    // --- Legacy path ---
+    resetIdCounter()
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(makeFixture()))
+    const useCompostLegacy = await importUseCompostWithFlag(false)
+    const legacyHook = renderHook(() => useCompostLegacy())
+
+    await waitFor(() => {
+      expect(legacyHook.result.current.data).not.toBeNull()
+    })
+
+    const legacySnapshots = await runCompostScript(legacyHook)
+    legacyHook.unmount()
+
+    // --- Reset for Yjs path ---
+    resetIdCounter()
+    localStorage.clear()
+    await resetIndexedDB()
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(makeFixture()))
+
+    // Spy on `console.warn` so we can assert the PR-A "unported call
+    // site" warning never fires during the compost run. If it does,
+    // `useCompost` still has a `setData` invocation that wasn't gated
+    // behind the `USE_YJS_STORAGE` check.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const useCompostYjs = await importUseCompostWithFlag(true)
+    const yjsHook = renderHook(() => useCompostYjs())
+
+    await waitFor(() => {
+      expect(yjsHook.result.current.data).not.toBeNull()
+    })
+
+    const yjsSnapshots = await runCompostScript(yjsHook)
+
     const unportedWarnings = warnSpy.mock.calls.filter(call =>
       typeof call[0] === 'string' &&
       call[0].includes('unported domain-hook call site'),

--- a/src/hooks/useCompost.ts
+++ b/src/hooks/useCompost.ts
@@ -3,6 +3,20 @@
  *
  * State management for compost pile tracking.
  * Reads/writes through useAllotment since compost data is part of AllotmentData (v18).
+ *
+ * Two-branch methods (ADR 027 Step 3, PR-B.2): closes the spec-inventory
+ * gap left by PR-B. Each mutation has a legacy `setData`/`applyCompostMutation`
+ * branch (byte-identical to the pre-PR-B.2 implementation) and a Yjs `mutate`
+ * branch that performs in-place mutations on the SyncedStore proxy. The
+ * branch is picked by the `USE_YJS_STORAGE` flag at the top of each method.
+ * While the flag is `false` the Yjs branch is dead code; the parity test
+ * exercises it with the flag flipped locally to keep both implementations
+ * in lock step.
+ *
+ * Unlike the seven hooks ported in PR-B, `useCompost` is consumed directly
+ * (not composed inside `useAllotment.ts`), so it pulls `mutate` from
+ * `useAllotmentData()` itself rather than taking it as a prop. The Yjs
+ * branches in this file are otherwise identical in shape to the PR-B ports.
  */
 
 'use client'
@@ -10,6 +24,8 @@
 import { useCallback, useMemo } from 'react'
 import {
   CompostPile,
+  CompostInput,
+  CompostEvent,
   NewCompostPile,
   NewCompostInput,
   NewCompostEvent,
@@ -28,7 +44,10 @@ import {
 } from '@/services/allotment-storage'
 import type { CompostData } from '@/types/compost'
 import type { AllotmentData } from '@/types/unified-allotment'
+import { generateId } from '@/lib/utils'
+import { USE_YJS_STORAGE } from '@/config/release-visibility'
 import { useAllotmentData } from './allotment/useAllotmentData'
+import { assignDefined, withoutUndefined } from './allotment/yjs-helpers'
 import type { SaveStatus } from './usePersistedStorage'
 
 // Re-export SaveStatus for backward compatibility
@@ -89,6 +108,7 @@ export function useCompost(): UseCompostReturn {
   const {
     data: allotmentData,
     setData,
+    mutate,
     isLoading,
     error,
     saveError,
@@ -105,12 +125,14 @@ export function useCompost(): UseCompostReturn {
     return toCompostData(allotmentData)
   }, [allotmentData])
 
-  // Helper: apply a compost-operations mutation and write back to AllotmentData
+  // Helper: apply a compost-operations mutation and write back to AllotmentData.
+  // Legacy path only — the Yjs branches mutate `store.compost` in place and
+  // never call this helper.
   const applyCompostMutation = useCallback(
-    (mutate: (cd: CompostData) => CompostData) => {
+    (mutateCd: (cd: CompostData) => CompostData) => {
       if (!allotmentData) return
       const cd = toCompostData(allotmentData)
-      const updated = mutate(cd)
+      const updated = mutateCd(cd)
       setData({ ...allotmentData, compost: updated.piles })
     },
     [allotmentData, setData],
@@ -119,19 +141,60 @@ export function useCompost(): UseCompostReturn {
   // ============ PILE OPERATIONS ============
 
   const addPile = useCallback((pile: NewCompostPile) => {
+    if (!allotmentData) return
+
+    if (USE_YJS_STORAGE) {
+      mutate(store => {
+        const now = new Date().toISOString()
+        const newPile: CompostPile = withoutUndefined({
+          ...pile,
+          id: generateId('pile'),
+          inputs: [],
+          events: [],
+          createdAt: now,
+          updatedAt: now,
+        })
+        store.compost.push(newPile)
+      })
+      return
+    }
+
     applyCompostMutation(cd => storageAddPile(cd, pile))
-  }, [applyCompostMutation])
+  }, [allotmentData, applyCompostMutation, mutate])
 
   const updatePile = useCallback((
     pileId: string,
     updates: Partial<Omit<CompostPile, 'id' | 'inputs' | 'events' | 'createdAt'>>
   ) => {
+    if (!allotmentData) return
+
+    if (USE_YJS_STORAGE) {
+      mutate(store => {
+        const pile = store.compost.find(p => p.id === pileId)
+        if (!pile) return
+        assignDefined(pile as unknown as Record<string, unknown>, updates as Record<string, unknown>)
+        pile.updatedAt = new Date().toISOString()
+      })
+      return
+    }
+
     applyCompostMutation(cd => storageUpdatePile(cd, pileId, updates))
-  }, [applyCompostMutation])
+  }, [allotmentData, applyCompostMutation, mutate])
 
   const removePile = useCallback((pileId: string) => {
+    if (!allotmentData) return
+
+    if (USE_YJS_STORAGE) {
+      mutate(store => {
+        const idx = store.compost.findIndex(p => p.id === pileId)
+        if (idx === -1) return
+        store.compost.splice(idx, 1)
+      })
+      return
+    }
+
     applyCompostMutation(cd => storageRemovePile(cd, pileId))
-  }, [applyCompostMutation])
+  }, [allotmentData, applyCompostMutation, mutate])
 
   const getPile = useCallback((pileId: string) => {
     if (!compostData) return undefined
@@ -151,22 +214,82 @@ export function useCompost(): UseCompostReturn {
   // ============ INPUT OPERATIONS ============
 
   const addInput = useCallback((pileId: string, input: NewCompostInput) => {
+    if (!allotmentData) return
+
+    if (USE_YJS_STORAGE) {
+      mutate(store => {
+        const pile = store.compost.find(p => p.id === pileId)
+        if (!pile) return
+        const newInput: CompostInput = withoutUndefined({
+          ...input,
+          id: generateId('input'),
+        })
+        pile.inputs.push(newInput)
+        pile.updatedAt = new Date().toISOString()
+      })
+      return
+    }
+
     applyCompostMutation(cd => storageAddInput(cd, pileId, input))
-  }, [applyCompostMutation])
+  }, [allotmentData, applyCompostMutation, mutate])
 
   const removeInput = useCallback((pileId: string, inputId: string) => {
+    if (!allotmentData) return
+
+    if (USE_YJS_STORAGE) {
+      mutate(store => {
+        const pile = store.compost.find(p => p.id === pileId)
+        if (!pile) return
+        const idx = pile.inputs.findIndex(i => i.id === inputId)
+        if (idx === -1) return
+        pile.inputs.splice(idx, 1)
+        pile.updatedAt = new Date().toISOString()
+      })
+      return
+    }
+
     applyCompostMutation(cd => storageRemoveInput(cd, pileId, inputId))
-  }, [applyCompostMutation])
+  }, [allotmentData, applyCompostMutation, mutate])
 
   // ============ EVENT OPERATIONS ============
 
   const addEvent = useCallback((pileId: string, event: NewCompostEvent) => {
+    if (!allotmentData) return
+
+    if (USE_YJS_STORAGE) {
+      mutate(store => {
+        const pile = store.compost.find(p => p.id === pileId)
+        if (!pile) return
+        const newEvent: CompostEvent = withoutUndefined({
+          ...event,
+          id: generateId('event'),
+        })
+        pile.events.push(newEvent)
+        pile.updatedAt = new Date().toISOString()
+      })
+      return
+    }
+
     applyCompostMutation(cd => storageAddEvent(cd, pileId, event))
-  }, [applyCompostMutation])
+  }, [allotmentData, applyCompostMutation, mutate])
 
   const removeEvent = useCallback((pileId: string, eventId: string) => {
+    if (!allotmentData) return
+
+    if (USE_YJS_STORAGE) {
+      mutate(store => {
+        const pile = store.compost.find(p => p.id === pileId)
+        if (!pile) return
+        const idx = pile.events.findIndex(e => e.id === eventId)
+        if (idx === -1) return
+        pile.events.splice(idx, 1)
+        pile.updatedAt = new Date().toISOString()
+      })
+      return
+    }
+
     applyCompostMutation(cd => storageRemoveEvent(cd, pileId, eventId))
-  }, [applyCompostMutation])
+  }, [allotmentData, applyCompostMutation, mutate])
 
   // ============ DATA OPERATIONS ============
 


### PR DESCRIPTION
## Summary

Closes the spec-inventory gap left by PR-B (#385). `useCompost` calls `setData` from `useAllotmentData` for compost-pile CRUD, so it needs the same two-branch treatment as the seven hooks PR-B ported. PR-C can now safely flip `USE_YJS_STORAGE` to default-on without leaving compost mutations on an unported `setData` path.

PR-B.2 is a runtime no-op: `USE_YJS_STORAGE` stays `false` here. The Yjs branches are dead code until PR-C flips the flag; the parity test holds the contract by exercising both branches under the flag-mock.

## Ported call sites in `src/hooks/useCompost.ts`

Each method gets a two-branch body in the PR-B style — Yjs branch first, gated on `USE_YJS_STORAGE`, then the byte-identical legacy `applyCompostMutation` call:

- `addPile` — `store.compost.push(newPile)`; `withoutUndefined` strips the optional `notes` field at the push site.
- `updatePile` — partial patch via `assignDefined`, then `pile.updatedAt = now`.
- `removePile` — `findIndex` + `splice` on `store.compost`.
- `addInput` — finds the pile, pushes the new input (with `withoutUndefined` for the optional `quantity`/`notes`), stamps `pile.updatedAt`.
- `removeInput` — finds the pile, finds the input by ID, splices, stamps `pile.updatedAt`.
- `addEvent` — same shape as `addInput` but on the events array.
- `removeEvent` — same shape as `removeInput` but on the events array.

No cross-collection mutations — compost ops only touch `store.compost`. The top-level `meta.updatedAt` is not bumped by either path, matching the existing legacy behaviour (the wrap-back `setData({ ...allotmentData, compost: updated.piles })` discards the new `updatedAt` that `storageAddPile` etc. compute).

Structural note: unlike the seven PR-B hooks, `useCompost` is consumed directly (not composed via `useAllotment.ts`), so it destructures `mutate` from `useAllotmentData()` itself rather than taking it as a prop. No prop-interface change for consumers — they keep calling `useCompost()` with zero args.

## New parity test step

`src/__tests__/hooks/allotment-path-parity.test.ts` gains a second `it` block that mounts `useCompost` under both flag states and runs a 5-step scripted sequence:

1. `addPile({ name: 'Bay 1', systemType: 'hot-compost', status: 'active', startDate: '2026-05-01' })`
2. `addInput('pile-1', { date, material: 'Kitchen scraps', type: 'green' })`
3. `addEvent('pile-1', { date, type: 'turn', notes: 'First turn' })`
4. `updatePile('pile-1', { status: 'maturing' })` — exercises `assignDefined`
5. `removeInput('pile-1', 'input-2')`

Snapshots use a new `stripVolatileCompost` helper that drops the top-level `compostData.updatedAt` (derived from `meta.updatedAt`, volatile by the same logic as the original `stripVolatile`). Pile-level `createdAt`/`updatedAt` stay in the comparison — the frozen-clock setup from PR-B makes them identical across paths. The unported-call-site warning is also asserted silent during the Yjs run.

## Acceptance

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 65 files, 1065 passed
- [x] Path-parity test passes both new compost block AND the original 8-step block
- [x] Flag stays `USE_YJS_STORAGE = false` — runtime no-op
- [x] `src/lib/yjs-spike/allotment-yjs.ts` and `yjs-helpers.ts` unchanged
- [x] Seven hooks PR-B ported are untouched

Note for orchestrator: `useCompost.ts` lives at `src/hooks/useCompost.ts` (not under `src/hooks/allotment/`). The directory move is out of scope per the no-rename constraint; happy to revisit as a follow-up if you want it under `allotment/` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)