### PR TITLE
fix(yjs): propagate cloud-sync events into the Yjs doc (PR-A.2)

### DIFF
--- a/src/__tests__/hooks/allotment-path-parity.test.ts
+++ b/src/__tests__/hooks/allotment-path-parity.test.ts
@@ -592,4 +592,266 @@ describe('useAllotment path parity', () => {
       expect(yjsSnapshots[i]).toEqual(legacySnapshots[i])
     }
   }, 30_000)
+
+  it('legacy and Yjs paths both adopt sibling-tab storage event payloads (PR-A.2)', async () => {
+    // PR-A.2 closes the gap where a sibling-tab `storage` event would
+    // update the legacy chain on the Yjs path but leave the Yjs doc
+    // stale — the mirror would then push the stale doc back over the
+    // sibling's fresh data, undoing the change. This test fires a
+    // synthetic `storage` event with a known "remote" payload at both
+    // hook instances and asserts that the public `data` snapshot
+    // converges to the remote payload on both flag states.
+    //
+    // We rebuild a small remote fixture (different allotment name, two
+    // areas instead of one) and write it to localStorage *before*
+    // dispatching the event so the listener's re-read from
+    // `initializeStorage` hands back the same payload jsdom doesn't
+    // dispatch the StorageEvent with `newValue` baked into the listener,
+    // it just re-reads the key.
+
+    const remotePayload: AllotmentData = {
+      ...makeFixture(),
+      meta: {
+        name: 'Remote Allotment',
+        location: 'Glasgow',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2026-05-16T10:00:00.000Z',
+      },
+      layout: {
+        areas: [
+          {
+            id: 'bed-a',
+            name: 'Bed A',
+            kind: 'rotation-bed',
+            canHavePlantings: true,
+            rotationGroup: 'legumes',
+            createdAt: '2025-01-01T00:00:00.000Z',
+          },
+          {
+            id: 'bed-b',
+            name: 'Bed B',
+            kind: 'rotation-bed',
+            canHavePlantings: true,
+            rotationGroup: 'brassicas',
+            createdAt: '2026-05-16T10:00:00.000Z',
+          },
+        ],
+      },
+    }
+
+    // Dispatch a synthetic same-storage-key event. The legacy chain's
+    // `usePersistedStorage.handleStorageChange` reads `event.newValue`
+    // when present but falls back to re-loading from `localStorage` for
+    // validation — we set the key first so both paths land at the same
+    // data.
+    function dispatchRemoteSync(): void {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(remotePayload))
+      // jsdom rejects `StorageEvent` constructed with `storageArea: localStorage`
+      // (it only accepts its own Storage wrapper). Omitting the field is safe —
+      // `usePersistedStorage.handleStorageChange` only reads `event.key` and
+      // `event.newValue`, then re-reads via `load()`.
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: STORAGE_KEY,
+          newValue: JSON.stringify(remotePayload),
+          oldValue: null,
+        }),
+      )
+    }
+
+    // --- Legacy path ---
+    resetIdCounter()
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(makeFixture()))
+    const useAllotmentLegacy = await importUseAllotmentWithFlag(false)
+    const legacyHook = renderHook(() => useAllotmentLegacy())
+    await waitFor(() => {
+      expect(legacyHook.result.current.data).not.toBeNull()
+    })
+
+    await act(async () => {
+      dispatchRemoteSync()
+    })
+
+    await waitFor(() => {
+      expect(legacyHook.result.current.data?.meta.name).toBe('Remote Allotment')
+    })
+    const legacyAfter = stripVolatile(legacyHook.result.current.data)
+    legacyHook.unmount()
+
+    // --- Yjs path ---
+    resetIdCounter()
+    localStorage.clear()
+    await resetIndexedDB()
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(makeFixture()))
+
+    const useAllotmentYjs = await importUseAllotmentWithFlag(true)
+    const yjsHook = renderHook(() => useAllotmentYjs())
+    await waitFor(() => {
+      expect(yjsHook.result.current.data).not.toBeNull()
+    })
+
+    await act(async () => {
+      dispatchRemoteSync()
+    })
+
+    // The Yjs path's `handleSync` calls `yjs.replaceFromJson`, which
+    // runs in a Yjs transaction. The `doc.on('update', ...)` listener
+    // then re-publishes the serialized snapshot asynchronously.
+    await waitFor(() => {
+      expect(yjsHook.result.current.data?.meta.name).toBe('Remote Allotment')
+    })
+    const yjsAfter = stripVolatile(yjsHook.result.current.data)
+    yjsHook.unmount()
+
+    // --- Compare ---
+    expect(yjsAfter).toEqual(legacyAfter)
+  }, 30_000)
+
+  it('legacy and Yjs paths both adopt the cloud payload after resolveConflict("cloud") (PR-A.2)', async () => {
+    // PR-A.2 wraps the legacy `resolveConflict` so a `'cloud'` choice
+    // also writes the remote snapshot into the Yjs doc. Without this,
+    // the legacy chain would adopt the cloud data but the Yjs doc would
+    // remain stale, and the mirror would push the stale doc back over
+    // the cloud copy the user just explicitly chose.
+    //
+    // This test cannot reuse the parity test's main scaffolding because
+    // a real conflict requires Supabase wiring (the legacy chain only
+    // raises `syncConflict` after a `fetchRemote` round-trip). Instead
+    // we mock `@/lib/supabase/sync` to surface a conflict, drive
+    // `resolveConflict('cloud')` against both paths, and compare the
+    // resulting `data` snapshots.
+
+    const remoteData: AllotmentData = {
+      ...makeFixture(),
+      meta: {
+        name: 'Cloud Allotment',
+        location: 'Aberdeen',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2026-05-16T11:00:00.000Z',
+      },
+    }
+
+    async function runWithFlag(useYjsStorage: boolean): Promise<unknown> {
+      vi.resetModules()
+      vi.doMock('@/config/release-visibility', () => ({
+        SHOW_ROTATION_SUGGESTIONS: false,
+        SHOW_ADVANCED_AREA_FIELDS: false,
+        SHOW_CARE_LOGS: true,
+        SHOW_UNDERPLANTINGS: false,
+        USE_YJS_STORAGE: useYjsStorage,
+      }))
+      // Pretend the user is signed in and Supabase is configured so
+      // `canSync` is `true` and the initial-sync effect runs. The flag
+      // helper for the conflict path is hand-rolled here because the
+      // test needs additional mocks the existing helpers don't apply.
+      vi.doMock('@/lib/utils/id', () => ({
+        generateId: (prefix?: string) => {
+          idCounter++
+          return prefix ? `${prefix}-${idCounter}` : `id-${idCounter}`
+        },
+        slugify: (text: string) =>
+          text.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-'),
+        generateSlugId: (name: string, existingIds: Set<string>) => {
+          const baseSlug = name.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')
+          if (!existingIds.has(baseSlug)) return baseSlug
+          let counter = 2
+          while (existingIds.has(`${baseSlug}-${counter}`)) counter++
+          return `${baseSlug}-${counter}`
+        },
+      }))
+      vi.doMock('@/lib/utils', async () => {
+        const id = await import('@/lib/utils/id')
+        const debounce = await import('@/lib/utils/debounce')
+        return { ...id, ...debounce }
+      })
+      vi.doMock('@/hooks/useOptionalAuth', () => ({
+        clerkAvailable: true,
+        useOptionalAuth: () => ({
+          getToken: async () => 'token',
+          userId: 'user-conflict',
+          isSignedIn: true,
+        }),
+      }))
+      vi.doMock('@/lib/supabase/client', () => ({
+        isSupabaseConfigured: () => true,
+        createAnonClient: () => null,
+        createAuthClient: () => null,
+      }))
+      vi.doMock('@/lib/supabase/sync', async () => {
+        const actual = await vi.importActual<typeof import('@/lib/supabase/sync')>(
+          '@/lib/supabase/sync',
+        )
+        return {
+          ...actual,
+          fetchRemote: async () => ({
+            data: remoteData,
+            updatedAt: '2026-05-16T11:00:00.000Z',
+          }),
+          pushToRemote: async () => undefined,
+        }
+      })
+      // Pre-seed a sync flag so the initial sync treats this as a
+      // *subsequent* sync (which can produce a conflict) rather than a
+      // first-time-cloud-wins sync. Set the flag's lastSyncedAt to
+      // before both local and remote `updatedAt` values so both sides
+      // appear to have changed.
+      localStorage.setItem(
+        'bonnie-synced-user-conflict',
+        JSON.stringify({ lastSyncedAt: '2024-01-01T00:00:00.000Z' }),
+      )
+
+      const localFixture: AllotmentData = {
+        ...makeFixture(),
+        meta: {
+          name: 'Local Allotment',
+          location: 'Edinburgh',
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2026-05-16T09:00:00.000Z',
+        },
+      }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(localFixture))
+
+      const mod = await import('@/hooks/useAllotment')
+      const hook = renderHook(() => mod.useAllotment())
+
+      await waitFor(() => {
+        expect(hook.result.current.data).not.toBeNull()
+      })
+
+      // Wait for the initial sync to raise the conflict.
+      await waitFor(() => {
+        expect(hook.result.current.syncConflict).not.toBeNull()
+      }, { timeout: 5000 })
+
+      await act(async () => {
+        hook.result.current.resolveConflict('cloud')
+      })
+
+      // After resolveConflict('cloud') the legacy chain adopts the
+      // remote snapshot synchronously. On the Yjs path the wrapped
+      // resolveConflict also fires `yjs.replaceFromJson` which republishes
+      // the snapshot async. Wait for the visible name to match.
+      await waitFor(() => {
+        expect(hook.result.current.data?.meta.name).toBe('Cloud Allotment')
+      })
+
+      const finalSnapshot = stripVolatile(hook.result.current.data)
+      hook.unmount()
+      return finalSnapshot
+    }
+
+    // --- Legacy path ---
+    resetIdCounter()
+    localStorage.clear()
+    await resetIndexedDB()
+    const legacySnapshot = await runWithFlag(false)
+
+    // --- Yjs path ---
+    resetIdCounter()
+    localStorage.clear()
+    await resetIndexedDB()
+    const yjsSnapshot = await runWithFlag(true)
+
+    expect(yjsSnapshot).toEqual(legacySnapshot)
+  }, 30_000)
 })

--- a/src/app/receive/[code]/page.tsx
+++ b/src/app/receive/[code]/page.tsx
@@ -7,6 +7,7 @@ import type { AllotmentData } from '@/types/unified-allotment'
 import { saveAllotmentData, migrateSchemaForImport, loadAllotmentData, validateAllotmentData } from '@/services/allotment-storage'
 import { createPreImportBackup } from '@/lib/storage-utils'
 import { setImportInProgress } from '@/lib/persistence-signal'
+import { clearYjsIndexedDb } from '@/hooks/useYjsDoc'
 
 interface PageProps {
   params: Promise<{ code: string }>
@@ -108,9 +109,17 @@ export default function ReceivePage({ params }: PageProps) {
       setState(prev => ({ ...prev, status: 'imported' }))
 
       // Redirect after short delay
-      setTimeout(() => {
+      setTimeout(async () => {
         // Set flag to prevent stale data from overwriting
         setImportInProgress(true)
+        // Drop the Yjs IndexedDB store so the post-redirect mount
+        // hydrates from the freshly-imported localStorage rather than
+        // resurrecting the previous session's Yjs state.
+        try {
+          await clearYjsIndexedDb()
+        } catch (err) {
+          console.warn('[receive] Failed to clear Yjs IndexedDB before redirect:', err)
+        }
         window.location.href = '/'
       }, 1500)
     } catch (error) {

--- a/src/hooks/allotment/useAllotmentData.ts
+++ b/src/hooks/allotment/useAllotmentData.ts
@@ -273,12 +273,31 @@ function emitUnportedSetDataWarning(): void {
 function useAllotmentDataYjs(): UseAllotmentDataReturn {
   const [selectedYear, setSelectedYear] = useState<number>(new Date().getFullYear())
 
-  const handleSync = useCallback((newData: AllotmentData) => {
-    setSelectedYear(newData.currentYear)
-  }, [])
-
-  // Yjs side: canonical engine on this path.
+  // Yjs side: canonical engine on this path. Constructed before
+  // `handleSync` so the callback can close over `yjs.replaceFromJson`
+  // and propagate cross-context updates into the Y.Doc — without this
+  // step the legacy chain would adopt sibling-tab / cloud writes while
+  // the Yjs doc stayed stale, and the mirror would push the stale doc
+  // straight back, undoing the remote change.
   const yjs = useYjsDoc()
+
+  // Propagate cross-context writes (sibling-tab `storage` events, P2P
+  // sync events, post-conflict cloud snapshots adopted via the legacy
+  // chain's `applyRemoteSnapshot`) into the Yjs doc. `replaceFromJson`
+  // runs inside a Yjs transaction tagged with the hook's local origin,
+  // so the doc's own `update` listener publishes a fresh snapshot but
+  // doesn't trip the "synced from another tab" flag — the legacy chain
+  // already raised that affordance.
+  //
+  // The downstream mirror (`useYjsToLegacyMirror`) will see the new
+  // snapshot and call `synced.setData(snapshot)`. The legacy chain just
+  // adopted the same data, so `usePersistedStorage`'s content-equality
+  // dedup on `latestSerializedRef` short-circuits the redundant save +
+  // cloud push.
+  const handleSync = useCallback((newData: AllotmentData) => {
+    yjs.replaceFromJson(newData)
+    setSelectedYear(newData.currentYear)
+  }, [yjs])
 
   // Legacy side: kept alive as the cloud-sync mirror. `useSyncedStorage`
   // continues to listen for `saveStatus === 'saved'` and pushes to
@@ -370,6 +389,23 @@ function useAllotmentDataYjs(): UseAllotmentDataReturn {
     return yjsFlushed && mirrorFlushed
   }, [yjs, synced])
 
+  // Wrap the legacy `resolveConflict` so a `'cloud'` choice also writes
+  // the remote snapshot into the Yjs doc. `synced.resolveConflict`
+  // clears `syncConflict` after running, so we capture the conflict
+  // payload *before* delegating. For the `'local'` choice the Yjs state
+  // is canonical — the mirror is already pushing it out, no action
+  // needed here.
+  const resolveConflict = useCallback(
+    (choice: 'cloud' | 'local') => {
+      const conflict = synced.syncConflict
+      synced.resolveConflict(choice)
+      if (choice === 'cloud' && conflict?.remote) {
+        yjs.replaceFromJson(conflict.remote)
+      }
+    },
+    [yjs, synced],
+  )
+
   return {
     data: yjs.data,
     setData,
@@ -385,7 +421,7 @@ function useAllotmentDataYjs(): UseAllotmentDataReturn {
     syncStatus: synced.syncStatus,
     syncError: synced.syncError,
     syncConflict: synced.syncConflict,
-    resolveConflict: synced.resolveConflict,
+    resolveConflict,
 
     selectYear,
     getYears,

--- a/src/hooks/useDataTransfer.ts
+++ b/src/hooks/useDataTransfer.ts
@@ -6,6 +6,7 @@ import { VarietyData } from '@/types/variety-data'
 import { saveAllotmentData, clearAllotmentData, getStorageStats, migrateSchemaForImport } from '@/services/allotment-storage'
 import { checkStorageQuota, createPreImportBackup, restoreFromBackup } from '@/lib/storage-utils'
 import { setImportInProgress } from '@/lib/persistence-signal'
+import { clearYjsIndexedDb } from '@/hooks/useYjsDoc'
 import { ImportError, ExportError } from '@/types/errors'
 
 /**
@@ -245,6 +246,16 @@ export function useDataTransfer({ data, onDataImported, flushSave }: UseDataTran
         }
 
         setImportInProgress(true)
+        // Drop the Yjs IndexedDB store so the post-reload `useYjsDoc`
+        // mount sees an empty doc and hydrates from the freshly-
+        // imported localStorage. Without this, the previous session's
+        // IDB state would win and the import would be silently
+        // overwritten by the mirror.
+        try {
+          await clearYjsIndexedDb()
+        } catch (err) {
+          console.warn('[useDataTransfer] Failed to clear Yjs IndexedDB before reload:', err)
+        }
         window.location.reload()
       } catch (error) {
         console.error('Import failed:', error)
@@ -293,9 +304,17 @@ export function useDataTransfer({ data, onDataImported, flushSave }: UseDataTran
     }
   }, [lastBackupKey, onDataImported])
 
-  const handleClear = useCallback(() => {
+  const handleClear = useCallback(async () => {
     const result = clearAllotmentData()
     if (result.success) {
+      // Drop the Yjs IndexedDB store too, otherwise the next mount
+      // resurrects the pre-clear state from IDB and the user sees the
+      // data they just deleted.
+      try {
+        await clearYjsIndexedDb()
+      } catch (err) {
+        console.warn('[useDataTransfer] Failed to clear Yjs IndexedDB:', err)
+      }
       setShowClearConfirm(false)
       onDataImported()
     }

--- a/src/hooks/useYjsDoc.ts
+++ b/src/hooks/useYjsDoc.ts
@@ -47,6 +47,118 @@ import type { SyncStatus } from '@/types/storage'
  */
 const YJS_DOC_NAME = 'bwp-allotment-yjs'
 
+/**
+ * Shared singleton state for the tab-wide Yjs doc. Multiple `useYjsDoc`
+ * consumers (Navigation, allotment page, modals) all read from and
+ * write to the same Y.Doc instance through this singleton. Refcounted so
+ * the doc + IDB provider tear down when the last consumer unmounts.
+ *
+ * Without this, two `useYjsDoc` instances mounting in parallel would
+ * each construct their own Y.Doc, both try to hydrate from legacy
+ * localStorage, and produce concurrent CRDT inserts that the merger
+ * keeps as duplicates — manifesting as duplicate seasons / areas after
+ * page reload. The singleton makes hydration single-shot by
+ * construction.
+ */
+interface YjsSingleton {
+  doc: Y.Doc
+  store: AllotmentStoreShape
+  provider: IndexeddbPersistence | null
+  /**
+   * Resolves once `provider.whenSynced` has resolved and (if needed)
+   * the one-shot legacy-localStorage hydration has run. Cached so
+   * later consumers await the same work instead of racing it.
+   */
+  whenReady: Promise<{ providerError: string | null }>
+  /** Origin tag for transactions initiated locally by `useYjsDoc` consumers. */
+  localOrigin: symbol
+  /** Number of mounted `useYjsDoc` consumers. */
+  refCount: number
+}
+
+let singleton: YjsSingleton | null = null
+
+function acquireSingleton(): YjsSingleton {
+  if (singleton) {
+    singleton.refCount += 1
+    return singleton
+  }
+
+  const doc = new Y.Doc()
+  const { store } = createAllotmentDoc(doc)
+  let provider: IndexeddbPersistence | null = null
+  let providerError: string | null = null
+  try {
+    provider = new IndexeddbPersistence(YJS_DOC_NAME, doc)
+  } catch (err) {
+    // `IndexeddbPersistence`'s constructor reads `indexedDB` eagerly;
+    // browsers without it (older Safari private mode) throw here. Fall
+    // back to a memory-only doc — the session is local-only and dies
+    // on reload, same as the legacy chain when localStorage is
+    // unavailable.
+    providerError = err instanceof Error ? err.message : 'IndexedDB unavailable'
+    provider = null
+  }
+
+  const localOrigin = Symbol('useYjsDoc-shared-local')
+
+  const whenReady = (async () => {
+    if (provider) {
+      try {
+        await provider.whenSynced
+      } catch (err) {
+        providerError =
+          err instanceof Error ? err.message : 'Failed to load IndexedDB state'
+      }
+    }
+    // First-run hydration: if the doc is still empty after IDB sync,
+    // pull the legacy localStorage snapshot in. This is single-shot
+    // because the singleton's `whenReady` is the only place that runs
+    // it — subsequent `useYjsDoc` mounts await the same Promise and
+    // see a non-empty doc. The IDB is authoritative on later boots;
+    // the import flow (`clearYjsIndexedDb`) and the in-app Clear Local
+    // Data button explicitly clear IDB when the user intends to
+    // discard the doc.
+    if (isStoreEmpty(store)) {
+      const legacy = readLegacyAllotment()
+      if (legacy) {
+        doc.transact(() => {
+          hydrateFromJson(store, legacy)
+        }, localOrigin)
+      }
+    }
+    return { providerError }
+  })()
+
+  singleton = {
+    doc,
+    store,
+    provider,
+    whenReady,
+    localOrigin,
+    refCount: 1,
+  }
+  return singleton
+}
+
+function releaseSingleton(): void {
+  if (!singleton) return
+  singleton.refCount -= 1
+  if (singleton.refCount > 0) return
+  // Last consumer unmounted — tear down. We hold the reference local
+  // before nulling so the destroy/cleanup runs against the same
+  // instance even if another mount races in.
+  const current = singleton
+  singleton = null
+  if (current.provider) {
+    // `destroy` returns a Promise but we don't await it during
+    // cleanup — React unmount is synchronous. The provider tears
+    // down its IDB connection in the background.
+    void current.provider.destroy()
+  }
+  current.doc.destroy()
+}
+
 export interface UseYjsDocReturn {
   /** Derived JSON snapshot of the current doc state. */
   data: AllotmentData | null
@@ -106,16 +218,11 @@ export function useYjsDoc(): UseYjsDocReturn {
   const [error, setError] = useState<string | null>(null)
   const [isSyncedFromOtherTab, setIsSyncedFromOtherTab] = useState(false)
 
-  // Hold the doc/store/provider in refs so the same instance survives
-  // re-renders and exposes them to callbacks without re-creating the
-  // listener wiring on every render.
-  const docRef = useRef<Y.Doc | null>(null)
-  const storeRef = useRef<AllotmentStoreShape | null>(null)
-  const providerRef = useRef<IndexeddbPersistence | null>(null)
-  // Tracks the origin of updates the hook applies itself, so the doc's
-  // own update listener can distinguish locally-initiated transactions
-  // from cross-tab broadcasts arriving through y-indexeddb.
-  const localOriginRef = useRef<symbol>(Symbol('useYjsDoc-local'))
+  // Hold the shared singleton in a ref so the actions exposed by this
+  // hook all close over the same Y.Doc instance. The singleton itself
+  // is module-scoped (see `acquireSingleton`); every `useYjsDoc`
+  // consumer shares the same Y.Doc to avoid concurrent-hydration races.
+  const singletonRef = useRef<YjsSingleton | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -123,36 +230,18 @@ export function useYjsDoc(): UseYjsDocReturn {
     // clear it and avoid a setState-on-unmounted warning.
     let syncedFlagTimeout: ReturnType<typeof setTimeout> | null = null
 
-    const doc = new Y.Doc()
-    const { store } = createAllotmentDoc(doc)
-    docRef.current = doc
-    storeRef.current = store
-
-    let provider: IndexeddbPersistence | null = null
-    try {
-      provider = new IndexeddbPersistence(YJS_DOC_NAME, doc)
-    } catch (err) {
-      // `IndexeddbPersistence`'s constructor reads `indexedDB` eagerly;
-      // browsers without it (older Safari private mode) throw here.
-      // Fall back to a memory-only doc — the session is local-only and
-      // dies on reload, same as the legacy chain when localStorage is
-      // unavailable.
-      const message =
-        err instanceof Error ? err.message : 'IndexedDB unavailable'
-      setError(message)
-      provider = null
-    }
-    providerRef.current = provider
+    const sg = acquireSingleton()
+    singletonRef.current = sg
 
     const handleUpdate = (_update: Uint8Array, origin: unknown) => {
-      if (!storeRef.current) return
-      const snapshot = serializeToJson(storeRef.current)
+      const snapshot = serializeToJson(sg.store)
       setData(snapshot)
-      // Any update that isn't tagged with our local origin came from
-      // somewhere else: the IndexeddbPersistence cross-tab broadcast,
-      // or a `Y.applyUpdate` from a future cloud transport. Flag it so
-      // existing UI affordances ("Synced from another tab") light up.
-      if (origin !== localOriginRef.current) {
+      // Any update that isn't tagged with the shared local origin came
+      // from somewhere else: the IndexeddbPersistence cross-tab
+      // broadcast, or a `Y.applyUpdate` from a future cloud transport.
+      // Flag it so existing UI affordances ("Synced from another tab")
+      // light up.
+      if (origin !== sg.localOrigin) {
         setIsSyncedFromOtherTab(true)
         if (syncedFlagTimeout) clearTimeout(syncedFlagTimeout)
         syncedFlagTimeout = setTimeout(() => {
@@ -161,43 +250,27 @@ export function useYjsDoc(): UseYjsDocReturn {
         }, 3000)
       }
     }
-    doc.on('update', handleUpdate)
+    sg.doc.on('update', handleUpdate)
 
     const init = async () => {
       try {
-        if (provider) {
-          await provider.whenSynced
-        }
+        const { providerError } = await sg.whenReady
         if (cancelled) return
 
-        const currentStore = storeRef.current
-        if (!currentStore) return
-
-        const isEmpty = isStoreEmpty(currentStore)
-        if (isEmpty) {
-          // Read the legacy localStorage key directly so an empty
-          // device truly stays empty (`data === null`). `initializeStorage`
-          // would conjure a fresh-init record here, which is the right
-          // behaviour for the legacy chain on first run but the wrong
-          // behaviour for the Yjs path — we want to defer initialisation
-          // until the user actually adds something.
-          const legacy = readLegacyAllotment()
-          if (legacy) {
-            doc.transact(() => {
-              hydrateFromJson(currentStore, legacy)
-            }, localOriginRef.current)
-          }
+        if (providerError) {
+          setError(providerError)
         }
 
-        // Publish the initial snapshot. After `whenSynced` the doc may
-        // already have content (from IndexedDB) without us having
-        // received a fresh update event, so emit a snapshot explicitly.
-        // If the store is still empty after the hydration attempt, keep
-        // `data` at its initial `null` — first-run consumers (e.g. the
-        // setup wizard) rely on the `null` signal.
+        // Publish the initial snapshot. After `whenReady` resolves the
+        // doc may already have content (from IndexedDB or first-run
+        // hydration) without us having received a fresh update event,
+        // so emit a snapshot explicitly. If the store is still empty
+        // (truly first-run device with no legacy data), keep `data` at
+        // its initial `null` — first-run consumers (e.g. the setup
+        // wizard) rely on the `null` signal.
         if (!cancelled) {
-          if (!isStoreEmpty(currentStore)) {
-            setData(serializeToJson(currentStore))
+          if (!isStoreEmpty(sg.store)) {
+            setData(serializeToJson(sg.store))
           }
           setIsLoading(false)
         }
@@ -220,46 +293,36 @@ export function useYjsDoc(): UseYjsDocReturn {
         clearTimeout(syncedFlagTimeout)
         syncedFlagTimeout = null
       }
-      doc.off('update', handleUpdate)
-      if (provider) {
-        // `destroy` returns a Promise but we don't await it during
-        // cleanup — React unmount is synchronous. The provider tears
-        // down its IDB connection in the background.
-        void provider.destroy()
-      }
-      doc.destroy()
-      docRef.current = null
-      storeRef.current = null
-      providerRef.current = null
+      sg.doc.off('update', handleUpdate)
+      singletonRef.current = null
+      releaseSingleton()
     }
   }, [])
 
   const mutate = useCallback(
     (fn: (store: AllotmentStoreShape) => void) => {
-      const doc = docRef.current
-      const store = storeRef.current
-      if (!doc || !store) return
-      doc.transact(() => {
-        fn(store)
-      }, localOriginRef.current)
+      const sg = singletonRef.current
+      if (!sg) return
+      sg.doc.transact(() => {
+        fn(sg.store)
+      }, sg.localOrigin)
     },
     [],
   )
 
   const replaceFromJson = useCallback((json: AllotmentData) => {
-    const doc = docRef.current
-    const store = storeRef.current
-    if (!doc || !store) return
-    doc.transact(() => {
-      hydrateFromJson(store, json)
-    }, localOriginRef.current)
+    const sg = singletonRef.current
+    if (!sg) return
+    sg.doc.transact(() => {
+      hydrateFromJson(sg.store, json)
+    }, sg.localOrigin)
   }, [])
 
   const flushSave = useCallback(async (): Promise<boolean> => {
-    const provider = providerRef.current
-    if (!provider) return true
+    const sg = singletonRef.current
+    if (!sg || !sg.provider) return true
     try {
-      await provider.whenSynced
+      await sg.provider.whenSynced
       return true
     } catch {
       return false
@@ -357,3 +420,53 @@ function isStoreEmpty(store: AllotmentStoreShape): boolean {
 // Re-export for callers that need to reference the underlying Yjs Doc
 // (e.g. tests).
 export { getYjsDoc }
+
+/**
+ * Drop the Yjs IndexedDB store so a subsequent `useYjsDoc` mount
+ * hydrates fresh from legacy localStorage. The import flow uses this
+ * after writing imported data to localStorage but before
+ * `window.location.reload()` — otherwise, on reload the Yjs path would
+ * load the *previous* session's state from IDB, ignore the freshly-
+ * imported localStorage, and then mirror the stale state back over the
+ * imported data.
+ *
+ * Tears down the singleton in-process so any post-reset `useYjsDoc`
+ * mount starts from scratch instead of reusing the in-memory cache.
+ * Safe to call when the singleton hasn't been constructed yet (e.g.
+ * if the flag is `false` and no consumer ever mounted).
+ *
+ * Returns a promise that resolves once the IDB database has been
+ * deleted, or rejects with the underlying browser error if the
+ * deletion fails. Callers (the import flow) are expected to `await`
+ * this before the reload so the deletion is guaranteed durable.
+ */
+export async function clearYjsIndexedDb(): Promise<void> {
+  // First, tear down the in-process singleton if it exists. This
+  // closes the IDB connection so the `deleteDatabase` call below can
+  // succeed (browsers reject open-handle deletions silently or with a
+  // blocked event).
+  if (singleton) {
+    const current = singleton
+    singleton = null
+    if (current.provider) {
+      try {
+        await current.provider.destroy()
+      } catch {
+        // Best-effort: continue to the database delete even if the
+        // provider tear-down failed.
+      }
+    }
+    current.doc.destroy()
+  }
+
+  if (typeof indexedDB === 'undefined') return
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(YJS_DOC_NAME)
+    request.onsuccess = () => resolve()
+    request.onerror = () => reject(request.error ?? new Error('Failed to delete Yjs IndexedDB'))
+    // `blocked` fires when another tab has the DB open. Resolve anyway
+    // — the import is about to reload this tab, and any other tabs will
+    // see the same localStorage on their next mount.
+    request.onblocked = () => resolve()
+  })
+}


### PR DESCRIPTION
## Summary

Closes the foundation-layer gaps that Gemini flagged as critical on PR-C (#387 inline comment 3267067349) — without these, flipping `USE_YJS_STORAGE` to `true` risks data loss for cloud-synced users.

PR-A.2 ships with `USE_YJS_STORAGE` still `false`, so the fixes are no-op at runtime until PR-C reattempts the flag flip.

### The Gemini finding (verified)

In `useAllotmentDataYjs` (`src/hooks/allotment/useAllotmentData.ts`):

1. **`handleSync`** was called by the legacy chain when a sibling tab's `storage` event landed but only updated `selectedYear` — the Yjs doc stayed stale. The mirror then pushed the stale doc back over the sibling's fresh data, undoing the change. Same hazard for a fresh device on sign-in pulling cloud data.

2. **`resolveConflict`** was a pass-through to `synced.resolveConflict`. When the user picked `'cloud'`, the legacy chain adopted the remote snapshot but the Yjs doc was never told.

### The two wired seams

- **`handleSync`** now calls `yjs.replaceFromJson(newData)` before `setSelectedYear`. The `useYjsDoc` constructor was reordered to come before `handleSync` so the callback can close over `yjs`.
- **`resolveConflict`** is wrapped: it captures `synced.syncConflict?.remote` before delegating, then for the `'cloud'` choice also calls `yjs.replaceFromJson(conflict.remote)`. The `'local'` choice needs no extra work — the Yjs state is canonical and the mirror is already pushing it out. The `SyncConflict` field name is `remote` (matched the actual type definition).

### Extra fixes surfaced when verifying with the flag flipped

Two separate gaps the spec authorised fixing in PR-A.2 scope:

- **Concurrent-mount race in `useYjsDoc`.** Multiple `useAllotment` consumers (Navigation + page + modals) each constructed their own Y.Doc against the same shared IndexedDB store, and each independently hydrated from legacy localStorage. Concurrent CRDT inserts produced duplicate seasons on every subsequent reload (visible as nine duplicate `2026` buttons in the year selector). Refactored to a refcounted module-level singleton so all consumers share one Y.Doc — hydration is single-shot by construction.

- **Import flow ignored Yjs IDB.** `useDataTransfer.handleImport` wrote new data to localStorage and reloaded, but Yjs IDB still held the previous session's state. On reload Yjs overrode the import. Added `clearYjsIndexedDb()` and called it before the reload in both the import flow and the `receive/[code]` redirect, plus the in-app "Clear Local Data" handler.

### Local Playwright result with the flag flipped

All 9 previously-failing tests from PR-C's run [26103536199](https://github.com/IsmaelMartinez/bonnie-wee-plot/actions/runs/26103536199) now pass in targeted runs with `USE_YJS_STORAGE = true`:

- `allotment.spec.ts:195` (persist selected year)
- `allotment.spec.ts:380` (mobile action buttons)
- `allotment.spec.ts:551` (persist notes — the spec's headline test)
- `allotment.spec.ts:746` (custom name in nav)
- `data-management.spec.ts:301` (old export format)
- `variety-management.spec.ts:168` (export-import cycle)
- `variety-management.spec.ts:235` (rapid sequential imports)
- `variety-management.spec.ts:310` (localStorage updates without data loss)
- `variety-management.spec.ts:343` (100 varieties performance)

Cross-test contamination in the full Playwright suite (Yjs IDB persisting between tests where the `beforeEach` only clears localStorage) is a test-infrastructure concern that PR-C will need to address with proper `beforeEach` cleanup — out of scope for PR-A.2 since the flag stays off.

### Tests

Extended `src/__tests__/hooks/allotment-path-parity.test.ts` with two new tests for both wired seams:

- Sibling-tab storage event: dispatches a synthetic `StorageEvent` against `window` with a known remote payload after both paths have mounted, asserts the public `data` snapshot converges to the remote payload on both flag states (modulo `stripVolatile`).
- Conflict resolution via `cloud`: hand-rolls Supabase mocks to surface a real conflict from `useSyncedStorage`'s initial-sync path, calls `resolveConflict('cloud')`, asserts both paths end at the cloud snapshot. This deviates from the spec's "scripted steps" pattern because a real conflict requires Supabase wiring that the parity test scaffolding doesn't provide; the focused per-test setup is the spec's documented fallback.

Test count: 1065 -> 1067 (added 2 parity tests, no removals).

### Constraints respected

- `USE_YJS_STORAGE` stays `false`; PR-A.2 is no-op at runtime.
- No changes to the seven domain hooks or `useCompost.ts` (PR-B/B.2 own them).
- No changes to `src/lib/yjs-spike/allotment-yjs.ts`.
- TypeScript strict, no `any` introduced (the existing `as unknown as` cast on the mirror prop was already present).

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 1067 passed
- [x] `npm run build` clean
- [x] Local Playwright with flag flipped: all 9 previously-failing tests pass in targeted runs
- [x] Flag reverted to `false` before commit
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)