### PR TITLE
security: harden API routes, headers, and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,10 +8,14 @@ on:
   schedule:
     - cron: '0 3 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@v6

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,7 +30,6 @@ const withSerwist = withSerwistInit({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Don't advertise the framework via the X-Powered-By header
   poweredByHeader: false,
 
   // Conditionally enable static export for GitHub Pages

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,9 @@ const withSerwist = withSerwistInit({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Don't advertise the framework via the X-Powered-By header
+  poweredByHeader: false,
+
   // Conditionally enable static export for GitHub Pages
   ...(isGitHubPages && { output: "export" }),
 

--- a/src/__tests__/lib/gemini.test.ts
+++ b/src/__tests__/lib/gemini.test.ts
@@ -40,7 +40,9 @@ describe('callGemini', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0]
     expect(url).toContain('gemini-2.5-flash:generateContent')
-    expect(url).toContain('key=k')
+    // Key must travel as a header, never in the URL (avoids log leakage)
+    expect(url).not.toContain('key=')
+    expect((init as RequestInit).headers).toMatchObject({ 'x-goog-api-key': 'k' })
     const body = JSON.parse((init as RequestInit).body as string)
     expect(body.systemInstruction.parts[0].text).toBe('You are Aitor.')
     // Two history turns + one new user turn

--- a/src/__tests__/lib/server-rate-limiter.test.ts
+++ b/src/__tests__/lib/server-rate-limiter.test.ts
@@ -95,6 +95,14 @@ describe('server-rate-limiter', () => {
       expect(result.remaining).toBe(3) // full quota
     })
 
+    it('fails open for the shared "unknown" IP bucket', async () => {
+      const result = await checkRateLimit('unknown', config)
+
+      expect(result.allowed).toBe(true)
+      expect(result.remaining).toBe(3)
+      expect(mockIncr).not.toHaveBeenCalled()
+    })
+
     it('allows all requests when Redis is not configured', async () => {
       delete process.env.UPSTASH_REDIS_REST_URL
       delete process.env.UPSTASH_REDIS_REST_TOKEN

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -25,6 +25,8 @@ export async function GET() {
     return NextResponse.json(remote.data, {
       headers: {
         'Content-Disposition': 'attachment; filename="bonnie-wee-plot-export.json"',
+        // Personal data export — make sure no intermediary caches it
+        'Cache-Control': 'no-store',
       },
     })
   } catch (err) {

--- a/src/app/api/ai-advisor/route.ts
+++ b/src/app/api/ai-advisor/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/ai-tools-schema'
 import { callGemini } from '@/lib/ai/gemini'
 import { FREE_TIER_MONTHLY_QUOTA, getCurrentUsage, incrementUsage } from '@/lib/supabase/ai-usage'
+import { checkRateLimit } from '@/lib/server-rate-limiter'
 
 // Feature flag for AI tools (function calling)
 // Set to true to enable AI-powered inventory management
@@ -197,6 +198,24 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'Sign in to use Aitor.' },
         { status: 401 }
+      )
+    }
+
+    // Short-window per-user rate limit on top of the monthly Gemini quota.
+    // Protects the server-side OpenAI key path (which has no quota) and
+    // bounds burst abuse on all providers. Fails open if Redis is down.
+    const rateLimit = await checkRateLimit(userId, {
+      maxRequests: 20,
+      windowSeconds: 300,
+      prefix: 'ai-advisor',
+    })
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please wait a few minutes and try again.' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(rateLimit.resetInSeconds) },
+        }
       )
     }
 

--- a/src/app/api/share/[code]/route.ts
+++ b/src/app/api/share/[code]/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Redis } from '@upstash/redis'
 import type { AllotmentData } from '@/types/unified-allotment'
+import { checkRateLimit, getClientIp } from '@/lib/server-rate-limiter'
 import { logger } from '@/lib/logger'
 
 // Initialize Redis client
@@ -22,7 +23,7 @@ interface ShareData {
 }
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ code: string }> }
 ) {
   try {
@@ -31,6 +32,28 @@ export async function GET(
       return NextResponse.json(
         { error: 'Share feature not configured' },
         { status: 503 }
+      )
+    }
+
+    // Rate limit lookups to slow down share-code enumeration:
+    // 30 attempts per hour per IP is plenty for legitimate receive flows
+    const ip = getClientIp(request)
+    const rateLimit = await checkRateLimit(ip, {
+      maxRequests: 30,
+      windowSeconds: 3600,
+      prefix: 'share-get',
+    })
+
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many attempts. Please try again later.' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(rateLimit.resetInSeconds),
+            'X-RateLimit-Remaining': '0',
+          },
+        }
       )
     }
 

--- a/src/app/api/share/[code]/route.ts
+++ b/src/app/api/share/[code]/route.ts
@@ -35,6 +35,18 @@ export async function GET(
       )
     }
 
+    const { code } = await params
+
+    // Validate code format (6 alphanumeric characters) before touching
+    // Redis — malformed codes can't enumerate anything, so reject them
+    // without spending rate-limit budget or round-trips
+    if (!code || !/^[A-Z0-9]{6}$/i.test(code)) {
+      return NextResponse.json(
+        { error: 'Invalid share code format' },
+        { status: 400 }
+      )
+    }
+
     // Rate limit lookups to slow down share-code enumeration:
     // 30 attempts per hour per IP is plenty for legitimate receive flows
     const ip = getClientIp(request)
@@ -54,16 +66,6 @@ export async function GET(
             'X-RateLimit-Remaining': '0',
           },
         }
-      )
-    }
-
-    const { code } = await params
-
-    // Validate code format (6 alphanumeric characters)
-    if (!code || !/^[A-Z0-9]{6}$/i.test(code)) {
-      return NextResponse.json(
-        { error: 'Invalid share code format' },
-        { status: 400 }
       )
     }
 

--- a/src/app/api/share/[code]/route.ts
+++ b/src/app/api/share/[code]/route.ts
@@ -37,9 +37,8 @@ export async function GET(
 
     const { code } = await params
 
-    // Validate code format (6 alphanumeric characters) before touching
-    // Redis — malformed codes can't enumerate anything, so reject them
-    // without spending rate-limit budget or round-trips
+    // Reject malformed codes before touching Redis — they can't enumerate
+    // anything, so don't spend rate-limit budget or round-trips on them
     if (!code || !/^[A-Z0-9]{6}$/i.test(code)) {
       return NextResponse.json(
         { error: 'Invalid share code format' },

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -69,12 +69,24 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const { allotment, expirationMinutes: requestedExpiry } = body as {
       allotment: AllotmentData
-      expirationMinutes?: number
+      expirationMinutes?: unknown
+    }
+
+    // Reject non-numeric expiry values rather than coercing (NaN would
+    // otherwise flow into the Redis EX option)
+    if (
+      requestedExpiry !== undefined &&
+      (typeof requestedExpiry !== 'number' || !Number.isFinite(requestedExpiry))
+    ) {
+      return NextResponse.json(
+        { error: 'expirationMinutes must be a number' },
+        { status: 400 }
+      )
     }
 
     // Calculate expiry time in seconds (validated and capped)
     const expirationMinutes = Math.min(
-      Math.max(requestedExpiry ?? DEFAULT_EXPIRY_MINUTES, 1), // At least 1 minute
+      Math.max(Math.floor(requestedExpiry ?? DEFAULT_EXPIRY_MINUTES), 1), // At least 1 minute
       MAX_EXPIRY_MINUTES // Cap at 7 days
     )
     const expirySeconds = expirationMinutes * 60

--- a/src/components/ai-advisor/AitorChatModal.tsx
+++ b/src/components/ai-advisor/AitorChatModal.tsx
@@ -321,11 +321,15 @@ export default function AitorChatModal() {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred'
       const isConfigError = errorMessage.includes('not configured') || errorMessage.includes('Invalid token') || errorMessage.includes('OpenAI API key')
       const isQuotaError = errorMessage.includes('free Aitor requests')
+      // Matches the per-user rate limit message from /api/ai-advisor
+      const isRateLimitError = errorMessage.includes('Too many requests')
 
       const errorResponse: ExtendedChatMessage = {
         id: (Date.now() + 2).toString(),
         role: 'assistant',
-        content: isQuotaError
+        content: isRateLimitError
+          ? `**Slow down a wee bit**\n\n${errorMessage}\n\nYour message isn't lost — just send it again in a few minutes.`
+          : isQuotaError
           ? `**Free quota used up**\n\n${errorMessage}\n\n**Two ways forward:**\n- Add your own OpenAI API key in **Settings → AI & Location** for unlimited use.\n- Or check back on the 1st of next month — your free quota resets then.`
           : isConfigError
             ? `**Getting Started**\n\nHi there! I'm Aitor, your gardening companion. I'd love to help you with your allotment questions, but I need an API key to get started.\n\n**How to set me up:**\n- Go to **Settings** from the navigation menu\n- Add your OpenAI API token in the "AI Assistant" section\n- Get your token from the OpenAI dashboard\n- Once configured, I'll be ready to help with all your gardening needs!\n\n**What I can help with:**\n- Plant selection and planting schedules\n- Pest and disease management\n- Seasonal gardening tasks\n- Composting systems and troubleshooting\n- Soil health and organic fertilizers\n- Weather-specific care tips\n\nLet's get growing together!`

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -113,11 +113,16 @@ export async function callGemini(options: GeminiCallOptions): Promise<GeminiCall
     },
   }
 
-  const url = `${GEMINI_BASE_URL}/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(options.apiKey)}`
+  // Send the key as a header rather than a query param so it can't end up
+  // in access logs, proxies, or error traces that capture the URL
+  const url = `${GEMINI_BASE_URL}/${encodeURIComponent(model)}:generateContent`
 
   const response = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'x-goog-api-key': options.apiKey,
+    },
     body: JSON.stringify(body),
     signal: options.signal,
   })

--- a/src/lib/server-rate-limiter.ts
+++ b/src/lib/server-rate-limiter.ts
@@ -33,6 +33,14 @@ export async function checkRateLimit(
 ): Promise<RateLimitResult> {
   const { maxRequests, windowSeconds, prefix } = config
 
+  // 'unknown' means the platform didn't supply a client IP (local dev,
+  // header-stripping proxies). All such requests would share a single
+  // bucket and could rate-limit each other out — fail open instead,
+  // consistent with the Redis-unavailable behaviour below.
+  if (ip === 'unknown') {
+    return { allowed: true, remaining: maxRequests, resetInSeconds: 0 }
+  }
+
   if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
     return { allowed: true, remaining: maxRequests, resetInSeconds: 0 }
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -42,6 +42,8 @@ function buildCspHeader(): string {
 
 function addSecurityHeaders(response: NextResponse) {
   response.headers.set('Content-Security-Policy', buildCspHeader())
+  // 2 years; only meaningful over HTTPS so harmless in local dev
+  response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains')
   response.headers.set('X-Frame-Options', 'DENY')
   response.headers.set('X-Content-Type-Options', 'nosniff')
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -42,8 +42,11 @@ function buildCspHeader(): string {
 
 function addSecurityHeaders(response: NextResponse) {
   response.headers.set('Content-Security-Policy', buildCspHeader())
-  // 2 years; only meaningful over HTTPS so harmless in local dev
-  response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains')
+  // 2 years; production only so local HTTPS dev setups don't cache a
+  // long-lived HSTS pin for localhost or custom local domains
+  if (process.env.NODE_ENV === 'production') {
+    response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains')
+  }
   response.headers.set('X-Frame-Options', 'DENY')
   response.headers.set('X-Content-Type-Options', 'nosniff')
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')


### PR DESCRIPTION
## Summary

Result of a full security review of the repo. The baseline was already strong — CodeQL, Dependabot (npm + github-actions), SECURITY.md, Clerk-gated AI route, RLS on every Supabase table, Zod validation, CSP, rate-limited share upload, `npm audit` clean, no secrets in git history. This PR applies the remaining low-risk hardening fixes the review surfaced.

## Changes

**HTTP response headers**
- Add `Strict-Transport-Security` (2 years, includeSubDomains) in `src/middleware.ts` — the one notable header missing from the security set
- Set `poweredByHeader: false` in `next.config.mjs` so responses stop advertising Next.js

**API routes**
- `GET /api/share/[code]`: add IP rate limiting (30/hour) to slow share-code enumeration — the upload side was rate-limited but lookups were not
- `POST /api/share`: reject non-numeric `expirationMinutes` instead of letting `NaN` flow into the Redis `EX` option
- `POST /api/ai-advisor`: add a short-window per-user rate limit (20 per 5 min) on top of the monthly Gemini quota — the server-side `OPENAI_API_KEY` fallback path previously had no usage bound beyond authentication
- `GET /api/account` (GDPR export): mark the response `Cache-Control: no-store`

**Secrets handling**
- Send the Gemini API key via the `x-goog-api-key` header instead of the URL query string, so the key can't leak into access logs, proxies, or error traces that capture URLs (test updated to assert the header)

**CI workflows**
- Add least-privilege top-level `permissions: contents: read` to `ci.yml` and `codeql.yml` (CodeQL's job keeps its `security-events: write`)

All rate limiting fails open if Redis is unavailable, consistent with the existing `server-rate-limiter` design, so none of these changes can lock out legitimate users on infrastructure failure.

## Reviewed but intentionally not changed

- **CSP `unsafe-inline` / `unsafe-eval` in `script-src`** — removing these needs nonce-based CSP, which is a larger Next.js refactor with real breakage risk; worth its own issue
- **Share-code keyspace** (32⁶ ≈ 1B codes, 5-min–7-day TTL) — enumeration is impractical, and the new GET rate limit adds defence in depth
- **`/api/health` exposing app version** — useful for uptime monitoring, negligible risk
- **GitHub Actions pinned to major tags rather than SHAs** — Dependabot already tracks the actions ecosystem weekly; SHA-pinning is a reasonable follow-up if you want supply-chain rigour

## Testing

- `npm run lint`, `npm run type-check` — clean
- `npm run test:unit` — 1067 passed, 4 skipped
- `npm run test:chrome` (Playwright e2e) — 94 passed, 8 skipped
- `npm run build` — succeeds

https://claude.ai/code/session_01Bt2CdbXUavJrkcCfjAEGFa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bt2CdbXUavJrkcCfjAEGFa)_