### PR TITLE
Feed alerts: feed type, overdue urgency, homemade feed suggestions

### DIFF
--- a/docs/plans/feeding-and-preserving-plan.md
+++ b/docs/plans/feeding-and-preserving-plan.md
@@ -45,36 +45,36 @@ Extend `MaintenanceInfo` usage across `src/lib/vegetables/data/*.ts` so the majo
   crops planted in season; unit test in `src/__tests__/lib/task-generator.test.ts`
   covers at least one newly-fed annual.
 
-### Goal A2 — Add a structured "feed type" so alerts say *what* to feed
-Add an optional `feedType` (e.g. `'high-potash' | 'high-nitrogen' | 'balanced' |
-'comfrey' | 'compost'`) to `MaintenanceInfo`, surfaced in the feed task note
-(e.g. "Feed tomatoes — high-potash, every 7 days"). Falls back to current generic
-text when absent.
-- Files: `src/types/garden-planner.ts`, `createFeedTask` in `task-generator.ts`,
-  `TaskList.tsx` note rendering.
-- Acceptance: feed task notes show the feed type when set; no regression when unset.
+### Goal A2 — Add a structured "feed type" so alerts say *what* to feed ✅ DONE (2026-06-17)
+> Implemented: added `FeedType` (`high-potash | high-nitrogen | balanced |
+> comfrey | compost`) and an optional `feedType` to `MaintenanceInfo`. Populated
+> it for every crop that already carries feed data (annuals + berries + trees +
+> the perennial veg): tomatoes/tomatillo, cucurbits, beans → high-potash;
+> brassicas, leek, sweetcorn, rhubarb → high-nitrogen; fruit trees, asparagus,
+> artichoke, seakale → balanced; berries → high-potash. `createFeedTask` now
+> reads it ("apply high-potash feed"); falls back to "general-purpose fertiliser"
+> when unset. `feedType` is carried on `GeneratedTask` so the UI can suggest a
+> homemade option (B1). Covered by a new unit test.
 
-### Goal A3 — "Feed overdue" urgency
-Today, a plant fed long past its cadence still shows low priority. Add urgency:
-when `daysSinceFeed >= feedFrequencyDays` by a margin (e.g. > cadence + 14d), mark
-the feed task medium/high priority and note "Overdue — last fed N days ago".
-- Files: `createFeedTask` / priority logic in `task-generator.ts` + tests.
-- Acceptance: unit test asserts overdue feed → elevated priority.
+### Goal A3 — "Feed overdue" urgency ✅ DONE (2026-06-17)
+> Implemented: `createFeedTask` marks a feed overdue when
+> `daysSinceLastFeed > feedFrequencyDays + 14`, elevating it to `medium` priority
+> with an "Overdue — last fed N days ago" note. Below the 14-day margin it stays
+> low priority. Two new unit tests cover the elevated and within-margin cases.
 
 ---
 
 ## Milestone B — Make your own plant food
 
-### Goal B1 — Lightweight "homemade feed" reference data + UI surface
-Add a small static dataset of homemade feeds (comfrey tea, nettle feed, wood-ash
-potash, worm-bin leachate, general liquid feed) with: what it's good for, NPK
-lean (high-N vs high-K), how to make it, dilution ratio, and which `feedType` it
-satisfies. Surface it where feeding is relevant (feed task detail / a small
-"How to make this feed" link, and/or a Help/Guide section).
-- New file: `src/lib/feeds/homemade-feeds.ts` (+ types).
-- Tie-in: when a feed task has `feedType: 'high-potash'`, offer "comfrey tea" etc.
-- Acceptance: clicking/opening a feed task surfaces a relevant homemade option;
-  unit test maps feedType → suggested homemade feed.
+### Goal B1 — Lightweight "homemade feed" reference data + UI surface ✅ DONE (2026-06-17)
+> Implemented: `src/lib/feeds/homemade-feeds.ts` holds five homemade feeds
+> (comfrey tea, nettle feed, wood ash, worm-bin leachate, compost/manure), each
+> with what it's good for, NPK lean, how to make it, a dilution ratio, and which
+> `feedType`(s) it satisfies. `getHomemadeFeedsForType(feedType)` returns matches
+> best-lean-first. UI tie-in: a collapsible "Make your own feed" disclosure
+> (`HomemadeFeedHint` in `TaskList.tsx`) renders under any feed task that carries
+> a `feedType`, listing the relevant homemade option(s). Six unit tests cover the
+> feedType → feed mapping and data shape.
 
 ### Goal B2 (optional) — Link comfrey/compost the user already grows
 If the user has comfrey planted or an active compost pile, prefer suggesting their
@@ -118,8 +118,9 @@ make chutney." Reuses the existing `care-tip` task plumbing — no new task type
 ---
 
 ## Suggested order & how to dispatch
-1. **A1 → A2 → A3** (feeding alerts; A1 alone already fixes the main complaint).
-2. **B1** (homemade feeds), then optional **B2**.
+1. ~~**A1 → A2 → A3**~~ ✅ done (feeding alerts; Milestone A complete).
+2. ~~**B1**~~ ✅ done (homemade feeds). Optional **B2** (prefer the user's own
+   comfrey bed / ready compost) is the next remaining feeding goal.
 3. Milestone C (preserving/storage) — deferred; revisit later.
 
 Each Goal above is self-contained and can be handed to an agent independently.

--- a/src/__tests__/lib/homemade-feeds.test.ts
+++ b/src/__tests__/lib/homemade-feeds.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { HOMEMADE_FEEDS, getHomemadeFeedsForType } from '@/lib/feeds/homemade-feeds'
+import type { FeedType } from '@/types/garden-planner'
+
+describe('homemade feeds', () => {
+  it('suggests comfrey tea (and only high-potash feeds) for a high-potash request', () => {
+    const feeds = getHomemadeFeedsForType('high-potash')
+    expect(feeds.length).toBeGreaterThan(0)
+    expect(feeds.map((f) => f.id)).toContain('comfrey-tea')
+    expect(feeds.every((f) => f.satisfies.includes('high-potash'))).toBe(true)
+  })
+
+  it('suggests nettle feed for a high-nitrogen request', () => {
+    const feeds = getHomemadeFeedsForType('high-nitrogen')
+    expect(feeds.map((f) => f.id)).toContain('nettle-feed')
+  })
+
+  it('leads with the feed whose NPK lean matches the request', () => {
+    const feeds = getHomemadeFeedsForType('high-potash')
+    expect(feeds[0].npkLean).toBe('high-potash')
+  })
+
+  it('maps the comfrey feedType to comfrey tea', () => {
+    const feeds = getHomemadeFeedsForType('comfrey')
+    expect(feeds.map((f) => f.id)).toContain('comfrey-tea')
+  })
+
+  it('returns nothing meaningless — every entry satisfies the requested type', () => {
+    const types: FeedType[] = ['high-potash', 'high-nitrogen', 'balanced', 'comfrey', 'compost']
+    for (const type of types) {
+      for (const feed of getHomemadeFeedsForType(type)) {
+        expect(feed.satisfies).toContain(type)
+      }
+    }
+  })
+
+  it('has well-formed data for every feed', () => {
+    for (const feed of HOMEMADE_FEEDS) {
+      expect(feed.id).toBeTruthy()
+      expect(feed.name).toBeTruthy()
+      expect(feed.goodFor).toBeTruthy()
+      expect(feed.howTo).toBeTruthy()
+      expect(feed.dilution).toBeTruthy()
+      expect(feed.satisfies.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/__tests__/lib/task-generator.test.ts
+++ b/src/__tests__/lib/task-generator.test.ts
@@ -1268,6 +1268,99 @@ describe('task-generator', () => {
       expect(feedTasks).toHaveLength(0)
     })
 
+    it('names the feed type in the note and on the task when set', () => {
+      const tomatoVeg = {
+        id: 'tomato',
+        name: 'Tomato',
+        planting: {
+          harvestMonths: [7, 8, 9],
+          sowIndoorsMonths: [],
+          sowOutdoorsMonths: [],
+          transplantMonths: [],
+        },
+        care: { water: 'high' as const },
+        maintenance: { feedMonths: [6, 7], feedFrequencyDays: 7, feedType: 'high-potash' as const },
+      }
+      mockGetVegetableById.mockReturnValue(tomatoVeg)
+
+      const bed: Area = { id: 'bed-a', name: 'Bed A', kind: 'rotation-bed', canHavePlantings: true }
+      const planting: Planting = { id: 'p1', plantId: 'tomato', status: 'active' }
+
+      const tasks = generateTasksForMonth(
+        7 as Month,
+        [{ planting, areaId: 'bed-a', areaName: 'Bed A' }],
+        [bed],
+        new Date('2026-07-15'),
+        [],
+        2026,
+        {}
+      )
+
+      const feedTasks = tasks.filter((t) => t.generatedType === 'feed')
+      expect(feedTasks).toHaveLength(1)
+      expect(feedTasks[0].feedType).toBe('high-potash')
+      expect(feedTasks[0].notes).toContain('high-potash feed')
+    })
+
+    it('elevates an overdue feed to medium priority with an "Overdue" note', () => {
+      const tomatoVeg = {
+        id: 'tomato',
+        name: 'Tomato',
+        planting: {
+          harvestMonths: [7, 8, 9],
+          sowIndoorsMonths: [],
+          sowOutdoorsMonths: [],
+          transplantMonths: [],
+        },
+        care: { water: 'high' as const },
+        maintenance: { feedMonths: [6, 7], feedFrequencyDays: 7, feedType: 'high-potash' as const },
+      }
+      mockGetVegetableById.mockReturnValue(tomatoVeg)
+
+      const bed: Area = { id: 'bed-a', name: 'Bed A', kind: 'rotation-bed', canHavePlantings: true }
+      const planting: Planting = { id: 'p1', plantId: 'tomato', status: 'active' }
+
+      // 30 days since feed, cadence 7 → well past the 14-day overdue margin.
+      const tasks = generateTasksForMonth(
+        7 as Month,
+        [{ planting, areaId: 'bed-a', areaName: 'Bed A' }],
+        [bed],
+        new Date('2026-07-15'),
+        [],
+        2026,
+        { 'bed-a': { feed: 30 } }
+      )
+
+      const feedTasks = tasks.filter((t) => t.generatedType === 'feed')
+      expect(feedTasks).toHaveLength(1)
+      expect(feedTasks[0].priority).toBe('medium')
+      expect(feedTasks[0].notes).toContain('Overdue')
+    })
+
+    it('keeps a feed within the overdue margin at low priority', () => {
+      const raspberryWithMargin = {
+        ...raspberryVeg,
+        maintenance: { feedMonths: [3, 6], feedFrequencyDays: 21 },
+      }
+      mockGetVegetableById.mockReturnValue(raspberryWithMargin)
+
+      // 30 days since feed, cadence 21 → only 9 days over, under the 14-day margin.
+      const tasks = generateTasksForMonth(
+        6 as Month,
+        [],
+        [raspberryArea],
+        new Date('2026-06-15'),
+        [],
+        2026,
+        { 'raspberry-patch': { feed: 30 } }
+      )
+
+      const feedTasks = tasks.filter((t) => t.generatedType === 'feed')
+      expect(feedTasks).toHaveLength(1)
+      expect(feedTasks[0].priority).toBe('low')
+      expect(feedTasks[0].notes).not.toContain('Overdue')
+    })
+
     it('emits a feed task for a hungry annual planted in a bed (no primary plant)', () => {
       const courgetteVeg = {
         id: 'courgette',

--- a/src/components/dashboard/TaskList.tsx
+++ b/src/components/dashboard/TaskList.tsx
@@ -61,10 +61,14 @@ const URGENCY_STYLES: Record<TaskUrgency, string> = {
  * feedType. Lists the homemade feeds that can stand in for the bought type
  * (comfrey tea for high-potash, nettle feed for high-nitrogen, etc.).
  */
-function HomemadeFeedHint({ feedType }: { feedType: FeedType }) {
+function HomemadeFeedHint({ feedType, taskId }: { feedType: FeedType; taskId: string }) {
   const [open, setOpen] = useState(false)
   const feeds = getHomemadeFeedsForType(feedType)
   if (feeds.length === 0) return null
+
+  // Unique per task so the button/list association stays valid when several
+  // feed tasks render on the same page.
+  const listId = `homemade-feed-list-${taskId}`
 
   return (
     <div className="mt-1">
@@ -73,12 +77,13 @@ function HomemadeFeedHint({ feedType }: { feedType: FeedType }) {
         onClick={() => setOpen((o) => !o)}
         className="inline-flex items-center gap-1 py-1 text-xs text-zen-bamboo-700 hover:text-zen-bamboo-800 transition-colors"
         aria-expanded={open}
+        aria-controls={listId}
       >
         {open ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
         Make your own feed
       </button>
       {open && (
-        <ul className="mt-1 space-y-2">
+        <ul id={listId} className="mt-1 space-y-2">
           {feeds.map((feed) => (
             <li key={feed.id} className="text-xs text-zen-stone-500 leading-relaxed">
               <span className="font-medium text-zen-ink-700">{feed.name}</span> — {feed.goodFor}
@@ -248,7 +253,7 @@ function GeneratedTaskItem({
         {task.notes && (
           <p className="text-xs text-zen-stone-500 mt-1">{task.notes}</p>
         )}
-        {task.feedType && <HomemadeFeedHint feedType={task.feedType} />}
+        {task.feedType && <HomemadeFeedHint feedType={task.feedType} taskId={task.id} />}
       </div>
       <div className="flex items-center gap-1.5 flex-shrink-0">
         {badge && (

--- a/src/components/dashboard/TaskList.tsx
+++ b/src/components/dashboard/TaskList.tsx
@@ -3,6 +3,8 @@ import { Scissors, Droplets, TreeDeciduous, Sparkles, CheckCircle2, Sprout, Arro
 import { CustomTask, NewCustomTask, MaintenanceTask, MaintenanceTaskType } from '@/types/unified-allotment'
 import { GeneratedTask, GeneratedTaskType, TaskUrgency } from '@/lib/task-generator'
 import { SeasonalTheme } from '@/lib/seasonal-theme'
+import { FeedType } from '@/types/garden-planner'
+import { getHomemadeFeedsForType } from '@/lib/feeds/homemade-feeds'
 
 interface TaskListProps {
   customTasks?: CustomTask[]
@@ -52,6 +54,42 @@ const URGENCY_STYLES: Record<TaskUrgency, string> = {
   'this-week': 'bg-zen-water-100 text-zen-water-700',
   'upcoming': 'bg-zen-moss-100 text-zen-moss-700',
   'later': 'bg-zen-stone-100 text-zen-stone-600',
+}
+
+/**
+ * Collapsible "make your own feed" hint shown under feed tasks that carry a
+ * feedType. Lists the homemade feeds that can stand in for the bought type
+ * (comfrey tea for high-potash, nettle feed for high-nitrogen, etc.).
+ */
+function HomemadeFeedHint({ feedType }: { feedType: FeedType }) {
+  const [open, setOpen] = useState(false)
+  const feeds = getHomemadeFeedsForType(feedType)
+  if (feeds.length === 0) return null
+
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1 py-1 text-xs text-zen-bamboo-700 hover:text-zen-bamboo-800 transition-colors"
+        aria-expanded={open}
+      >
+        {open ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        Make your own feed
+      </button>
+      {open && (
+        <ul className="mt-1 space-y-2">
+          {feeds.map((feed) => (
+            <li key={feed.id} className="text-xs text-zen-stone-500 leading-relaxed">
+              <span className="font-medium text-zen-ink-700">{feed.name}</span> — {feed.goodFor}
+              <span className="block">{feed.howTo}</span>
+              <span className="block italic">{feed.dilution}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
 }
 
 function CustomTaskItem({
@@ -210,6 +248,7 @@ function GeneratedTaskItem({
         {task.notes && (
           <p className="text-xs text-zen-stone-500 mt-1">{task.notes}</p>
         )}
+        {task.feedType && <HomemadeFeedHint feedType={task.feedType} />}
       </div>
       <div className="flex items-center gap-1.5 flex-shrink-0">
         {badge && (

--- a/src/lib/feeds/homemade-feeds.ts
+++ b/src/lib/feeds/homemade-feeds.ts
@@ -1,0 +1,90 @@
+/**
+ * Homemade plant feeds (Milestone B1)
+ *
+ * A small static reference of feeds a gardener can make from things they
+ * grow or already have on the plot. Each entry records what it's good for,
+ * its NPK lean, how to make it, a dilution ratio, and which `feedType`(s) it
+ * can stand in for — so a feed task that wants "high-potash feed" can offer
+ * "comfrey tea" as a make-your-own alternative.
+ *
+ * Informational only (Simplicity First) — no tracking, no schema.
+ */
+
+import type { FeedType } from '@/types/garden-planner'
+
+export interface HomemadeFeed {
+  id: string
+  name: string
+  /** One line on what it's best used for. */
+  goodFor: string
+  /** Whether it leans nitrogen, potash, or roughly balanced. */
+  npkLean: 'high-nitrogen' | 'high-potash' | 'balanced'
+  /** How to make it, in a sentence or two. */
+  howTo: string
+  /** Dilution ratio for application (or "Apply neat"/"Top dress"). */
+  dilution: string
+  /** Which bought-feed types this can replace. */
+  satisfies: FeedType[]
+}
+
+export const HOMEMADE_FEEDS: HomemadeFeed[] = [
+  {
+    id: 'comfrey-tea',
+    name: 'Comfrey tea',
+    goodFor: 'Fruiting crops — tomatoes, courgettes, squash, beans, peppers',
+    npkLean: 'high-potash',
+    howTo: 'Pack a bucket with comfrey leaves, weigh down, cover with water and leave 4–6 weeks until it turns dark and smelly. Strain off the liquid.',
+    dilution: 'Dilute 1:10 with water (until weak-tea colour) before watering on.',
+    satisfies: ['high-potash', 'comfrey'],
+  },
+  {
+    id: 'nettle-feed',
+    name: 'Nettle feed',
+    goodFor: 'Leafy growth — brassicas, leeks, sweetcorn, young transplants',
+    npkLean: 'high-nitrogen',
+    howTo: 'Steep young nettle tops in water for 2–4 weeks, weighed down and covered. Strain off the liquid.',
+    dilution: 'Dilute 1:10 with water before watering on.',
+    satisfies: ['high-nitrogen'],
+  },
+  {
+    id: 'wood-ash',
+    name: 'Wood ash',
+    goodFor: 'A potash boost for fruiting and root crops',
+    npkLean: 'high-potash',
+    howTo: 'Save ash from untreated wood fires. Keep it dry until use.',
+    dilution: 'Sprinkle a thin dusting around plants and rake in; use sparingly as it raises soil pH.',
+    satisfies: ['high-potash'],
+  },
+  {
+    id: 'worm-leachate',
+    name: 'Worm-bin leachate',
+    goodFor: 'A gentle all-rounder for most crops and seedlings',
+    npkLean: 'balanced',
+    howTo: 'Drain the liquid that collects in the base of a wormery.',
+    dilution: 'Dilute 1:10 with water until it looks like weak tea.',
+    satisfies: ['balanced'],
+  },
+  {
+    id: 'compost-mulch',
+    name: 'Garden compost or well-rotted manure',
+    goodFor: 'Slow-release feeding and soil improvement for hungry beds',
+    npkLean: 'balanced',
+    howTo: 'Use your own finished compost or a well-rotted manure pile.',
+    dilution: 'Top-dress a 2–3cm layer around plants, or fork in before planting.',
+    satisfies: ['balanced', 'compost'],
+  },
+]
+
+/**
+ * Return the homemade feeds that can stand in for a given bought-feed type,
+ * best match first (entries whose own lean matches the requested type lead).
+ */
+export function getHomemadeFeedsForType(feedType: FeedType): HomemadeFeed[] {
+  const matches = HOMEMADE_FEEDS.filter((feed) => feed.satisfies.includes(feedType))
+  // Prefer feeds whose NPK lean matches the request (e.g. comfrey for high-potash).
+  return [...matches].sort((a, b) => {
+    const aMatch = a.npkLean === feedType ? 0 : 1
+    const bMatch = b.npkLean === feedType ? 0 : 1
+    return aMatch - bMatch
+  })
+}

--- a/src/lib/feeds/homemade-feeds.ts
+++ b/src/lib/feeds/homemade-feeds.ts
@@ -80,9 +80,11 @@ export const HOMEMADE_FEEDS: HomemadeFeed[] = [
  * best match first (entries whose own lean matches the requested type lead).
  */
 export function getHomemadeFeedsForType(feedType: FeedType): HomemadeFeed[] {
-  const matches = HOMEMADE_FEEDS.filter((feed) => feed.satisfies.includes(feedType))
-  // Prefer feeds whose NPK lean matches the request (e.g. comfrey for high-potash).
-  return [...matches].sort((a, b) => {
+  // filter() returns a fresh array, so it is safe to sort in place.
+  // Prefer feeds whose NPK lean matches the request (e.g. comfrey for
+  // high-potash). npkLean is only ever a lean ('high-*'/'balanced'), so for the
+  // 'comfrey'/'compost' types — which each have a single match — this is a no-op.
+  return HOMEMADE_FEEDS.filter((feed) => feed.satisfies.includes(feedType)).sort((a, b) => {
     const aMatch = a.npkLean === feedType ? 0 : 1
     const bMatch = b.npkLean === feedType ? 0 : 1
     return aMatch - bMatch

--- a/src/lib/task-generator.ts
+++ b/src/lib/task-generator.ts
@@ -9,7 +9,7 @@
  */
 
 import { MaintenanceTask, MaintenanceTaskType, Planting, Area, StoredVariety } from '@/types/unified-allotment'
-import { Vegetable, Month, WaterRequirement } from '@/types/garden-planner'
+import { Vegetable, Month, WaterRequirement, FeedType } from '@/types/garden-planner'
 import { getVegetableById } from '@/lib/vegetable-database'
 import { getGerminationDays } from '@/lib/date-calculator'
 import { calculatePerennialStatus } from '@/lib/perennial-calculator'
@@ -57,7 +57,24 @@ export interface GeneratedTask {
   daysRemaining?: number
   urgency?: TaskUrgency
   calculatedFrom?: 'actual-date' | 'calendar-month'
+  /** For feed tasks: the kind of feed wanted, so the UI can suggest a homemade option. */
+  feedType?: FeedType
 }
+
+/** Human-readable label for each feed type, used in feed task notes. */
+const FEED_TYPE_LABEL: Record<FeedType, string> = {
+  'high-potash': 'high-potash feed',
+  'high-nitrogen': 'high-nitrogen feed',
+  balanced: 'balanced feed',
+  comfrey: 'comfrey feed',
+  compost: 'compost or well-rotted manure',
+}
+
+/**
+ * A feed is "overdue" once it is this many days past its cadence. Below this
+ * margin the reminder stays low priority; past it the task is elevated.
+ */
+const FEED_OVERDUE_MARGIN_DAYS = 14
 
 interface PlantingWithContext {
   planting: Planting
@@ -706,11 +723,28 @@ function createFeedTask(
   const variety = area.primaryPlant?.variety
   const displayName = variety ? `${area.name} (${variety})` : area.name
 
-  let notes = 'Apply general-purpose fertiliser'
-  if (daysSinceLastFeed !== undefined && daysSinceLastFeed > 0) {
-    notes = `Last fed ${daysSinceLastFeed} day${daysSinceLastFeed === 1 ? '' : 's'} ago — apply general-purpose fertiliser`
+  const feedType = vegetable.maintenance?.feedType
+  // Lowercase action phrase ("apply high-potash feed") used mid-sentence;
+  // capitalised when it leads the note.
+  const action = feedType
+    ? `apply ${FEED_TYPE_LABEL[feedType]}`
+    : 'apply general-purpose fertiliser'
+  const leadAction = action.charAt(0).toUpperCase() + action.slice(1)
+
+  // A3: a feed left well past its cadence is overdue — elevate it and say so.
+  const cadence = vegetable.maintenance?.feedFrequencyDays
+  const isOverdue =
+    cadence !== undefined &&
+    daysSinceLastFeed !== undefined &&
+    daysSinceLastFeed > cadence + FEED_OVERDUE_MARGIN_DAYS
+
+  let notes = leadAction
+  if (isOverdue) {
+    notes = `Overdue — last fed ${daysSinceLastFeed} days ago. ${leadAction}`
+  } else if (daysSinceLastFeed !== undefined && daysSinceLastFeed > 0) {
+    notes = `Last fed ${daysSinceLastFeed} day${daysSinceLastFeed === 1 ? '' : 's'} ago — ${action}`
   }
-  // daysSinceLastFeed === 0 (just tapped ✓) keeps the generic note so a
+  // daysSinceLastFeed === 0 (just tapped ✓) keeps the plain note so a
   // restored task reads as a normal active reminder rather than "Fed today".
 
   return {
@@ -723,8 +757,9 @@ function createFeedTask(
     areaId: area.id,
     areaName: area.name,
     month,
-    priority: 'low',
+    priority: isOverdue ? 'medium' : 'low',
     notes,
+    feedType,
   }
 }
 

--- a/src/lib/vegetables/data/alliums.ts
+++ b/src/lib/vegetables/data/alliums.ts
@@ -108,6 +108,7 @@ export const alliums: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 28,
+      feedType: 'high-nitrogen',
       notes: ['A monthly nitrogen feed in summer thickens the stems']
     },
     rhsUrl: 'https://www.rhs.org.uk/vegetables/leeks/grow-your-own',

--- a/src/lib/vegetables/data/berries.ts
+++ b/src/lib/vegetables/data/berries.ts
@@ -96,6 +96,7 @@ export const berries: Vegetable[] = [
       feedMonths: [3],
       mulchMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 5,
       notes: ['Summer types: cut fruited canes after harvest', 'Autumn types: cut all canes to ground in Feb']
     },
@@ -225,6 +226,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [11, 12, 1, 2],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 5,
       notes: ['Prune to open goblet shape in winter', 'Watch for sawfly in spring']
     },
@@ -271,6 +273,7 @@ export const berries: Vegetable[] = [
       feedMonths: [3],
       mulchMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 5,
       notes: ['Remove a third of oldest wood each year after fruiting']
     },
@@ -315,6 +318,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [11, 12, 1, 2],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 5,
       notes: ['Prune to open goblet shape like gooseberries']
     },
@@ -360,6 +364,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [8, 9],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 5,
       notes: ['Remove fruited canes after harvest']
     },
@@ -404,6 +409,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [8, 9],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 5,
       notes: ['Remove fruited canes after harvest']
     },
@@ -447,6 +453,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [11, 12, 1, 2],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 5,
       notes: ['Minimal pruning needed - remove dead wood']
     },
@@ -487,6 +494,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [11, 12, 1, 2],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 7,
       notes: ['Minimal pruning - remove dead wood only']
     },
@@ -528,6 +536,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [2, 3],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 7,
       notes: ['Control suckers to prevent spread']
     },
@@ -569,6 +578,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [11, 12, 1, 2],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 7,
       notes: ['Minimal pruning needed']
     },
@@ -610,6 +620,7 @@ export const berries: Vegetable[] = [
       pruneMonths: [11, 12, 1],
       feedMonths: [3],
       feedFrequencyDays: 28,
+      feedType: 'high-potash',
       waterFrequencyDays: 7,
       notes: ['Prune to maintain size and shape']
     },

--- a/src/lib/vegetables/data/brassicas.ts
+++ b/src/lib/vegetables/data/brassicas.ts
@@ -145,6 +145,7 @@ export const brassicas: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7],
       feedFrequencyDays: 28,
+      feedType: 'high-nitrogen',
       notes: ['Top-dress with a high-nitrogen feed monthly during active growth']
     },
     rhsUrl: 'https://www.rhs.org.uk/vegetables/cabbages/grow-your-own',
@@ -188,6 +189,7 @@ export const brassicas: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7],
       feedFrequencyDays: 28,
+      feedType: 'high-nitrogen',
       notes: ['Top-dress with a high-nitrogen feed monthly during active growth']
     },
     rhsUrl: 'https://www.rhs.org.uk/vegetables/broccoli/grow-your-own',
@@ -231,6 +233,7 @@ export const brassicas: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8, 9],
       feedFrequencyDays: 28,
+      feedType: 'high-nitrogen',
       notes: ['Top-dress with a high-nitrogen feed monthly during active growth']
     },
     enhancedCompanions: [
@@ -270,6 +273,7 @@ export const brassicas: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7],
       feedFrequencyDays: 28,
+      feedType: 'high-nitrogen',
       notes: ['Top-dress with a high-nitrogen feed monthly during active growth']
     },
     enhancedCompanions: [
@@ -312,6 +316,7 @@ export const brassicas: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 28,
+      feedType: 'high-nitrogen',
       notes: ['Top-dress with a high-nitrogen feed monthly during summer growth']
     },
     enhancedCompanions: [
@@ -392,6 +397,7 @@ export const brassicas: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 28,
+      feedType: 'high-nitrogen',
       notes: ['Top-dress with a high-nitrogen feed monthly during active growth']
     },
     enhancedCompanions: [
@@ -433,6 +439,7 @@ export const brassicas: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 28,
+      feedType: 'high-nitrogen',
       notes: ['Top-dress with a high-nitrogen feed monthly during active growth']
     },
     enhancedCompanions: [
@@ -623,6 +630,7 @@ export const brassicas: Vegetable[] = [
     maintenance: {
       feedMonths: [3],
       feedFrequencyDays: 60,
+      feedType: 'balanced',
       waterFrequencyDays: 10,
       notes: ['Cover crowns to blanch shoots']
     },

--- a/src/lib/vegetables/data/cucurbits.ts
+++ b/src/lib/vegetables/data/cucurbits.ts
@@ -33,6 +33,7 @@ export const cucurbits: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7, 8],
       feedFrequencyDays: 14,
+      feedType: 'high-potash',
       notes: ['High-potash feed (e.g. tomato feed) every 2 weeks once fruits set']
     },
     enhancedCompanions: [
@@ -75,6 +76,7 @@ export const cucurbits: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 14,
+      feedType: 'high-potash',
       notes: ['High-potash feed every 2 weeks once fruits start to swell']
     },
     enhancedCompanions: [
@@ -117,6 +119,7 @@ export const cucurbits: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 14,
+      feedType: 'high-potash',
       notes: ['High-potash feed every 2 weeks once fruits start to swell']
     },
     enhancedCompanions: [
@@ -159,6 +162,7 @@ export const cucurbits: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7, 8],
       feedFrequencyDays: 14,
+      feedType: 'high-potash',
       notes: ['High-potash feed (e.g. tomato feed) every 2 weeks once fruits set']
     },
     enhancedCompanions: [
@@ -200,6 +204,7 @@ export const cucurbits: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 14,
+      feedType: 'high-potash',
       notes: ['High-potash feed every 2 weeks once fruits start to swell']
     },
     enhancedCompanions: [
@@ -241,6 +246,7 @@ export const cucurbits: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 14,
+      feedType: 'high-potash',
       notes: ['High-potash feed every 2 weeks once fruits start to swell']
     },
     enhancedCompanions: [
@@ -282,6 +288,7 @@ export const cucurbits: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 14,
+      feedType: 'high-potash',
       notes: ['High-potash feed every 2 weeks once fruits start to swell']
     },
     enhancedCompanions: [

--- a/src/lib/vegetables/data/fruit-trees.ts
+++ b/src/lib/vegetables/data/fruit-trees.ts
@@ -44,6 +44,7 @@ export const fruitTrees: Vegetable[] = [
       feedMonths: [3],
       mulchMonths: [11],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 7,
       notes: ['Winter prune when dormant', 'Summer prune water shoots in July-Aug']
     },
@@ -98,6 +99,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [7, 8],
       feedMonths: [3],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 7,
       notes: ['ONLY prune in summer to avoid silver leaf and bacterial canker']
     },
@@ -145,6 +147,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [2, 3],
       feedMonths: [3],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 7,
       notes: ['Minimal pruning needed - just remove dead/crossing branches']
     },
@@ -190,6 +193,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [6, 7],
       feedMonths: [3],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 7,
       notes: ['Prune in summer to avoid silver leaf disease']
     },
@@ -237,6 +241,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [12, 1, 2],
       feedMonths: [3],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 7,
       notes: ['Winter prune when dormant', 'May need thinning if heavy crop']
     },
@@ -284,6 +289,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [6, 7],
       feedMonths: [3],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 7,
       notes: ['Prune in summer to avoid silver leaf disease']
     },
@@ -329,6 +335,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [12, 1, 2],
       feedMonths: [3],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 10,
       notes: ['Minimal pruning needed - very low maintenance']
     },
@@ -374,6 +381,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [12, 1, 2],
       feedMonths: [3],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 10,
       notes: ['Minimal pruning - just remove dead/crossing branches']
     },
@@ -418,6 +426,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [3, 4],
       feedMonths: [4, 5],
       feedFrequencyDays: 30,
+      feedType: 'balanced',
       waterFrequencyDays: 5,
       notes: ['Prune in early spring', 'May need winter protection in cold areas']
     },
@@ -463,6 +472,7 @@ export const fruitTrees: Vegetable[] = [
       pruneMonths: [12, 1],
       feedMonths: [3],
       feedFrequencyDays: 90,
+      feedType: 'balanced',
       waterFrequencyDays: 10,
       notes: ['Minimal pruning needed - bleeds sap if cut in growing season']
     },

--- a/src/lib/vegetables/data/legumes.ts
+++ b/src/lib/vegetables/data/legumes.ts
@@ -33,6 +33,7 @@ export const legumes: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 21,
+      feedType: 'high-potash',
       notes: ['Beans fix their own nitrogen — a high-potash feed once flowering boosts pod set']
     },
     enhancedCompanions: [
@@ -194,6 +195,7 @@ export const legumes: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8],
       feedFrequencyDays: 21,
+      feedType: 'high-potash',
       notes: ['Beans fix their own nitrogen — a high-potash feed once flowering boosts pod set']
     },
     enhancedCompanions: [

--- a/src/lib/vegetables/data/other.ts
+++ b/src/lib/vegetables/data/other.ts
@@ -42,6 +42,7 @@ export const other: Vegetable[] = [
       feedMonths: [3],
       mulchMonths: [11],
       feedFrequencyDays: 60,
+      feedType: 'high-nitrogen',
       waterFrequencyDays: 7,
       notes: ['Force under pot from January for early crop', 'Remove flower stalks immediately']
     },
@@ -122,6 +123,7 @@ export const other: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7],
       feedFrequencyDays: 21,
+      feedType: 'high-nitrogen',
       notes: ['A high-nitrogen feed every 3 weeks supports fast leafy growth']
     },
     enhancedCompanions: [
@@ -174,6 +176,7 @@ export const other: Vegetable[] = [
       feedMonths: [3],
       mulchMonths: [11],
       feedFrequencyDays: 60,
+      feedType: 'balanced',
       waterFrequencyDays: 7,
       notes: ['Cut down ferns in autumn', 'Weed regularly']
     },
@@ -215,6 +218,7 @@ export const other: Vegetable[] = [
       feedMonths: [3, 5],
       mulchMonths: [11],
       feedFrequencyDays: 30,
+      feedType: 'balanced',
       waterFrequencyDays: 7,
       notes: ['Protect crowns with straw in winter']
     },

--- a/src/lib/vegetables/data/solanaceae.ts
+++ b/src/lib/vegetables/data/solanaceae.ts
@@ -182,6 +182,7 @@ export const solanaceae: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7, 8, 9],
       feedFrequencyDays: 7,
+      feedType: 'high-potash',
       notes: ['High-potash tomato feed weekly once the first truss sets']
     },
     enhancedCompanions: [
@@ -225,6 +226,7 @@ export const solanaceae: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7, 8, 9],
       feedFrequencyDays: 7,
+      feedType: 'high-potash',
       notes: ['High-potash tomato feed weekly once the first truss sets']
     },
     enhancedCompanions: [
@@ -267,6 +269,7 @@ export const solanaceae: Vegetable[] = [
     maintenance: {
       feedMonths: [6, 7, 8, 9],
       feedFrequencyDays: 7,
+      feedType: 'high-potash',
       notes: ['High-potash tomato feed weekly once the first truss sets']
     },
     enhancedCompanions: [
@@ -309,6 +312,7 @@ export const solanaceae: Vegetable[] = [
     maintenance: {
       feedMonths: [7, 8, 9],
       feedFrequencyDays: 14,
+      feedType: 'high-potash',
       notes: ['High-potash feed every 2 weeks once fruits begin to form']
     },
     enhancedCompanions: [

--- a/src/types/garden-planner.ts
+++ b/src/types/garden-planner.ts
@@ -132,6 +132,13 @@ export interface Vegetable {
   enhancedAvoid: EnhancedCompanion[]       // Avoid relationships with metadata
 }
 
+/**
+ * What kind of feed a crop wants. Drives the feed-task note ("apply
+ * high-potash feed") and maps to homemade feed suggestions. Absent = a
+ * generic general-purpose fertiliser reminder.
+ */
+export type FeedType = 'high-potash' | 'high-nitrogen' | 'balanced' | 'comfrey' | 'compost'
+
 // Maintenance info for perennials, trees, and shrubs
 export interface MaintenanceInfo {
   pruneMonths?: Month[]    // Months when pruning is recommended
@@ -143,6 +150,8 @@ export interface MaintenanceInfo {
    * elapsed. Falls back to feedMonths when unset or no prior feed log.
    */
   feedFrequencyDays?: number
+  /** Preferred feed (e.g. high-potash for fruiting crops). Surfaced in the feed task note. */
+  feedType?: FeedType
   /**
    * Cadence between waterings in days. Combined with the plant's
    * `care.water` requirement and recent rainfall to produce date-based


### PR DESCRIPTION
Continues the feeding plan (Milestone A2/A3 + B1) on top of the A1 work.

A2 — feed type: add FeedType + optional maintenance.feedType. Populate
every crop that already carries feed data (high-potash for fruiting crops
and berries, high-nitrogen for leafy brassicas/leek/sweetcorn/rhubarb,
balanced for trees and perennial veg). createFeedTask now names the feed
("apply high-potash feed") and carries feedType on the task; falls back to
the generic note when unset.

A3 — overdue urgency: a feed left more than 14 days past its cadence is
elevated to medium priority with an "Overdue — last fed N days ago" note.

B1 — homemade feeds: new src/lib/feeds/homemade-feeds.ts (comfrey tea,
nettle feed, wood ash, worm leachate, compost) with feedType mapping, and a
collapsible "Make your own feed" hint under feed tasks in TaskList.

New unit tests for the feed-type note, overdue elevation, within-margin
case, and the feedType -> homemade-feed mapping.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QmqQazSkLGeo3jEZQkPZ2X