### PR TITLE
Storage QA: fill high-glut/keeper gaps + complete-coverage plan

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -373,6 +373,53 @@ PR #388 (squash `5a2eb2d`) closed two foundation-layer gaps Gemini flagged as cr
 
 PR #387 (squash `5580c59`) flipped `USE_YJS_STORAGE` to `true`. The Yjs path is now canonical; the legacy chain stays in tree as the rollback floor and the cloud-sync mirror target throughout the soak window. Rollback is a one-line flag flip back, no data migration — the mirror has been keeping localStorage and Supabase in sync. PR-C also added a `tests/utils/storage.ts` helper, `clearAllStorage(page)`, that deletes the `bwp-allotment-yjs` IndexedDB database alongside `localStorage.clear()`; without it, Playwright's full-suite run saw cross-test contamination from stale Yjs state. Every `await page.evaluate(() => localStorage.clear())` call site now routes through the helper, and `seedTestData` / `seedBedWithCarrot` clear storage before seeding so the Yjs-path first-run hydrates from the fresh legacy snapshot. The deployment-runbook step `UPDATE allotments SET data = data` ran against production Supabase post-merge — the `BEFORE UPDATE` history trigger from PR #332 fired and inserted two new rows into `allotment_history` (IDs 35 and 36, one per active user). The `archived_at` on each carries the user's last legacy-chain `updated_at` (the trigger archives `OLD.updated_at`), which is exactly the pre-cutover state worth keeping as a recovery point.
 
+### Feeding & Preserving — Milestones B2 + C (PR #425 + storage QA follow-up)
+
+PR #425 shipped the feed-task own-resource hints (B2 — feed hints prefer the
+user's own comfrey bed / ready compost over generic make-your-own advice) and
+the storage/preserving surface (Milestone C): an optional `storage` field on
+`Vegetable` (`methods` / `freshDays` / `tip`), a read-only "Storage &
+Preserving" panel on the plant/variety detail page (C2), and a "Glut of X?"
+care-tip nudge that fires in a crop's expected harvest window when its storage
+data offers a preserving method (C3 — `generatePreserveNudges`, preserve
+methods = freeze/jam/pickle/ferment/dry).
+
+The storage-QA follow-up reviewed and corrected the authored data and filled the
+obvious high-glut / staple-keeper gaps the first pass missed — **33 crops
+added** (alliums: leek, shallot; brassicas: swede, turnip, cauliflower,
+calabrese, purple-sprouting broccoli, Brussels sprouts, savoy; roots: parsnip,
+celeriac; other: sweetcorn, Jerusalem artichoke; berries: gooseberry,
+redcurrant, blueberry; fruit trees: pear, cherry, damson, greengage; cucurbits:
+patty-pan, spaghetti, acorn squash; solanaceae: blight-resistant tomato; leafy:
+kale, cavolo nero, chard, spinach; legumes: borlotti, black turtle, edamame,
+mangetout, sugar snap), plus a courgette methods/tip consistency fix (added
+`jam` to match its chutney tip). All 26 pre-existing entries were sanity-checked
+against Scottish-allotment practice and found sound. C2 and C3 were verified
+in-app (Playwright screenshots: detail panel renders for crops with data and is
+hidden without; the glut nudge shows for an in-window preservable crop and not
+for an out-of-window one). Coverage now **59 / ~191 crops**.
+
+**Backlog — complete storage tips for all plants in the database.** ~132 crops
+still lack `storage` data. Priority edible long tail: all **herbs** (20 — dry /
+freeze guidance), remaining **leafy greens** (lettuce, rocket, mizuna, pak choi,
+perpetual spinach, …), remaining **roots** (salsify, scorzonera, mooli, black
+radish, horseradish, Florence fennel, Hamburg parsley, yacon, oca, skirret,
+ulluco, Chinese artichoke), remaining **berries** (tayberry, loganberry,
+jostaberry, honeyberry, aronia, elderberry, sea buckthorn, goji), remaining
+**fruit trees** (medlar, quince, fig, mulberry), remaining **alliums**
+(spring onion, Welsh onion, elephant garlic, walking onion, potato onion,
+garlic chives, ramps), remaining **brassicas** (radish, kohlrabi, romanesco,
+Chinese broccoli, turnip tops, mibuna, sea kale), remaining **legumes**
+(asparagus peas, fenugreek, ground nut), remaining **solanaceae** (first/second
+early potato — "eat fresh", tomatillo), and remaining **other** (asparagus,
+globe artichoke, celery, cardoon, mashua). Ornamentals (annual & perennial
+flowers, bulbs, climbers), green manures, and mushrooms mostly don't need
+storage tips — though edible flowers (calendula, nasturtium) and culinary herbs
+are worthwhile exceptions. Rule of thumb when authoring: only crops with a
+genuine preserving option (freeze/jam/pickle/ferment/dry) should carry one (and
+thus trigger the C3 nudge); pure keepers get cure/store-cool/fridge/fresh only,
+so they show storage info without nagging to "preserve the glut".
+
 ### Up Next: Phase 1 soak then Step 5 cleanup
 
 The soak window is open. Success criterion is qualitative for the two-user cohort: both real users use the app on the flag for ~3–5 days each, run at least one manual cross-device conflict (edit on phone and laptop, watch the conflict-replace path actually re-hydrate the Yjs doc from cloud), and report no data anomalies. The Yjs binary on each device is the source of truth from this point; the legacy `allotment-unified-data` localStorage key is being mirrored from Yjs and is the rollback floor. Step 5 then deletes `useSyncedStorage`, the legacy branch of every domain-hook method, `useYjsToLegacyMirror`, the `bwp-storage-flag` BroadcastChannel, the legacy localStorage key, and the same-tab broadcast apparatus from PR #369 (the `bonnie:storage-update` CustomEvent, the `instanceId`/`sameTabSeq` bookkeeping, the `recordSavedState`/`recordAdoptedState` helpers, the `recentSavesRef` echo dedup) — every line of that broadcast becomes redundant the day the legacy chain leaves the tree. `serializeToJson` and `decodeDocState` stay forever (rollback + GDPR export + debug). Separate follow-ups worth filing: rename `src/lib/yjs-spike/` → `src/lib/yjs/`, consolidate `src/hooks/allotment/yjs-helpers.ts` with the now-internal `assignDefined` in `allotment-yjs.ts`, and tighten the still-`addInitScript`-pattern Playwright seeds (homepage / onboarding / boost-this-bed) to also clear Yjs IDB if those tests start contaminating each other later.

--- a/src/__tests__/lib/plant-data-integrity.test.ts
+++ b/src/__tests__/lib/plant-data-integrity.test.ts
@@ -109,7 +109,13 @@ describe('Plant Data Integrity', () => {
     })
 
     it('populates high-glut crops with storage data', () => {
-      const expected = ['courgette', 'runner-beans', 'cherry-tomato', 'apple-tree', 'rhubarb', 'onion']
+      const expected = [
+        'courgette', 'runner-beans', 'cherry-tomato', 'apple-tree', 'rhubarb', 'onion',
+        // Staple keepers / glut crops added in the storage QA pass
+        'leek', 'swede', 'parsnip', 'celeriac', 'sweetcorn', 'cauliflower',
+        'brussels-sprouts', 'gooseberry', 'redcurrant', 'blueberry', 'pear-tree',
+        'damson-tree', 'kale', 'spinach', 'borlotti-beans',
+      ]
       for (const id of expected) {
         expect(getVegetableById(id)?.storage).toBeDefined()
       }

--- a/src/__tests__/lib/plant-data-integrity.test.ts
+++ b/src/__tests__/lib/plant-data-integrity.test.ts
@@ -108,7 +108,7 @@ describe('Plant Data Integrity', () => {
       }
     })
 
-    it('populates high-glut crops with storage data', () => {
+    it('populates staple keeper and glut crops with storage data', () => {
       const expected = [
         // Headline glut crops populated in the original Milestone C pass
         'courgette', 'runner-beans', 'cherry-tomato', 'apple-tree', 'rhubarb', 'onion',

--- a/src/__tests__/lib/plant-data-integrity.test.ts
+++ b/src/__tests__/lib/plant-data-integrity.test.ts
@@ -110,11 +110,20 @@ describe('Plant Data Integrity', () => {
 
     it('populates high-glut crops with storage data', () => {
       const expected = [
+        // Headline glut crops populated in the original Milestone C pass
         'courgette', 'runner-beans', 'cherry-tomato', 'apple-tree', 'rhubarb', 'onion',
-        // Staple keepers / glut crops added in the storage QA pass
-        'leek', 'swede', 'parsnip', 'celeriac', 'sweetcorn', 'cauliflower',
-        'brussels-sprouts', 'gooseberry', 'redcurrant', 'blueberry', 'pear-tree',
-        'damson-tree', 'kale', 'spinach', 'borlotti-beans',
+        // All staple keepers / glut crops added in the storage QA pass
+        'leek', 'shallot',
+        'swede', 'turnip', 'cauliflower', 'broccoli', 'purple-sprouting-broccoli',
+        'brussels-sprouts', 'savoy-cabbage',
+        'parsnip', 'celeriac',
+        'sweetcorn', 'jerusalem-artichoke',
+        'gooseberry', 'redcurrant', 'blueberry',
+        'pear-tree', 'cherry-tree', 'damson-tree', 'greengage-tree',
+        'patty-pan-squash', 'spaghetti-squash', 'acorn-squash',
+        'blight-resistant-tomato',
+        'kale', 'cavolo-nero', 'chard', 'spinach',
+        'borlotti-beans', 'black-turtle-beans', 'edamame', 'mangetout', 'sugar-snap-peas',
       ]
       for (const id of expected) {
         expect(getVegetableById(id)?.storage).toBeDefined()

--- a/src/lib/vegetables/data/alliums.ts
+++ b/src/lib/vegetables/data/alliums.ts
@@ -91,6 +91,10 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'leek',
+    storage: {
+      methods: ['fresh', 'fridge'],
+      tip: 'Very hardy — leave standing in the ground over winter and lift as needed; keeps about a week in the fridge once pulled.',
+    },
     name: 'Leek',
     category: 'alliums',
     description: 'Hardy winter vegetable. Excellent for Scottish gardens!',
@@ -172,6 +176,10 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'shallot',
+    storage: {
+      methods: ['cure', 'store-cool'],
+      tip: 'Dry the bulbs off thoroughly, then net or tray them somewhere cool and airy — they keep right through to spring.',
+    },
     name: 'Shallot',
     category: 'alliums',
     description: 'Milder than onions, easier to grow from sets. Good for Scottish climate.',

--- a/src/lib/vegetables/data/berries.ts
+++ b/src/lib/vegetables/data/berries.ts
@@ -175,6 +175,11 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'blueberry',
+    storage: {
+      methods: ['fresh', 'freeze', 'jam'],
+      freshDays: 7,
+      tip: 'Open-freeze on trays then bag, or make jam — they keep a few days fresh in the fridge.',
+    },
     name: 'Blueberry',
     category: 'berries',
     description: 'Acid-loving shrub with delicious berries. Needs ericaceous soil.',
@@ -211,6 +216,11 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'gooseberry',
+    storage: {
+      methods: ['fresh', 'freeze', 'jam'],
+      freshDays: 7,
+      tip: 'Top and tail, then freeze — they freeze brilliantly — or cook into gooseberry jam.',
+    },
     name: 'Gooseberry',
     category: 'berries',
     description: 'Traditional Scottish soft fruit. Hardy and productive.',
@@ -308,6 +318,11 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'redcurrant',
+    storage: {
+      methods: ['fresh', 'freeze', 'jam'],
+      freshDays: 4,
+      tip: 'Freeze whole off the strig, or cook into redcurrant jelly for the cheeseboard and gravies.',
+    },
     name: 'Redcurrant',
     category: 'berries',
     description: 'Ornamental and productive soft fruit. Easy to grow in Scotland.',

--- a/src/lib/vegetables/data/brassicas.ts
+++ b/src/lib/vegetables/data/brassicas.ts
@@ -8,6 +8,10 @@ import { Vegetable } from '@/types/garden-planner'
 export const brassicas: Vegetable[] = [
   {
     id: 'swede',
+    storage: {
+      methods: ['store-cool', 'fresh'],
+      tip: 'Very hardy — leave in the ground and lift as needed, or store the roots in boxes of damp sand somewhere cool and frost-free.',
+    },
     name: 'Swede (Neeps)',
     category: 'brassicas',
     description: 'Essential for Burns Night! Hardy Scottish favorite that loves cool weather.',
@@ -46,6 +50,10 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'turnip',
+    storage: {
+      methods: ['store-cool', 'fridge'],
+      tip: 'Eat small ones fresh; twist the tops off maincrop turnips and store in boxes of damp sand somewhere cool.',
+    },
     name: 'Turnip',
     category: 'brassicas',
     description: 'Fast-growing root with edible greens. Best harvested young.',
@@ -168,6 +176,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'broccoli',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze'],
+      freshDays: 7,
+      tip: 'Cut the main head then keep picking side shoots; blanch and freeze any glut.',
+    },
     name: 'Calabrese (Broccoli)',
     category: 'brassicas',
     description: 'Quick maturing broccoli. Start indoors for best results in Scotland.',
@@ -212,6 +225,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'purple-sprouting-broccoli',
+    storage: {
+      methods: ['fresh', 'freeze'],
+      freshDays: 5,
+      tip: 'Pick spears regularly to keep them coming; blanch and freeze a glut.',
+    },
     name: 'Purple Sprouting Broccoli',
     category: 'brassicas',
     description: 'Hardy winter broccoli - harvests when little else is available!',
@@ -252,6 +270,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'cauliflower',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze', 'pickle'],
+      freshDays: 7,
+      tip: 'Curds don’t hold long once ready — break into florets and freeze, or make piccalilli with a glut.',
+    },
     name: 'Cauliflower',
     category: 'brassicas',
     description: 'Demanding but rewarding. Choose varieties suited to Scotland.',
@@ -295,6 +318,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'brussels-sprouts',
+    storage: {
+      methods: ['fresh', 'freeze'],
+      freshDays: 7,
+      tip: 'Stands through hard frost — pick up the stalk as needed; freezes well blanched.',
+    },
     name: 'Brussels Sprouts',
     category: 'brassicas',
     description: 'Christmas dinner essential! Improves after frost.',
@@ -375,6 +403,10 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'savoy-cabbage',
+    storage: {
+      methods: ['fresh', 'store-cool', 'freeze'],
+      tip: 'Very hardy — stands in the ground through frost; shred and freeze any surplus.',
+    },
     name: 'Savoy Cabbage',
     category: 'brassicas',
     description: 'Frost-hardy winter cabbage with crinkled leaves. Traditional Scottish winter vegetable.',

--- a/src/lib/vegetables/data/cucurbits.ts
+++ b/src/lib/vegetables/data/cucurbits.ts
@@ -9,7 +9,7 @@ export const cucurbits: Vegetable[] = [
   {
     id: 'courgette',
     storage: {
-      methods: ['fresh', 'fridge', 'freeze'],
+      methods: ['fresh', 'fridge', 'freeze', 'jam'],
       freshDays: 7,
       tip: 'Glut crop — pick small and often. Freeze grated for soups and cakes, or make chutney.',
     },
@@ -149,6 +149,11 @@ export const cucurbits: Vegetable[] = [
   },
   {
     id: 'patty-pan-squash',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze'],
+      freshDays: 7,
+      tip: 'A summer squash like courgette — pick small and often; freeze sliced or grated for soups and bakes.',
+    },
     name: 'Patty Pan Squash',
     category: 'cucurbits',
     description: 'UFO-shaped summer squash. Compact plants ideal for small Scottish allotments.',
@@ -237,6 +242,10 @@ export const cucurbits: Vegetable[] = [
   },
   {
     id: 'spaghetti-squash',
+    storage: {
+      methods: ['cure', 'store-cool'],
+      tip: 'Cure the skin hard, then store somewhere cool and dry — keeps for months like other winter squash.',
+    },
     name: 'Spaghetti Squash',
     category: 'cucurbits',
     description: 'Winter squash with stringy flesh. Unique texture when cooked.',
@@ -279,6 +288,10 @@ export const cucurbits: Vegetable[] = [
   },
   {
     id: 'acorn-squash',
+    storage: {
+      methods: ['cure', 'store-cool'],
+      tip: 'Cure 10–14 days until the skin hardens, then store cool and dry; eats best within a couple of months.',
+    },
     name: 'Acorn Squash',
     category: 'cucurbits',
     description: 'Compact winter squash with ridged shape. More reliable than butternut in Scotland.',

--- a/src/lib/vegetables/data/fruit-trees.ts
+++ b/src/lib/vegetables/data/fruit-trees.ts
@@ -71,6 +71,11 @@ export const fruitTrees: Vegetable[] = [
   },
   {
     id: 'cherry-tree',
+    storage: {
+      methods: ['fresh', 'freeze', 'jam'],
+      freshDays: 4,
+      tip: 'Best fresh — stone and open-freeze, or make jam; sweet cherries don’t keep long once ripe.',
+    },
     name: 'Cherry Tree',
     category: 'fruit-trees',
     description: 'Beautiful blossom and delicious fruit. Sweet and sour varieties available.',
@@ -119,6 +124,11 @@ export const fruitTrees: Vegetable[] = [
   },
   {
     id: 'damson-tree',
+    storage: {
+      methods: ['fresh', 'freeze', 'jam'],
+      freshDays: 5,
+      tip: 'Classic for jam, chutney and damson gin; or stone and freeze the glut.',
+    },
     name: 'Damson Tree',
     category: 'fruit-trees',
     description: 'Hardy plum relative. Self-fertile and excellent for Scottish gardens.',
@@ -218,6 +228,10 @@ export const fruitTrees: Vegetable[] = [
   },
   {
     id: 'pear-tree',
+    storage: {
+      methods: ['store-cool', 'fridge', 'freeze', 'jam'],
+      tip: 'Pick slightly under-ripe and store cool, ripening a few at a time indoors; poach and freeze or make chutney with windfalls.',
+    },
     name: 'Pear Tree',
     category: 'fruit-trees',
     description: 'Classic dessert fruit. Conference and Concorde are reliable self-fertile varieties.',
@@ -266,6 +280,11 @@ export const fruitTrees: Vegetable[] = [
   },
   {
     id: 'greengage-tree',
+    storage: {
+      methods: ['fresh', 'freeze', 'jam'],
+      freshDays: 4,
+      tip: 'Best eaten ripe off the tree; stone and freeze or make jam with any surplus.',
+    },
     name: 'Greengage Tree',
     category: 'fruit-trees',
     description: 'Sweet green plum variety. Cambridge Gage is hardiest for Scottish gardens.',

--- a/src/lib/vegetables/data/leafy-greens.ts
+++ b/src/lib/vegetables/data/leafy-greens.ts
@@ -44,6 +44,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'spinach',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze'],
+      freshDays: 3,
+      tip: 'Wilts fast — use within a few days or blanch and freeze; bolts quickly in dry spells, so pick young.',
+    },
     name: 'Spinach',
     category: 'leafy-greens',
     description: 'Nutritious leafy green. Thrives in cool Scottish climate.',
@@ -112,6 +117,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'kale',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze'],
+      freshDays: 5,
+      tip: 'Very hardy — pick leaves through autumn and winter; blanch and freeze a glut.',
+    },
     name: 'Kale',
     category: 'leafy-greens',
     description: 'Hardy winter green - a Scottish staple! Improves after frost.',
@@ -150,6 +160,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'chard',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze'],
+      freshDays: 4,
+      tip: 'Cut outer leaves regularly to keep it coming; blanch and freeze a glut like spinach.',
+    },
     name: 'Swiss Chard',
     category: 'leafy-greens',
     description: 'Colorful, productive leafy green with edible stems. Hardy in mild winters.',
@@ -683,6 +698,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'cavolo-nero',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze'],
+      freshDays: 5,
+      tip: 'Pick leaves from the bottom up as needed; freezes well blanched.',
+    },
     name: 'Cavolo Nero (Black Kale)',
     category: 'leafy-greens',
     description: 'Italian black kale. Extremely hardy and improves with frost - perfect for Scotland.',

--- a/src/lib/vegetables/data/legumes.ts
+++ b/src/lib/vegetables/data/legumes.ts
@@ -235,6 +235,11 @@ export const legumes: Vegetable[] = [
   },
   {
     id: 'borlotti-beans',
+    storage: {
+      methods: ['fresh', 'dry', 'store-cool'],
+      freshDays: 5,
+      tip: 'Eat young pods fresh, or leave them to dry on the plant, then shell and store the beans in jars.',
+    },
     name: 'Borlotti Beans',
     category: 'legumes',
     description: 'Italian beans for fresh or dried. Beautiful speckled pods.',
@@ -270,6 +275,11 @@ export const legumes: Vegetable[] = [
   },
   {
     id: 'edamame',
+    storage: {
+      methods: ['fresh', 'freeze'],
+      freshDays: 3,
+      tip: 'Best fresh — steam the pods straight away, or blanch and freeze them.',
+    },
     name: 'Edamame (Soy Beans)',
     category: 'legumes',
     description: 'Fresh green soy beans. Protein-rich and increasingly popular.',
@@ -305,6 +315,11 @@ export const legumes: Vegetable[] = [
   },
   {
     id: 'mangetout',
+    storage: {
+      methods: ['fresh', 'freeze'],
+      freshDays: 4,
+      tip: 'Pick young while the pods are flat; eat fresh or blanch and freeze a glut.',
+    },
     name: 'Mangetout (Snow Peas)',
     category: 'legumes',
     description: 'Flat edible-pod peas. Harvest young before peas develop.',
@@ -342,6 +357,11 @@ export const legumes: Vegetable[] = [
   },
   {
     id: 'sugar-snap-peas',
+    storage: {
+      methods: ['fresh', 'freeze'],
+      freshDays: 4,
+      tip: 'Pick before the pods swell; sweetest eaten fresh, but they blanch and freeze well.',
+    },
     name: 'Sugar Snap Peas',
     category: 'legumes',
     description: 'Sweet edible-pod peas. Eat pods and peas together.',
@@ -414,6 +434,10 @@ export const legumes: Vegetable[] = [
   },
   {
     id: 'black-turtle-beans',
+    storage: {
+      methods: ['dry', 'store-cool'],
+      tip: 'A drying bean — let the pods dry fully on the plant, then shell and keep the beans in airtight jars.',
+    },
     name: 'Black Turtle Beans',
     category: 'legumes',
     description: 'Drying bean for storage. Excellent for soups and Mexican dishes.',

--- a/src/lib/vegetables/data/other.ts
+++ b/src/lib/vegetables/data/other.ts
@@ -67,6 +67,10 @@ export const other: Vegetable[] = [
   },
   {
     id: 'jerusalem-artichoke',
+    storage: {
+      methods: ['store-cool', 'fresh'],
+      tip: 'Best left in the ground and dug as needed — the knobbly tubers don’t keep long once lifted.',
+    },
     name: 'Jerusalem Artichoke',
     category: 'other',
     description: 'Perennial tuber with nutty flavor. Extremely productive and hardy in Scotland.',
@@ -102,6 +106,11 @@ export const other: Vegetable[] = [
   },
   {
     id: 'sweetcorn',
+    storage: {
+      methods: ['fresh', 'freeze'],
+      freshDays: 2,
+      tip: 'Eat or freeze within hours of picking — the sugars turn to starch fast. Blanch whole cobs or strip the kernels to freeze.',
+    },
     name: 'Sweetcorn',
     category: 'other',
     description: 'Sweet summer treat. Choose early varieties like Swift F1 for Scottish climate.',

--- a/src/lib/vegetables/data/root-vegetables.ts
+++ b/src/lib/vegetables/data/root-vegetables.ts
@@ -92,6 +92,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'parsnip',
+    storage: {
+      methods: ['store-cool', 'fresh'],
+      tip: 'Leave in the ground — frost sweetens the roots — and lift through winter, or store in boxes of damp sand somewhere cool.',
+    },
     name: 'Parsnip',
     category: 'root-vegetables',
     description: 'Sweet winter root. Frost improves flavor - perfect for Scotland!',
@@ -432,6 +436,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'celeriac',
+    storage: {
+      methods: ['store-cool', 'fridge'],
+      tip: 'Trim the roots and tops, then store in boxes of damp sand somewhere cool, or keep in the fridge for a few weeks.',
+    },
     name: 'Celeriac',
     category: 'root-vegetables',
     description: 'Celery-flavored root vegetable. Easier than celery to grow.',

--- a/src/lib/vegetables/data/solanaceae.ts
+++ b/src/lib/vegetables/data/solanaceae.ts
@@ -261,6 +261,11 @@ export const solanaceae: Vegetable[] = [
   },
   {
     id: 'blight-resistant-tomato',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze', 'dry'],
+      freshDays: 7,
+      tip: 'Glut crop — roast and freeze, semi-dry in a low oven, or cook down into sauce and passata.',
+    },
     name: 'Blight-Resistant Tomato',
     category: 'solanaceae',
     description: 'Bred for resistance to late blight. Essential for wet Scottish summers.',


### PR DESCRIPTION
## Summary

Follow-up to PR #425 (Feeding B2 + Milestone C). This pass does the storage-data QA that was flagged as the lowest-confidence part of the shipped work, and verifies the C2 / C3 surfaces in-app.

### 1. Data QA
- **Reviewed all 26 pre-existing `storage` entries** against good Scottish-allotment practice — all sound, no corrections needed.
- **Added storage to 33 staple crops** the first pass missed (high-glut crops + major keepers + direct siblings of already-covered crops):
  - **alliums:** leek, shallot
  - **brassicas:** swede (neeps), turnip, cauliflower, calabrese, purple-sprouting broccoli, Brussels sprouts, savoy cabbage
  - **roots:** parsnip, celeriac
  - **other:** sweetcorn, Jerusalem artichoke
  - **berries:** gooseberry, redcurrant, blueberry
  - **fruit trees:** pear, cherry, damson, greengage
  - **cucurbits:** patty-pan, spaghetti, acorn squash (completes the category)
  - **solanaceae:** blight-resistant tomato
  - **leafy:** kale, cavolo nero, chard, spinach
  - **legumes:** borlotti, black turtle, edamame, mangetout, sugar snap
- **Design intent preserved:** pure keepers use `cure`/`store-cool`/`fridge`/`fresh` only (storage info, **no** C3 nudge); glut crops include a preserving method (`freeze`/`jam`/`pickle`/`ferment`/`dry`) so the "Glut of X?" nudge fires in their harvest window.
- **Fixed courgette:** added `jam` so its method badges match its existing "make chutney" tip.
- **Coverage now 59 / ~191 crops.** The remaining ~132 (herbs, remaining leafy/roots/berries/fruit, asparagus/celery/globe artichoke, plus ornamentals/green-manures/mushrooms that mostly don't need it) are captured as a backlog item in `current-plan.md`.

### 2. Visual verify (C2)
Detail panel renders cleanly for crops **with** data and is hidden when **absent**:
- `/plants/gooseberry` (new glut crop) → badges `Best fresh · Freeze · Jam / chutney`, "Keeps roughly 7 days fresh", tip.
- `/plants/swede` (new keeper) → `Store cool · Best fresh`, no freshDays line.
- `/plants/lettuce` (no data) → no "Storage & Preserving" section.

### 3. Verify (C3)
Seeded a plot and confirmed on the Today dashboard (current month June):
- **Peas** (harvest window covers June) → "Glut of Peas?" nudge shows with its storage tip. ✅
- **Courgette** (harvest window Aug–Sep) → **no** glut nudge in June. ✅

Verified with a headless Playwright run (production build); screenshots captured locally and shared with the requester.

### Checks
`type-check` ✅ · `lint` ✅ · `test:unit` (1099 passed) ✅ · `build` ✅

### Notes
- Strengthened `plant-data-integrity.test.ts` to assert key new staples carry storage data.
- The temporary `docs/plans/feeding-and-preserving-plan.md` was already removed as part of PR #425, so no separate cleanup commit was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTooJL5xg9cFiaHYUEhVak

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTooJL5xg9cFiaHYUEhVak)_