### PR TITLE
Storage tips: complete the edible long tail (90 crops, 149/191 coverage)

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -399,26 +399,33 @@ in-app (Playwright screenshots: detail panel renders for crops with data and is
 hidden without; the glut nudge shows for an in-window preservable crop and not
 for an out-of-window one). Coverage now **59 / ~191 crops**.
 
-**Backlog — complete storage tips for all plants in the database.** ~132 crops
-still lack `storage` data. Priority edible long tail: all **herbs** (20 — dry /
-freeze guidance), remaining **leafy greens** (lettuce, rocket, mizuna, pak choi,
-perpetual spinach, …), remaining **roots** (salsify, scorzonera, mooli, black
-radish, horseradish, Florence fennel, Hamburg parsley, yacon, oca, skirret,
-ulluco, Chinese artichoke), remaining **berries** (tayberry, loganberry,
-jostaberry, honeyberry, aronia, elderberry, sea buckthorn, goji), remaining
-**fruit trees** (medlar, quince, fig, mulberry), remaining **alliums**
-(spring onion, Welsh onion, elephant garlic, walking onion, potato onion,
-garlic chives, ramps), remaining **brassicas** (radish, kohlrabi, romanesco,
-Chinese broccoli, turnip tops, mibuna, sea kale), remaining **legumes**
-(asparagus peas, fenugreek, ground nut), remaining **solanaceae** (first/second
-early potato — "eat fresh", tomatillo), and remaining **other** (asparagus,
-globe artichoke, celery, cardoon, mashua). Ornamentals (annual & perennial
-flowers, bulbs, climbers), green manures, and mushrooms mostly don't need
-storage tips — though edible flowers (calendula, nasturtium) and culinary herbs
-are worthwhile exceptions. Rule of thumb when authoring: only crops with a
-genuine preserving option (freeze/jam/pickle/ferment/dry) should carry one (and
-thus trigger the C3 nudge); pure keepers get cure/store-cool/fridge/fresh only,
-so they show storage info without nagging to "preserve the glut".
+### Storage tips — edible long tail complete (branch `claude/storage-remaining-crops`)
+
+The edible long tail called out in the previous backlog is now authored — **90
+crops added** in one pass, bringing coverage to **149 / 191 crops**. Filled
+completely: all **herbs** (20 — soft herbs freeze-first, woody herbs dry-first,
+bay/chamomile dry, sorrel/borage fresh), all remaining **leafy greens** (17 —
+salad leaves fridge/fresh, cooking greens freeze, mustard/pak-choi ferment),
+all remaining **roots** (12 — in-ground/damp-sand keepers, mooli/horseradish
+ferment-or-pickle, oca/yacon cure notes), all remaining **berries** (8 —
+freeze/jam soft-fruit, goji/aronia/elderberry dry, elderberry "cook first"),
+all remaining **brassicas** (7), **fruit trees** (4 — medlar bletting, quince
+membrillo), **alliums** (7 — cure-and-store keepers vs fresh-leaf), **legumes**
+(3), **solanaceae** (3 — new tatties "eat fresh", tomatillo husks-on), and
+**other** (5 — asparagus/globe-artichoke/celery/cardoon/mashua). Plus the named
+ornamental exceptions: edible flowers calendula + nasturtium (annual) and
+culinary lavender + bergamot (perennial). Authored to the rule of thumb — only
+genuine preserving crops carry a preserve method (so keepers like maincrop-style
+potatoes, salsify, scorzonera, fennel bulb, crosnes, oca, ulluco show storage
+info without triggering the C3 glut nudge). All 1099 unit tests pass.
+
+**Remaining (deliberately out of scope):** ~42 crops — non-edible ornamental
+flowers (annual & perennial), bulbs, climbers, green manures, and mushrooms.
+Per the prior guidance these mostly don't warrant storage tips. A few genuine
+edibles in those families are the only candidates worth a future pass if desired
+— sunflower (seeds, dry), hardy-kiwi and hops (climbers), and the gourmet
+mushrooms (shiitake/oyster dry well) — left untouched to respect the stated
+category boundary rather than expand scope unannounced.
 
 ### Up Next: Phase 1 soak then Step 5 cleanup
 

--- a/src/lib/vegetables/data/alliums.ts
+++ b/src/lib/vegetables/data/alliums.ts
@@ -139,6 +139,11 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'spring-onion',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 10,
+      tip: 'Keep in the fridge; chop and freeze any glut for cooking.',
+    },
     name: 'Spring Onions',
     category: 'alliums',
     description: 'Quick-growing salad onion. Sow successionally.',
@@ -219,6 +224,11 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'welsh-onion',
+    storage: {
+      methods: ['fresh', 'freeze'],
+      freshDays: 7,
+      tip: 'Cut-and-come-again, so use fresh from the plot; freeze chopped surplus.',
+    },
     name: 'Welsh Onion',
     category: 'alliums',
     description: 'Perennial bunching onion. Harvest year-round in Scotland.',
@@ -255,6 +265,10 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'elephant-garlic',
+    storage: {
+      methods: ['cure', 'store-cool'],
+      tip: 'Cure the bulbs after lifting, then keep somewhere cool, dry and airy.',
+    },
     name: 'Elephant Garlic',
     category: 'alliums',
     description: 'Giant mild garlic. Actually closer to leek than true garlic.',
@@ -288,6 +302,11 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'walking-onion',
+    storage: {
+      methods: ['cure', 'store-cool', 'fridge'],
+      freshDays: 10,
+      tip: 'Cure the topset bulbils for storing; use the green tops fresh.',
+    },
     name: 'Walking Onion (Tree Onion)',
     category: 'alliums',
     description: 'Perennial onion with top-setting bulbils. Quirky and productive.',
@@ -324,6 +343,10 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'potato-onion',
+    storage: {
+      methods: ['cure', 'store-cool'],
+      tip: 'An excellent keeper: cure well and store cool and dry like shallots.',
+    },
     name: 'Potato Onion',
     category: 'alliums',
     description: 'Multiplier onion forming clusters. Heritage variety very hardy.',
@@ -360,6 +383,11 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'garlic-chives',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 7,
+      tip: 'Use fresh from the fridge; freeze chopped leaves and the edible flowers.',
+    },
     name: 'Garlic Chives',
     category: 'alliums',
     description: 'Flat-leaved chives with garlic flavor. Perennial herb.',
@@ -395,6 +423,11 @@ export const alliums: Vegetable[] = [
   },
   {
     id: 'ramps',
+    storage: {
+      methods: ['fresh', 'freeze', 'pickle'],
+      freshDays: 4,
+      tip: 'Leaves wilt fast, so use fresh; freeze as pesto or pickle the bulbs.',
+    },
     name: 'Ramps (Wild Leeks)',
     category: 'alliums',
     description: 'Woodland perennial leek. Spring ephemeral with garlicky flavor.',

--- a/src/lib/vegetables/data/annual-flowers.ts
+++ b/src/lib/vegetables/data/annual-flowers.ts
@@ -139,6 +139,10 @@ export const annualFlowers: Vegetable[] = [
   },
   {
     id: 'calendula',
+    storage: {
+      methods: ['dry'],
+      tip: 'Pick petals on a dry day and dry them for tea, colour, or sprinkling over salads.',
+    },
     name: 'Calendula',
     category: 'annual-flowers',
     description: 'Pot marigold with edible flowers. Attracts beneficial insects and has medicinal properties.',
@@ -172,6 +176,11 @@ export const annualFlowers: Vegetable[] = [
   },
   {
     id: 'nasturtium',
+    storage: {
+      methods: ['fresh', 'pickle'],
+      freshDays: 3,
+      tip: 'Use leaves and flowers fresh; pickle the green seed pods as a caper substitute.',
+    },
     name: 'Nasturtium',
     category: 'annual-flowers',
     description: 'Fast-growing annual with edible flowers and leaves. Attracts aphids away from crops.',

--- a/src/lib/vegetables/data/berries.ts
+++ b/src/lib/vegetables/data/berries.ts
@@ -369,7 +369,7 @@ export const berries: Vegetable[] = [
   {
     id: 'tayberry',
     storage: {
-      methods: ['freeze', 'jam', 'fresh'],
+      methods: ['fresh', 'freeze', 'jam'],
       freshDays: 3,
       tip: 'Soft cane fruit that bruises fast; freeze on trays then bag, or boil into jam.',
     },
@@ -419,7 +419,7 @@ export const berries: Vegetable[] = [
   {
     id: 'loganberry',
     storage: {
-      methods: ['freeze', 'jam', 'fresh'],
+      methods: ['fresh', 'freeze', 'jam'],
       freshDays: 3,
       tip: 'Eat within days of picking; open-freeze the berries or make a sharp jam.',
     },
@@ -469,7 +469,7 @@ export const berries: Vegetable[] = [
   {
     id: 'jostaberry',
     storage: {
-      methods: ['freeze', 'jam'],
+      methods: ['fresh', 'freeze', 'jam'],
       freshDays: 5,
       tip: 'Gooseberry-blackcurrant cross; freezes well and cooks down into a fine jam.',
     },

--- a/src/lib/vegetables/data/berries.ts
+++ b/src/lib/vegetables/data/berries.ts
@@ -368,6 +368,11 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'tayberry',
+    storage: {
+      methods: ['freeze', 'jam', 'fresh'],
+      freshDays: 3,
+      tip: 'Soft cane fruit that bruises fast; freeze on trays then bag, or boil into jam.',
+    },
     name: 'Tayberry',
     category: 'berries',
     description: 'Raspberry-blackberry hybrid from Scotland. Large aromatic berries.',
@@ -413,6 +418,11 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'loganberry',
+    storage: {
+      methods: ['freeze', 'jam', 'fresh'],
+      freshDays: 3,
+      tip: 'Eat within days of picking; open-freeze the berries or make a sharp jam.',
+    },
     name: 'Loganberry',
     category: 'berries',
     description: 'Another raspberry-blackberry hybrid. Tart flavor good for cooking.',
@@ -458,6 +468,11 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'jostaberry',
+    storage: {
+      methods: ['freeze', 'jam'],
+      freshDays: 5,
+      tip: 'Gooseberry-blackcurrant cross; freezes well and cooks down into a fine jam.',
+    },
     name: 'Jostaberry',
     category: 'berries',
     description: 'Blackcurrant-gooseberry hybrid. Thornless and productive.',
@@ -502,6 +517,11 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'honeyberry',
+    storage: {
+      methods: ['fresh', 'freeze', 'jam'],
+      freshDays: 4,
+      tip: 'Early haskap berries are lovely fresh; freeze a glut or simmer into jam.',
+    },
     name: 'Honeyberry (Haskap)',
     category: 'berries',
     description: 'Blue honeysuckle berry. Extremely cold-hardy superfruit.',
@@ -544,6 +564,10 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'goji-berry',
+    storage: {
+      methods: ['dry', 'freeze', 'fresh'],
+      tip: 'Traditionally dried for storage; freeze the surplus or eat a few fresh.',
+    },
     name: 'Goji Berry',
     category: 'berries',
     description: 'Superfood shrub from Asia. Hardy and productive in Scotland.',
@@ -586,6 +610,10 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'aronia',
+    storage: {
+      methods: ['freeze', 'jam', 'dry'],
+      tip: 'Too astringent raw; freeze, cook into juice or jam, or dry the chokeberries.',
+    },
     name: 'Aronia (Chokeberry)',
     category: 'berries',
     description: 'Antioxidant-rich native American berry. Very hardy shrub.',
@@ -628,6 +656,10 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'elderberry',
+    storage: {
+      methods: ['jam', 'freeze', 'dry'],
+      tip: 'Always cook before eating; make cordial or jam, or freeze and dry the berries.',
+    },
     name: 'Elderberry',
     category: 'berries',
     description: 'Native British shrub. Flowers and berries both useful.',
@@ -670,6 +702,10 @@ export const berries: Vegetable[] = [
   },
   {
     id: 'sea-buckthorn',
+    storage: {
+      methods: ['freeze', 'jam'],
+      tip: 'Pick the sharp berries easier once frozen on the branch; freeze for juice or jam.',
+    },
     name: 'Sea Buckthorn',
     category: 'berries',
     description: 'Coastal native with vitamin C-rich berries. Fixes nitrogen.',

--- a/src/lib/vegetables/data/brassicas.ts
+++ b/src/lib/vegetables/data/brassicas.ts
@@ -90,6 +90,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'radish',
+    storage: {
+      methods: ['fridge', 'pickle', 'fresh'],
+      freshDays: 10,
+      tip: 'Best eaten fresh from the plot; quick-pickle a glut of summer radish.',
+    },
     name: 'Radish',
     category: 'brassicas',
     description: 'Quick-growing root crop. Ready in weeks - ideal for Scottish summer.',
@@ -366,6 +371,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'kohlrabi',
+    storage: {
+      methods: ['fridge', 'store-cool', 'freeze'],
+      freshDays: 21,
+      tip: 'Keeps well in the fridge or a cool shed; dice and freeze a surplus.',
+    },
     name: 'Kohlrabi',
     category: 'brassicas',
     description: 'Fast-growing unusual brassica. Very cold-hardy, perfect for Scotland.',
@@ -495,6 +505,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'chinese-broccoli',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 5,
+      tip: 'Best used fresh; blanch florets before freezing any extra.',
+    },
     name: 'Chinese Broccoli (Kai Lan)',
     category: 'brassicas',
     description: 'Fast-growing Asian green. Harvest young shoots and leaves.',
@@ -531,6 +546,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'romanesco',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 7,
+      tip: 'Treat like cauliflower; blanch florets to freeze a glut.',
+    },
     name: 'Romanesco',
     category: 'brassicas',
     description: 'Fractal cauliflower with lime-green spirals. Stunning and delicious.',
@@ -567,6 +587,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'turnip-tops',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 4,
+      tip: 'Cook the greens soon after picking; blanch and freeze extras.',
+    },
     name: 'Turnip Tops (Rapini)',
     category: 'brassicas',
     description: 'Grown for leafy greens rather than roots. Italian favorite, fast-growing.',
@@ -603,6 +628,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'mibuna',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 5,
+      tip: 'Pick young leaves for the salad bowl; does not freeze well.',
+    },
     name: 'Mibuna',
     category: 'brassicas',
     description: 'Japanese mustard green with serrated leaves. Very cold-hardy for Scotland.',
@@ -637,6 +667,11 @@ export const brassicas: Vegetable[] = [
   },
   {
     id: 'seakale',
+    storage: {
+      methods: ['fresh', 'fridge'],
+      freshDays: 3,
+      tip: 'Eat the blanched spring shoots straight away; they wilt fast.',
+    },
     name: 'Sea Kale',
     category: 'brassicas',
     description: 'Coastal native perennial vegetable. Blanched shoots eaten in spring.',

--- a/src/lib/vegetables/data/fruit-trees.ts
+++ b/src/lib/vegetables/data/fruit-trees.ts
@@ -331,6 +331,10 @@ export const fruitTrees: Vegetable[] = [
   },
   {
     id: 'medlar-tree',
+    storage: {
+      methods: ['store-cool', 'jam'],
+      tip: 'Pick after first frosts and blet (store cool until soft and brown) before eating, or boil down into medlar jelly.',
+    },
     name: 'Medlar Tree',
     category: 'fruit-trees',
     description: 'Unusual historic fruit tree. Extremely hardy and self-fertile - perfect for Scottish climate.',
@@ -377,6 +381,10 @@ export const fruitTrees: Vegetable[] = [
   },
   {
     id: 'quince-tree',
+    storage: {
+      methods: ['store-cool', 'jam'],
+      tip: 'Keeps cool and aromatic for weeks; never eaten raw, so cook into membrillo, jelly or jam.',
+    },
     name: 'Quince Tree',
     category: 'fruit-trees',
     description: 'Historic cooking fruit. Hardy and self-fertile with beautiful blossom.',
@@ -423,6 +431,11 @@ export const fruitTrees: Vegetable[] = [
   },
   {
     id: 'fig-tree',
+    storage: {
+      methods: ['fresh', 'dry', 'jam'],
+      freshDays: 3,
+      tip: 'Eat ripe figs fresh within a couple of days; a glut dries well or makes a fine jam.',
+    },
     name: 'Fig Tree',
     category: 'fruit-trees',
     description: 'Mediterranean fruit increasingly viable in UK. Brown Turkey is hardiest variety.',
@@ -468,6 +481,11 @@ export const fruitTrees: Vegetable[] = [
   },
   {
     id: 'mulberry-tree',
+    storage: {
+      methods: ['fresh', 'freeze', 'jam'],
+      freshDays: 2,
+      tip: 'Very soft, so eat within a day or freeze on trays; the rest makes a lovely deep jam.',
+    },
     name: 'Mulberry Tree',
     category: 'fruit-trees',
     description: 'Hardy long-lived fruit tree. Black mulberry is sweetest and most productive.',

--- a/src/lib/vegetables/data/herbs.ts
+++ b/src/lib/vegetables/data/herbs.ts
@@ -8,6 +8,11 @@ import { Vegetable } from '@/types/garden-planner'
 export const herbs: Vegetable[] = [
   {
     id: 'parsley',
+    storage: {
+      methods: ['freeze', 'dry'],
+      freshDays: 7,
+      tip: 'Freeze chopped in ice-cube trays with a little water or oil; flavour beats dried.',
+    },
     name: 'Parsley',
     category: 'herbs',
     description: 'Versatile hardy herb. Survives Scottish winters.',
@@ -43,6 +48,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'coriander',
+    storage: {
+      methods: ['freeze', 'dry'],
+      freshDays: 5,
+      tip: 'Freeze leaves in oil cubes; let some plants set seed for dried coriander.',
+    },
     name: 'Coriander (Cilantro)',
     category: 'herbs',
     description: 'Fast-growing herb. Less prone to bolting in Scottish climate!',
@@ -78,6 +88,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'mint',
+    storage: {
+      methods: ['freeze', 'dry'],
+      freshDays: 7,
+      tip: 'Freeze chopped in ice-cube trays; dries reasonably for winter teas.',
+    },
     name: 'Mint',
     category: 'herbs',
     description: 'Vigorous perennial herb. Very hardy - thrives in Scotland!',
@@ -115,6 +130,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'chives',
+    storage: {
+      methods: ['freeze'],
+      freshDays: 7,
+      tip: 'Snip and freeze in bags or oil cubes; chives lose flavour when dried.',
+    },
     name: 'Chives',
     category: 'herbs',
     description: 'Hardy perennial. One of the easiest herbs for Scotland.',
@@ -148,6 +168,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'rosemary',
+    storage: {
+      methods: ['dry', 'freeze'],
+      freshDays: 14,
+      tip: 'Hang sprigs to dry in an airy spot; keeps potency for months.',
+    },
     name: 'Rosemary',
     category: 'herbs',
     description: 'Woody perennial herb. Needs sheltered spot in Scotland.',
@@ -184,6 +209,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'thyme',
+    storage: {
+      methods: ['dry', 'freeze'],
+      freshDays: 14,
+      tip: 'Hang bundles to dry, then strip leaves from stems into a jar.',
+    },
     name: 'Thyme',
     category: 'herbs',
     description: 'Low-growing perennial herb. Hardy in Scotland.',
@@ -217,6 +247,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'lovage',
+    storage: {
+      methods: ['freeze', 'dry'],
+      freshDays: 7,
+      tip: 'Freeze chopped leaves for soups and stocks; dries fairly well too.',
+    },
     name: 'Lovage',
     category: 'herbs',
     description: 'Tall perennial herb with celery flavor. Thrives in Scottish conditions.',
@@ -246,6 +281,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'sorrel',
+    storage: {
+      methods: ['fresh', 'freeze'],
+      freshDays: 5,
+      tip: 'Best used fresh in salads; cook down and freeze as a puree for sauces.',
+    },
     name: 'Sorrel',
     category: 'herbs',
     description: 'Tangy perennial leaf. Extremely hardy in Scottish gardens.',
@@ -278,6 +318,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'oregano',
+    storage: {
+      methods: ['dry', 'freeze'],
+      freshDays: 10,
+      tip: 'Flavour intensifies when dried; hang sprigs in an airy spot.',
+    },
     name: 'Oregano',
     category: 'herbs',
     description: 'Mediterranean herb. Very hardy perennial for Scottish gardens.',
@@ -312,6 +357,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'sage',
+    storage: {
+      methods: ['dry', 'freeze'],
+      freshDays: 14,
+      tip: 'Dries excellently; hang leaves or freeze in oil for winter roasts.',
+    },
     name: 'Sage',
     category: 'herbs',
     description: 'Evergreen perennial herb. Very hardy and drought-tolerant.',
@@ -348,6 +398,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'french-tarragon',
+    storage: {
+      methods: ['freeze', 'dry'],
+      freshDays: 7,
+      tip: 'Freeze sprigs or steep in vinegar; loses much flavour if dried.',
+    },
     name: 'French Tarragon',
     category: 'herbs',
     description: 'Classic French herb. Must propagate from cuttings, not seed.',
@@ -378,6 +433,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'dill',
+    storage: {
+      methods: ['freeze', 'dry'],
+      freshDays: 5,
+      tip: 'Freeze leaves for best flavour; let plants set seed to dry for pickling.',
+    },
     name: 'Dill',
     category: 'herbs',
     description: 'Annual herb with feathery leaves. Self-seeds readily.',
@@ -415,6 +475,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'herb-fennel',
+    storage: {
+      methods: ['freeze', 'dry'],
+      freshDays: 5,
+      tip: 'Freeze the feathery leaves; dry the ripe seeds for cooking.',
+    },
     name: 'Herb Fennel',
     category: 'herbs',
     description: 'Feathery perennial herb. Different from Florence fennel bulb.',
@@ -448,6 +513,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'lemon-balm',
+    storage: {
+      methods: ['freeze', 'dry'],
+      freshDays: 5,
+      tip: 'Freeze in oil cubes; dries adequately for teas though scent fades.',
+    },
     name: 'Lemon Balm',
     category: 'herbs',
     description: 'Lemon-scented perennial herb. Very vigorous and hardy.',
@@ -478,6 +548,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'marjoram',
+    storage: {
+      methods: ['dry', 'freeze'],
+      freshDays: 10,
+      tip: 'Hang sprigs to dry; holds its sweet flavour well in a jar.',
+    },
     name: 'Marjoram',
     category: 'herbs',
     description: 'Sweet oregano relative. Tender perennial often grown as annual.',
@@ -508,6 +583,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'bay',
+    storage: {
+      methods: ['dry'],
+      freshDays: 14,
+      tip: 'Dry whole leaves flat; they keep their flavour for a year or more.',
+    },
     name: 'Bay',
     category: 'herbs',
     description: 'Evergreen shrub with aromatic leaves. Slow-growing but very long-lived.',
@@ -541,6 +621,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'borage',
+    storage: {
+      methods: ['fresh'],
+      freshDays: 2,
+      tip: 'Use flowers and leaves fresh; they wilt fast, so pick just before use.',
+    },
     name: 'Borage',
     category: 'herbs',
     description: 'Annual herb with blue edible flowers. Excellent bee plant.',
@@ -573,6 +658,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'chamomile',
+    storage: {
+      methods: ['dry'],
+      freshDays: 3,
+      tip: 'Dry the open flowers on a tray, then store airtight for teas.',
+    },
     name: 'Chamomile',
     category: 'herbs',
     description: 'Low-growing perennial herb. Used for tea and as lawn alternative.',
@@ -606,6 +696,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'winter-savory',
+    storage: {
+      methods: ['dry', 'freeze'],
+      freshDays: 14,
+      tip: 'Hang sprigs to dry; peppery flavour holds well for winter bean dishes.',
+    },
     name: 'Winter Savory',
     category: 'herbs',
     description: 'Hardy perennial herb. Peppery flavor good with beans.',
@@ -639,6 +734,11 @@ export const herbs: Vegetable[] = [
   },
   {
     id: 'hyssop',
+    storage: {
+      methods: ['dry', 'freeze'],
+      freshDays: 14,
+      tip: 'Hang sprigs to dry for teas; keeps its minty-bitter flavour in a jar.',
+    },
     name: 'Hyssop',
     category: 'herbs',
     description: 'Hardy perennial herb with blue flowers. Excellent bee plant.',

--- a/src/lib/vegetables/data/herbs.ts
+++ b/src/lib/vegetables/data/herbs.ts
@@ -9,7 +9,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'parsley',
     storage: {
-      methods: ['freeze', 'dry'],
+      methods: ['fridge', 'freeze', 'dry'],
       freshDays: 7,
       tip: 'Freeze chopped in ice-cube trays with a little water or oil; flavour beats dried.',
     },
@@ -49,7 +49,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'coriander',
     storage: {
-      methods: ['freeze', 'dry'],
+      methods: ['fridge', 'freeze', 'dry'],
       freshDays: 5,
       tip: 'Freeze leaves in oil cubes; let some plants set seed for dried coriander.',
     },
@@ -89,7 +89,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'mint',
     storage: {
-      methods: ['freeze', 'dry'],
+      methods: ['fridge', 'freeze', 'dry'],
       freshDays: 7,
       tip: 'Freeze chopped in ice-cube trays; dries reasonably for winter teas.',
     },
@@ -131,7 +131,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'chives',
     storage: {
-      methods: ['freeze'],
+      methods: ['fridge', 'freeze'],
       freshDays: 7,
       tip: 'Snip and freeze in bags or oil cubes; chives lose flavour when dried.',
     },
@@ -169,7 +169,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'rosemary',
     storage: {
-      methods: ['dry', 'freeze'],
+      methods: ['fridge', 'dry', 'freeze'],
       freshDays: 14,
       tip: 'Hang sprigs to dry in an airy spot; keeps potency for months.',
     },
@@ -210,7 +210,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'thyme',
     storage: {
-      methods: ['dry', 'freeze'],
+      methods: ['fridge', 'dry', 'freeze'],
       freshDays: 14,
       tip: 'Hang bundles to dry, then strip leaves from stems into a jar.',
     },
@@ -248,7 +248,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'lovage',
     storage: {
-      methods: ['freeze', 'dry'],
+      methods: ['fridge', 'freeze', 'dry'],
       freshDays: 7,
       tip: 'Freeze chopped leaves for soups and stocks; dries fairly well too.',
     },
@@ -319,7 +319,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'oregano',
     storage: {
-      methods: ['dry', 'freeze'],
+      methods: ['fridge', 'dry', 'freeze'],
       freshDays: 10,
       tip: 'Flavour intensifies when dried; hang sprigs in an airy spot.',
     },
@@ -358,7 +358,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'sage',
     storage: {
-      methods: ['dry', 'freeze'],
+      methods: ['fridge', 'dry', 'freeze'],
       freshDays: 14,
       tip: 'Dries excellently; hang leaves or freeze in oil for winter roasts.',
     },
@@ -399,7 +399,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'french-tarragon',
     storage: {
-      methods: ['freeze', 'dry'],
+      methods: ['fridge', 'freeze'],
       freshDays: 7,
       tip: 'Freeze sprigs or steep in vinegar; loses much flavour if dried.',
     },
@@ -434,9 +434,9 @@ export const herbs: Vegetable[] = [
   {
     id: 'dill',
     storage: {
-      methods: ['freeze', 'dry'],
+      methods: ['fridge', 'freeze', 'dry'],
       freshDays: 5,
-      tip: 'Freeze leaves for best flavour; let plants set seed to dry for pickling.',
+      tip: 'Freeze the feathery leaves for best flavour; dry the ripe seed heads for the spice rack.',
     },
     name: 'Dill',
     category: 'herbs',
@@ -476,7 +476,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'herb-fennel',
     storage: {
-      methods: ['freeze', 'dry'],
+      methods: ['fridge', 'freeze', 'dry'],
       freshDays: 5,
       tip: 'Freeze the feathery leaves; dry the ripe seeds for cooking.',
     },
@@ -514,7 +514,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'lemon-balm',
     storage: {
-      methods: ['freeze', 'dry'],
+      methods: ['fridge', 'freeze', 'dry'],
       freshDays: 5,
       tip: 'Freeze in oil cubes; dries adequately for teas though scent fades.',
     },
@@ -549,7 +549,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'marjoram',
     storage: {
-      methods: ['dry', 'freeze'],
+      methods: ['fridge', 'dry', 'freeze'],
       freshDays: 10,
       tip: 'Hang sprigs to dry; holds its sweet flavour well in a jar.',
     },
@@ -584,7 +584,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'bay',
     storage: {
-      methods: ['dry'],
+      methods: ['fridge', 'dry'],
       freshDays: 14,
       tip: 'Dry whole leaves flat; they keep their flavour for a year or more.',
     },
@@ -660,7 +660,6 @@ export const herbs: Vegetable[] = [
     id: 'chamomile',
     storage: {
       methods: ['dry'],
-      freshDays: 3,
       tip: 'Dry the open flowers on a tray, then store airtight for teas.',
     },
     name: 'Chamomile',
@@ -697,7 +696,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'winter-savory',
     storage: {
-      methods: ['dry', 'freeze'],
+      methods: ['fridge', 'dry', 'freeze'],
       freshDays: 14,
       tip: 'Hang sprigs to dry; peppery flavour holds well for winter bean dishes.',
     },
@@ -735,7 +734,7 @@ export const herbs: Vegetable[] = [
   {
     id: 'hyssop',
     storage: {
-      methods: ['dry', 'freeze'],
+      methods: ['fridge', 'dry', 'freeze'],
       freshDays: 14,
       tip: 'Hang sprigs to dry for teas; keeps its minty-bitter flavour in a jar.',
     },

--- a/src/lib/vegetables/data/leafy-greens.ts
+++ b/src/lib/vegetables/data/leafy-greens.ts
@@ -8,6 +8,11 @@ import { Vegetable } from '@/types/garden-planner'
 export const leafyGreens: Vegetable[] = [
   {
     id: 'lettuce',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 5,
+      tip: 'Pick leaves cool in the morning; keep in a sealed bag in the salad drawer.',
+    },
     name: 'Lettuce',
     category: 'leafy-greens',
     description: 'Fast-growing salad crop. Start indoors in Scotland for earlier harvest.',
@@ -84,6 +89,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'perpetual-spinach',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 6,
+      tip: 'Use fresh within days; blanch and freeze any glut from a heavy cut.',
+    },
     name: 'Perpetual Spinach',
     category: 'leafy-greens',
     description: 'Hardy leaf beet that survives Scottish winters. Cut-and-come-again.',
@@ -200,6 +210,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'rocket',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 4,
+      tip: 'Best eaten fresh; store dry in a sealed bag and use within a few days.',
+    },
     name: 'Rocket (Arugula)',
     category: 'leafy-greens',
     description: 'Peppery salad leaf that grows quickly. Less likely to bolt in Scotland.',
@@ -235,6 +250,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'mizuna',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 5,
+      tip: 'Crisp peppery leaf; keep in the salad drawer and pick young for best flavour.',
+    },
     name: 'Mizuna',
     category: 'leafy-greens',
     description: 'Japanese mustard green with frilly leaves. Very cold-hardy, ideal for Scotland.',
@@ -270,6 +290,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'land-cress',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 4,
+      tip: 'Peppery wee leaf best eaten fresh; keep cool and use within days.',
+    },
     name: 'Land Cress',
     category: 'leafy-greens',
     description: 'Peppery like watercress but grows in soil. Very hardy.',
@@ -302,6 +327,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'corn-salad',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 5,
+      tip: 'A hardy winter salad; pick rosettes fresh and keep cool in a sealed bag.',
+    },
     name: 'Corn Salad (Lamb\'s Lettuce)',
     category: 'leafy-greens',
     description: 'Hardy winter salad green. Perfect for Scottish winters, survives frost.',
@@ -334,6 +364,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'winter-purslane',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 5,
+      tip: 'Succulent winter leaf; eat fresh and keep cool in the salad drawer.',
+    },
     name: 'Winter Purslane (Claytonia)',
     category: 'leafy-greens',
     description: 'Succulent winter salad. Thrives in cold wet Scottish conditions.',
@@ -365,6 +400,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'mustard-greens',
+    storage: {
+      methods: ['fridge', 'freeze', 'ferment'],
+      freshDays: 6,
+      tip: 'Eat young leaves fresh; blanch and freeze a glut, or ferment kimchi-style.',
+    },
     name: 'Mustard Greens',
     category: 'leafy-greens',
     description: 'Fast-growing spicy greens. Very cold-tolerant for Scottish winters.',
@@ -399,6 +439,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'watercress',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 3,
+      tip: 'Best fresh; stand stems in water or wrap damp in the fridge and use quickly.',
+    },
     name: 'Watercress',
     category: 'leafy-greens',
     description: 'Aquatic or marginal plant with peppery leaves. Thrives in Scottish dampness.',
@@ -431,6 +476,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'salad-burnet',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 4,
+      tip: 'Cucumber-flavoured leaf best fresh; pick young sprigs and keep cool.',
+    },
     name: 'Salad Burnet',
     category: 'leafy-greens',
     description: 'Perennial herb with cucumber-flavored leaves. Very hardy for Scottish winters.',
@@ -464,6 +514,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'orache',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 5,
+      tip: 'Cook like spinach; use fresh or blanch and freeze a heavy cut.',
+    },
     name: 'Orache (Mountain Spinach)',
     category: 'leafy-greens',
     description: 'Colorful spinach substitute. Salt-tolerant and good for Scottish coastal gardens.',
@@ -497,6 +552,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'new-zealand-spinach',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 6,
+      tip: 'Pick tips often; cook like spinach or blanch and freeze a summer glut.',
+    },
     name: 'New Zealand Spinach',
     category: 'leafy-greens',
     description: 'Heat-tolerant spinach substitute. Sprawling plant good for Scottish summers.',
@@ -530,6 +590,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'good-king-henry',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 6,
+      tip: 'Cook the spinach-like leaves fresh, or blanch and freeze a spring glut.',
+    },
     name: 'Good King Henry',
     category: 'leafy-greens',
     description: 'Perennial vegetable with spinach-like leaves. Very hardy traditional Scottish plant.',
@@ -563,6 +628,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'radicchio',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 7,
+      tip: 'Firm heads keep a week in the fridge; trim the base and use the crisp leaves.',
+    },
     name: 'Radicchio',
     category: 'leafy-greens',
     description: 'Italian chicory with burgundy leaves. Very cold-hardy for Scottish winters.',
@@ -596,6 +666,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'endive',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 6,
+      tip: 'Keep heads in the salad drawer; blanching in the plot cuts the bitterness.',
+    },
     name: 'Endive',
     category: 'leafy-greens',
     description: 'Bitter salad green for autumn/winter. More cold-tolerant than lettuce.',
@@ -629,6 +704,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'ice-plant',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 4,
+      tip: 'Succulent crunchy leaf best eaten fresh; keep cool and use within days.',
+    },
     name: 'Ice Plant',
     category: 'leafy-greens',
     description: 'Succulent salad plant with glistening leaves. Drought-tolerant and unusual.',
@@ -661,6 +741,11 @@ export const leafyGreens: Vegetable[] = [
   },
   {
     id: 'pak-choi',
+    storage: {
+      methods: ['fridge', 'ferment'],
+      freshDays: 5,
+      tip: 'Keeps a few days in the fridge; ferment a glut kimchi-style for the winter.',
+    },
     name: 'Pak Choi',
     category: 'leafy-greens',
     description: 'Fast-growing Asian green. Thrives in cool Scottish weather - less prone to bolting.',

--- a/src/lib/vegetables/data/legumes.ts
+++ b/src/lib/vegetables/data/legumes.ts
@@ -399,6 +399,11 @@ export const legumes: Vegetable[] = [
   },
   {
     id: 'asparagus-peas',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze'],
+      freshDays: 4,
+      tip: 'Pick the winged pods tiny and tender; eat fresh, or briefly blanch and freeze a glut.',
+    },
     name: 'Asparagus Peas',
     category: 'legumes',
     description: 'Unusual winged pods with asparagus flavor. Low-growing plant.',
@@ -473,6 +478,11 @@ export const legumes: Vegetable[] = [
   },
   {
     id: 'fenugreek',
+    storage: {
+      methods: ['fresh', 'dry', 'fridge'],
+      freshDays: 3,
+      tip: 'Use the methi leaves fresh; let seed heads dry fully, then store the seeds dry for spice.',
+    },
     name: 'Fenugreek',
     category: 'legumes',
     description: 'Herb and nitrogen-fixing legume. Use leaves fresh, seeds dried.',
@@ -503,6 +513,10 @@ export const legumes: Vegetable[] = [
   },
   {
     id: 'ground-nut',
+    storage: {
+      methods: ['store-cool', 'fridge'],
+      tip: 'Lift the tubers in autumn and keep cool and dark like spuds; always cook before eating.',
+    },
     name: 'Ground Nut (Apios)',
     category: 'legumes',
     description: 'Native American climbing legume with edible tubers. Nitrogen-fixing.',

--- a/src/lib/vegetables/data/other.ts
+++ b/src/lib/vegetables/data/other.ts
@@ -152,6 +152,11 @@ export const other: Vegetable[] = [
   },
   {
     id: 'asparagus',
+    storage: {
+      methods: ['fresh', 'fridge', 'freeze'],
+      freshDays: 4,
+      tip: 'Best eaten the day you cut it; stand spears in water in the fridge, or blanch and freeze a glut.',
+    },
     name: 'Asparagus',
     category: 'other',
     description: 'Perennial vegetable producing tender spears in spring. Takes 2-3 years to establish.',
@@ -201,6 +206,11 @@ export const other: Vegetable[] = [
   },
   {
     id: 'globe-artichoke',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 7,
+      tip: 'Keeps a week in the fridge but best fresh; cook and preserve trimmed hearts in oil if you have a surplus.',
+    },
     name: 'Globe Artichoke',
     category: 'other',
     description: 'Architectural perennial vegetable. Edible flower buds with silvery foliage.',
@@ -242,6 +252,11 @@ export const other: Vegetable[] = [
   },
   {
     id: 'celery',
+    storage: {
+      methods: ['fridge', 'freeze'],
+      freshDays: 14,
+      tip: 'Keeps a couple of weeks in the fridge; freeze chopped for soups and stews (cooked use only).',
+    },
     name: 'Celery',
     category: 'other',
     description: 'Crunchy stalks for salads and cooking. Needs consistent moisture.',
@@ -280,6 +295,11 @@ export const other: Vegetable[] = [
   },
   {
     id: 'cardoon',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 7,
+      tip: 'Use the blanched stems fresh within a week; always cook before eating.',
+    },
     name: 'Cardoon',
     category: 'other',
     description: 'Relative of globe artichoke with edible stems. Dramatic architectural plant.',
@@ -313,6 +333,10 @@ export const other: Vegetable[] = [
   },
   {
     id: 'mashua',
+    storage: {
+      methods: ['store-cool', 'fridge'],
+      tip: 'Lift the tubers after the first frost and store somewhere cool and dark like oca; best cooked.',
+    },
     name: 'Mashua',
     category: 'other',
     description: 'Andean climbing tuber with peppery edible tubers and flowers.',

--- a/src/lib/vegetables/data/other.ts
+++ b/src/lib/vegetables/data/other.ts
@@ -207,9 +207,9 @@ export const other: Vegetable[] = [
   {
     id: 'globe-artichoke',
     storage: {
-      methods: ['fridge', 'fresh'],
+      methods: ['fresh', 'fridge', 'freeze'],
       freshDays: 7,
-      tip: 'Keeps a week in the fridge but best fresh; cook and preserve trimmed hearts in oil if you have a surplus.',
+      tip: 'Best fresh; keeps about a week in the fridge. Blanch and freeze trimmed hearts to preserve a glut, or keep cooked hearts in oil in the fridge for a few days.',
     },
     name: 'Globe Artichoke',
     category: 'other',

--- a/src/lib/vegetables/data/perennial-flowers.ts
+++ b/src/lib/vegetables/data/perennial-flowers.ts
@@ -8,6 +8,10 @@ import { Vegetable } from '@/types/garden-planner'
 export const perennialFlowers: Vegetable[] = [
   {
     id: 'lavender',
+    storage: {
+      methods: ['dry'],
+      tip: 'Cut stems as the flowers open and hang in small bunches to dry for sachets or culinary use.',
+    },
     name: 'Lavender',
     category: 'perennial-flowers',
     description: 'Aromatic evergreen shrub with purple flower spikes. Excellent bee plant and culinary herb.',
@@ -239,6 +243,10 @@ export const perennialFlowers: Vegetable[] = [
   },
   {
     id: 'bergamot',
+    storage: {
+      methods: ['dry', 'freeze'],
+      tip: 'Dry the leaves and flowers for herbal tea, or freeze chopped leaves for later.',
+    },
     name: 'Bergamot (Monarda)',
     category: 'perennial-flowers',
     description: 'Bee balm with aromatic leaves and showy flowers. Edible flowers and leaves for tea.',

--- a/src/lib/vegetables/data/root-vegetables.ts
+++ b/src/lib/vegetables/data/root-vegetables.ts
@@ -441,7 +441,7 @@ export const rootVegetables: Vegetable[] = [
   {
     id: 'yacon',
     storage: {
-      methods: ['store-cool', 'fridge'],
+      methods: ['cure', 'store-cool', 'fridge'],
       tip: 'Cure the tubers in the sun for a week or two to sweeten them, then store cool and dark.',
     },
     name: 'Yacon',

--- a/src/lib/vegetables/data/root-vegetables.ts
+++ b/src/lib/vegetables/data/root-vegetables.ts
@@ -134,6 +134,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'salsify',
+    storage: {
+      methods: ['store-cool', 'fresh'],
+      tip: 'Hardy enough to leave in the ground over a Scottish winter; lift as needed or store roots in a box of damp sand.',
+    },
     name: 'Salsify',
     category: 'root-vegetables',
     description: 'Oyster-flavored root vegetable. Hardy and underrated!',
@@ -166,6 +170,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'hamburg-parsley',
+    storage: {
+      methods: ['store-cool', 'fresh'],
+      tip: 'Fully hardy; leave roots in the ground and lift through winter, or pack them in damp sand in a cool shed.',
+    },
     name: 'Hamburg Parsley',
     category: 'root-vegetables',
     description: 'Dual-purpose parsley with edible root. Very hardy for Scottish winters.',
@@ -197,6 +205,11 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'florence-fennel',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 10,
+      tip: 'Best eaten fresh; keep whole bulbs in the fridge salad drawer for a week or so.',
+    },
     name: 'Florence Fennel',
     category: 'root-vegetables',
     description: 'Anise-flavored swollen stem base. Tricky in Scotland but possible with bolt-resistant varieties.',
@@ -235,6 +248,11 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'mooli',
+    storage: {
+      methods: ['fridge', 'ferment', 'pickle'],
+      freshDays: 14,
+      tip: 'Keeps a couple of weeks in the fridge; a glut ferments or pickles brilliantly Asian-style.',
+    },
     name: 'Mooli (Daikon)',
     category: 'root-vegetables',
     description: 'Large Asian radish for autumn/winter. Very hardy and good for Scottish climate.',
@@ -271,6 +289,11 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'black-radish',
+    storage: {
+      methods: ['fridge', 'store-cool'],
+      freshDays: 21,
+      tip: 'A good winter keeper; stores for weeks in the fridge or packed in damp sand in a cool shed.',
+    },
     name: 'Black Radish',
     category: 'root-vegetables',
     description: 'Winter storage radish with black skin. Very hardy for Scottish winters.',
@@ -307,6 +330,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'scorzonera',
+    storage: {
+      methods: ['store-cool', 'fresh'],
+      tip: 'Fully hardy; leave the long roots in the ground and lift as needed, or store in a box of damp sand.',
+    },
     name: 'Scorzonera',
     category: 'root-vegetables',
     description: 'Black salsify with delicate flavor. Hardy perennial vegetable ideal for Scotland.',
@@ -340,6 +367,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'horseradish',
+    storage: {
+      methods: ['store-cool', 'fridge', 'pickle'],
+      tip: 'Store roots in damp sand in a cool shed; grated horseradish keeps for months preserved in vinegar.',
+    },
     name: 'Horseradish',
     category: 'root-vegetables',
     description: 'Perennial root for making pungent condiment. Very vigorous and hardy.',
@@ -372,6 +403,11 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'chinese-artichoke',
+    storage: {
+      methods: ['fridge', 'fresh'],
+      freshDays: 7,
+      tip: 'Crosnes do not store long; lift as needed and eat fresh, or keep a few days in the fridge in a sealed bag.',
+    },
     name: 'Chinese Artichoke (Crosnes)',
     category: 'root-vegetables',
     description: 'Unusual nutty-flavored tubers. Very hardy perennial for Scottish gardens.',
@@ -404,6 +440,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'yacon',
+    storage: {
+      methods: ['store-cool', 'fridge'],
+      tip: 'Cure the tubers in the sun for a week or two to sweeten them, then store cool and dark.',
+    },
     name: 'Yacon',
     category: 'root-vegetables',
     description: 'Sweet crunchy tubers from South America. Frost-tender but grows well in Scottish summers.',
@@ -478,6 +518,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'skirret',
+    storage: {
+      methods: ['store-cool', 'fresh'],
+      tip: 'Hardy; leave the root clusters in the ground over winter and lift as needed, or store in damp sand.',
+    },
     name: 'Skirret',
     category: 'root-vegetables',
     description: 'Medieval root vegetable with sweet parsnip-like roots. Very hardy.',
@@ -511,6 +555,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'oca',
+    storage: {
+      methods: ['store-cool'],
+      tip: 'Lift after the first frost, green the tubers in light for a few days to mellow oxalates, then store cool and dark.',
+    },
     name: 'Oca',
     category: 'root-vegetables',
     description: 'Andean tuber with lemony flavor. Cold-hardy potato alternative.',
@@ -544,6 +592,10 @@ export const rootVegetables: Vegetable[] = [
   },
   {
     id: 'ulluco',
+    storage: {
+      methods: ['store-cool', 'fridge'],
+      tip: 'Handle the soft tubers gently; a fairly short keeper, so store cool and dark and use within a few weeks.',
+    },
     name: 'Ulluco',
     category: 'root-vegetables',
     description: 'Andean tuber with waxy texture. Colorful tubers and edible leaves.',

--- a/src/lib/vegetables/data/solanaceae.ts
+++ b/src/lib/vegetables/data/solanaceae.ts
@@ -49,6 +49,11 @@ export const solanaceae: Vegetable[] = [
   },
   {
     id: 'early-potato',
+    storage: {
+      methods: ['fresh', 'fridge'],
+      freshDays: 7,
+      tip: 'New tatties do not keep — dig only what you need and eat within a few days of lifting.',
+    },
     name: 'First Early Potato',
     category: 'solanaceae',
     description: 'Fast-maturing new potatoes. Ready 10-12 weeks after planting, ideal for Scottish climate.',
@@ -86,6 +91,11 @@ export const solanaceae: Vegetable[] = [
   },
   {
     id: 'second-early-potato',
+    storage: {
+      methods: ['fresh', 'store-cool'],
+      freshDays: 14,
+      tip: 'Best eaten within a few weeks; keep any spare cool and dark for short-term storage only.',
+    },
     name: 'Second Early Potato',
     category: 'solanaceae',
     description: 'Mid-season potatoes with better yields than first earlies. Harvest July-August.',
@@ -309,6 +319,11 @@ export const solanaceae: Vegetable[] = [
   },
   {
     id: 'tomatillo',
+    storage: {
+      methods: ['fridge', 'freeze', 'store-cool'],
+      freshDays: 21,
+      tip: 'Leave the husks on and keep in the fridge for weeks; freeze whole or cook into salsa verde.',
+    },
     name: 'Tomatillo',
     category: 'solanaceae',
     description: 'Mexican green tomato in papery husk. Surprisingly viable in Scotland.',


### PR DESCRIPTION
## Summary

Authors `storage` data for every remaining **edible** crop called out in the storage-tips backlog, taking coverage from **59 → 149 of 191 plants** (90 new entries). Rebased on latest `main`.

Filled completely:
- **herbs (20)** — soft herbs freeze-first, woody herbs dry-first, bay/chamomile dry, sorrel/borage fresh
- **leafy greens (17)** — salad leaves fridge/fresh, cooking greens freeze, mustard/pak-choi ferment
- **roots (12)** — in-ground / damp-sand keepers, mooli & horseradish ferment-or-pickle, oca/yacon curing notes
- **berries (8)** — soft fruit freeze/jam, goji/aronia/elderberry dry, elderberry "cook first"
- **brassicas (7)**, **alliums (7)** (cure-and-store keepers vs fresh-leaf), **fruit trees (4)** (medlar bletting, quince membrillo), **legumes (3)**, **solanaceae (3)** (new tatties "eat fresh", tomatillo husks-on), **other (5)**
- ornamental exceptions: edible flowers **calendula + nasturtium**, culinary **lavender + bergamot**

Authored to the established rule of thumb — only crops with a genuine preserving option carry a `freeze/jam/pickle/ferment/dry` method (which triggers the C3 glut nudge). Pure keepers (new potatoes, salsify, scorzonera, fennel bulb, crosnes, oca, ulluco…) use only `fresh/fridge/store-cool/cure`, so they show storage info without nagging to preserve.

**Out of scope by design** (~42 crops): non-edible ornamental flowers, bulbs, climbers, green manures, and mushrooms, per the prior category guidance. `docs/plans/current-plan.md` is updated to reflect the new coverage and note the deliberate boundary.

## Related issue

Closes #

## Type of change

- [x] New feature (plant-database data)
- [ ] Bug fix
- [x] Documentation update (`current-plan.md`)

## Checklist

- [x] I have tested my changes — all 1099 unit tests pass; type-check clean (only the pre-existing `baseUrl` deprecation)
- [x] I have updated documentation if needed — `docs/plans/current-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXJeznpsvtiPtk91yeUx65