### PR TITLE
Fix care-tip task dedup and switch to order-independent task IDs

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -551,6 +551,35 @@ Four valid items from Gemini's #444 review that shipped to main:
 Existing entries untouched. type-check, lint clean; plant-data-integrity,
 task-generator, and vegetable-database suites all pass.
 
+### Care-tip task dedup + stable IDs (branch `claude/care-tip-dedup-design-9o1nmw`)
+
+Fixed two coupled design smells in the care-tip pipeline (`src/lib/task-generator.ts`)
+that the #446 review exposed:
+
+- **Dedup collapsed same-month tips.** `taskDedupeKey` keyed care-tips on
+  plant + area + month, so a plant with several tips in one month (asparagus in
+  June has three for a productive plant) silently showed only the first on the
+  Today dashboard. Decided semantics: **distinct tips are distinct tasks**; the
+  *same* tip is deduped across areas (generic per-plant advice, matching the
+  one-per-plant pattern of sow tasks and preserve nudges). The dedupe key for
+  `care-tip` tasks is now the task ID itself, which encodes plant + tip content
+  + month. Preserve nudges (which reuse the care-tip type with `preserve-nudge-*`
+  IDs) stay distinct automatically.
+- **IDs embedded the tip's array index.** `care-tip-<areaId>-<vegId>-<tipIdx>-<month>`
+  meant inserting or reordering tips in the vegetable database silently
+  invalidated month-scoped dismissals in localStorage on deploy. IDs are now
+  `care-tip-<plantId>-<hash>-<month>` where the hash is a short FNV-1a of
+  plantId + tip text (`careTipHash`, exported) — order-independent and free of
+  area churn. Dismissed-task records are month-scoped, so existing dismissals
+  under old IDs worst-case reappear once mid-month and self-heal at rollover.
+
+The dashboard copes with several tips per plant per month by construction —
+`TaskList` renders a flat list keyed by `task.id`, capped at 8 with a "+N more"
+expander. Regression tests added for: all same-month tips emitted with distinct
+IDs, ID stability under tip reorder/insert, same-tip-across-areas dedup,
+preserve-nudge/care-tip coexistence, and the hash itself. type-check, lint, and
+the full unit suite (1124) pass.
+
 ### Up Next: Phase 1 soak then Step 5 cleanup
 
 The soak window is open. Success criterion is qualitative for the two-user cohort: both real users use the app on the flag for ~3–5 days each, run at least one manual cross-device conflict (edit on phone and laptop, watch the conflict-replace path actually re-hydrate the Yjs doc from cloud), and report no data anomalies. The Yjs binary on each device is the source of truth from this point; the legacy `allotment-unified-data` localStorage key is being mirrored from Yjs and is the rollback floor. Step 5 then deletes `useSyncedStorage`, the legacy branch of every domain-hook method, `useYjsToLegacyMirror`, the `bwp-storage-flag` BroadcastChannel, the legacy localStorage key, and the same-tab broadcast apparatus from PR #369 (the `bonnie:storage-update` CustomEvent, the `instanceId`/`sameTabSeq` bookkeeping, the `recordSavedState`/`recordAdoptedState` helpers, the `recentSavesRef` echo dedup) — every line of that broadcast becomes redundant the day the legacy chain leaves the tree. `serializeToJson` and `decodeDocState` stay forever (rollback + GDPR export + debug). Separate follow-ups worth filing: rename `src/lib/yjs-spike/` → `src/lib/yjs/`, consolidate `src/hooks/allotment/yjs-helpers.ts` with the now-internal `assignDefined` in `allotment-yjs.ts`, and tighten the still-`addInitScript`-pattern Playwright seeds (homepage / onboarding / boost-this-bed) to also clear Yjs IDB if those tests start contaminating each other later.

--- a/src/__tests__/lib/task-generator.test.ts
+++ b/src/__tests__/lib/task-generator.test.ts
@@ -5,7 +5,8 @@ import {
   generateSuccessionReminders,
   generateVarietyTasks,
   getUrgency,
-  getTaskLabel
+  getTaskLabel,
+  careTipHash
 } from '@/lib/task-generator'
 import { Area, Planting, StoredVariety } from '@/types/unified-allotment'
 import { Month } from '@/types/garden-planner'
@@ -515,6 +516,198 @@ describe('task-generator', () => {
       // stage-less tips still show, stage-specific tips skipped (no plantedYear)
       expect(careTipTasks).toHaveLength(1)
       expect(careTipTasks[0].description).toBe('Cut back autumn-fruiting canes to ground level')
+    })
+
+    it('should emit every care tip matching the same month for one plant', () => {
+      // Regression: asparagus in June has three matching tips for a productive
+      // plant; the old plant+area dedupe key collapsed them to the first.
+      const area: Area = {
+        id: 'asparagus-bed',
+        name: 'Asparagus Bed',
+        kind: 'perennial-bed',
+        canHavePlantings: true,
+        primaryPlant: {
+          plantId: 'asparagus',
+          plantedYear: 2020,
+        }
+      }
+
+      mockGetVegetableById.mockReturnValue({
+        id: 'asparagus',
+        name: 'Asparagus',
+        planting: {
+          harvestMonths: [4, 5, 6],
+          sowIndoorsMonths: [],
+          sowOutdoorsMonths: [],
+          transplantMonths: []
+        },
+        careTips: [
+          { months: [4, 5, 6], tip: 'From year three, cut spears when about 18cm tall', category: 'harvest', stage: 'productive' },
+          { months: [6], tip: 'Stop cutting by mid-June and let the ferny foliage grow', category: 'harvest', stage: 'productive' },
+          { months: [6, 7, 8], tip: 'Weed the bed by hand and watch for asparagus beetle', category: 'care' },
+        ],
+        perennialInfo: {
+          yearsToFirstHarvest: { min: 2, max: 3 },
+          productiveYears: { min: 15, max: 20 }
+        }
+      })
+
+      mockCalculatePerennialStatus.mockReturnValue({ status: 'productive' })
+
+      const tasks = generateTasksForMonth(6 as Month, [], [area])
+
+      const careTipTasks = tasks.filter(t => t.generatedType === 'care-tip')
+      expect(careTipTasks).toHaveLength(3)
+      expect(careTipTasks.map(t => t.description).sort()).toEqual([
+        'From year three, cut spears when about 18cm tall',
+        'Stop cutting by mid-June and let the ferny foliage grow',
+        'Weed the bed by hand and watch for asparagus beetle',
+      ])
+      // Each tip must be independently dismissable, so IDs must be distinct
+      expect(new Set(careTipTasks.map(t => t.id)).size).toBe(3)
+    })
+
+    it('should keep care-tip task IDs stable when tips are inserted or reordered', () => {
+      const area: Area = {
+        id: 'raspberry-patch',
+        name: 'Raspberry Patch',
+        kind: 'berry',
+        canHavePlantings: true,
+        primaryPlant: {
+          plantId: 'raspberry',
+          plantedYear: 2020,
+        }
+      }
+
+      const netTip = { months: [7], tip: 'Net fruit to protect from birds', category: 'protect' }
+      const weedTip = { months: [7], tip: 'Weed around the canes', category: 'care' }
+      const vegetable = {
+        id: 'raspberry',
+        name: 'Raspberry',
+        planting: {
+          harvestMonths: [7, 8],
+          sowIndoorsMonths: [],
+          sowOutdoorsMonths: [],
+          transplantMonths: []
+        },
+      }
+
+      mockGetVegetableById.mockReturnValue({ ...vegetable, careTips: [netTip, weedTip] })
+      const before = generateTasksForMonth(7 as Month, [], [area])
+        .find(t => t.description === 'Net fruit to protect from birds')
+
+      // Prepend a new tip and swap the order of the existing two
+      const newTip = { months: [7], tip: 'Tie in new canes as they grow', category: 'care' }
+      mockGetVegetableById.mockReturnValue({ ...vegetable, careTips: [newTip, weedTip, netTip] })
+      const after = generateTasksForMonth(7 as Month, [], [area])
+        .find(t => t.description === 'Net fruit to protect from birds')
+
+      // Same tip keeps the same ID, so month-scoped dismissals survive
+      // vegetable-database edits (the old index-based IDs did not)
+      expect(before?.id).toBeDefined()
+      expect(after?.id).toBe(before?.id)
+    })
+
+    it('should dedupe the same care tip across multiple areas of the same plant', () => {
+      const makeArea = (id: string, name: string): Area => ({
+        id,
+        name,
+        kind: 'perennial-bed',
+        canHavePlantings: true,
+        primaryPlant: {
+          plantId: 'asparagus',
+          plantedYear: 2020,
+        }
+      })
+
+      mockGetVegetableById.mockReturnValue({
+        id: 'asparagus',
+        name: 'Asparagus',
+        planting: {
+          harvestMonths: [4, 5, 6],
+          sowIndoorsMonths: [],
+          sowOutdoorsMonths: [],
+          transplantMonths: []
+        },
+        careTips: [
+          { months: [6], tip: 'Stop cutting by mid-June and let the ferny foliage grow', category: 'harvest' },
+        ],
+      })
+
+      const tasks = generateTasksForMonth(6 as Month, [], [
+        makeArea('asparagus-bed-1', 'Asparagus Bed 1'),
+        makeArea('asparagus-bed-2', 'Asparagus Bed 2'),
+      ])
+
+      // Generic per-plant advice: one task, not one per bed
+      const careTipTasks = tasks.filter(t => t.generatedType === 'care-tip')
+      expect(careTipTasks).toHaveLength(1)
+      expect(careTipTasks[0].areaId).toBeDefined()
+    })
+
+    it('should keep preserve nudges and care tips for the same plant distinct', () => {
+      // Preserve nudges reuse the care-tip task type; the per-tip dedupe key
+      // must not collapse them with a real care tip for the same plant.
+      const area: Area = {
+        id: 'asparagus-bed',
+        name: 'Asparagus Bed',
+        kind: 'perennial-bed',
+        canHavePlantings: true,
+        primaryPlant: {
+          plantId: 'asparagus',
+          plantedYear: 2020,
+        }
+      }
+      const planting: Planting = { id: 'p1', plantId: 'asparagus' }
+
+      mockGetVegetableById.mockReturnValue({
+        id: 'asparagus',
+        name: 'Asparagus',
+        planting: {
+          harvestMonths: [4, 5, 6],
+          sowIndoorsMonths: [],
+          sowOutdoorsMonths: [],
+          transplantMonths: []
+        },
+        storage: {
+          methods: ['freeze'],
+          tip: 'Blanch and freeze a glut.',
+        },
+        careTips: [
+          { months: [6], tip: 'Stop cutting by mid-June and let the ferny foliage grow', category: 'harvest' },
+        ],
+      })
+
+      const tasks = generateTasksForMonth(
+        6 as Month,
+        [{ planting, areaId: 'asparagus-bed', areaName: 'Asparagus Bed' }],
+        [area]
+      )
+
+      const careTipTasks = tasks.filter(t => t.generatedType === 'care-tip')
+      expect(careTipTasks).toHaveLength(2)
+      expect(careTipTasks.map(t => t.description).sort()).toEqual([
+        'Glut of Asparagus?',
+        'Stop cutting by mid-June and let the ferny foliage grow',
+      ])
+    })
+  })
+
+  describe('careTipHash', () => {
+    it('is deterministic for the same plant and tip text', () => {
+      expect(careTipHash('asparagus', 'Stop cutting by mid-June')).toBe(
+        careTipHash('asparagus', 'Stop cutting by mid-June')
+      )
+    })
+
+    it('differs for different tip text or plant', () => {
+      const base = careTipHash('asparagus', 'Stop cutting by mid-June')
+      expect(careTipHash('asparagus', 'Weed the bed by hand')).not.toBe(base)
+      expect(careTipHash('rhubarb', 'Stop cutting by mid-June')).not.toBe(base)
+    })
+
+    it('produces a short url/id-safe token', () => {
+      expect(careTipHash('asparagus', 'Stop cutting by mid-June')).toMatch(/^[0-9a-z]{1,7}$/)
     })
   })
 

--- a/src/lib/task-generator.ts
+++ b/src/lib/task-generator.ts
@@ -324,8 +324,10 @@ function generateCareTipTasks(
         if (tip.stage !== lifecycleStatus) continue
       }
 
-      // Content-derived ID, no area: the same tip for a plant grown in
-      // several areas is one task, and dismissals survive database edits.
+      // The ID is content-derived and has no area component, so the same
+      // tip for a plant grown in several areas dedupes to one task and
+      // dismissals survive database edits. The task itself still carries
+      // areaId/areaName for display context.
       tasks.push({
         id: `care-tip-${vegetable.id}-${careTipHash(vegetable.id, tip.tip)}-${currentMonth}`,
         type: 'other',

--- a/src/lib/task-generator.ts
+++ b/src/lib/task-generator.ts
@@ -272,6 +272,22 @@ export function generateSuccessionReminders(
 }
 
 /**
+ * Short, stable identity for a care tip: FNV-1a 32-bit hash of
+ * plantId + tip text, rendered in base36. Task IDs built from this survive
+ * inserting or reordering tips in the vegetable database — an array index
+ * would silently invalidate month-scoped dismissals in localStorage on deploy.
+ */
+export function careTipHash(plantId: string, tipText: string): string {
+  const input = `${plantId}:${tipText}`
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+/**
  * Generate care tip tasks for perennial areas
  * Filters by current month and the plant's lifecycle stage
  */
@@ -299,8 +315,7 @@ function generateCareTipTasks(
       lifecycleStatus = result.status
     }
 
-    for (let tipIdx = 0; tipIdx < vegetable.careTips.length; tipIdx++) {
-      const tip = vegetable.careTips[tipIdx]
+    for (const tip of vegetable.careTips) {
       if (!tip.months.includes(currentMonth)) continue
 
       // Stage filtering: if tip has a stage, only show when lifecycle matches
@@ -309,8 +324,10 @@ function generateCareTipTasks(
         if (tip.stage !== lifecycleStatus) continue
       }
 
+      // Content-derived ID, no area: the same tip for a plant grown in
+      // several areas is one task, and dismissals survive database edits.
       tasks.push({
-        id: `care-tip-${area.id}-${vegetable.id}-${tipIdx}-${currentMonth}`,
+        id: `care-tip-${vegetable.id}-${careTipHash(vegetable.id, tip.tip)}-${currentMonth}`,
         type: 'other',
         generatedType: 'care-tip',
         description: tip.tip,
@@ -498,6 +515,12 @@ function generateMonthBasedTasks(
  * derived tasks for the same crop.
  */
 function taskDedupeKey(task: GeneratedTask): string {
+  // Care tips: distinct tips are distinct tasks, so the key is the task ID,
+  // which already encodes plant + tip content + month (no area). The same
+  // tip for a plant grown in several areas collapses to one task, while
+  // several same-month tips for one plant all survive. Preserve nudges share
+  // the care-tip type but have their own stable preserve-nudge-* IDs.
+  if (task.generatedType === 'care-tip') return task.id
   const source = task.id.startsWith('variety-') ? 'variety' : 'planting'
   return `${source}-${task.generatedType}-${task.plantId}-${task.areaId || 'general'}`
 }


### PR DESCRIPTION
## Summary

Fixes the two coupled design smells in the care-tip task pipeline (`src/lib/task-generator.ts`) that the #446 review exposed:

1. **Dedup collapsed same-month tips.** `taskDedupeKey` keyed care-tips on plant + area + month, so a plant with several tips in one month — asparagus in June has three for a productive plant — silently showed only the first on the Today dashboard. **Decided semantics: distinct tips are distinct tasks**; the *same* tip is deduped across areas (generic per-plant advice, matching the one-per-plant pattern of sow tasks and preserve nudges). Care-tip tasks now dedupe on the task ID, which fully encodes plant + tip content + month. Preserve nudges, which reuse the care-tip type with their own `preserve-nudge-*` IDs, stay distinct automatically.

2. **IDs embedded the tip's array index.** `care-tip-<areaId>-<vegId>-<tipIdx>-<month>` meant inserting or reordering tips in the vegetable database silently invalidated month-scoped dismissals in localStorage on deploy. IDs are now `care-tip-<plantId>-<hash>-<month>`, where the hash is a short FNV-1a of plantId + tip text (`careTipHash`, exported) — order-independent and free of area churn.

**Dismissal compatibility:** dismissed-task records are month-scoped and auto-clear on month rollover, so existing dismissals under old-format IDs worst-case reappear once mid-month after deploy and self-heal at rollover. No migration needed.

**Dashboard:** copes with several care tips per plant per month by construction — `TaskList` renders a flat list keyed by `task.id`, capped at 8 with a "+N more" expander.

Regression tests added: all same-month tips emitted with distinct IDs (asparagus-in-June case), ID stability under tip reorder/insert, same-tip-across-areas dedup, preserve-nudge/care-tip coexistence, and determinism/distinctness of the hash. Also updated `docs/plans/current-plan.md`.

## Related issue

Follow-up to the #446 review discussion (no tracking issue).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] I have tested my changes (type-check, lint, and full unit suite — 1124 tests — pass; 7 new regression tests)
- [x] I have updated documentation if needed (`docs/plans/current-plan.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxgXtJmtfS85Ljg3LYyZmy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxgXtJmtfS85Ljg3LYyZmy)_