### PR TITLE
Add Preserving section: foundation, cucurbits exemplar, and parallel authoring plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,16 @@ Split into index, per-category data files, and lazy loader for performance:
 - `src/lib/vegetable-database.ts` - combines all category files into single array
 - `src/lib/vegetable-loader.ts` - per-category dynamic imports for code splitting
 
+### Preserving Guides
+
+Rich per-crop preservation guidance (method how-tos, storage life, free online resource links, recipe ideas) for the `/preserving` page, building on the lightweight `Vegetable.storage` field:
+- `src/types/preservation.ts` - `PreservationGuide` types
+- `src/lib/preservation/index.ts` - aggregator and lookups
+- `src/lib/preservation/resources.ts` - shared fetch-verified free resources (NCHFP, RHS, Garden Organic, BBC Food, etc.)
+- `src/lib/preservation/data/*.ts` - per-category guide files (parallel-authoring-safe)
+
+Authoring spec and per-category session goals: `docs/plans/food-preservation-plan.md`.
+
 ### Key Type Definitions
 
 `src/types/garden-planner.ts` defines:

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -555,6 +555,21 @@ task-generator, and vegetable-database suites all pass.
 
 The soak window is open. Success criterion is qualitative for the two-user cohort: both real users use the app on the flag for ~3–5 days each, run at least one manual cross-device conflict (edit on phone and laptop, watch the conflict-replace path actually re-hydrate the Yjs doc from cloud), and report no data anomalies. The Yjs binary on each device is the source of truth from this point; the legacy `allotment-unified-data` localStorage key is being mirrored from Yjs and is the rollback floor. Step 5 then deletes `useSyncedStorage`, the legacy branch of every domain-hook method, `useYjsToLegacyMirror`, the `bwp-storage-flag` BroadcastChannel, the legacy localStorage key, and the same-tab broadcast apparatus from PR #369 (the `bonnie:storage-update` CustomEvent, the `instanceId`/`sameTabSeq` bookkeeping, the `recordSavedState`/`recordAdoptedState` helpers, the `recentSavesRef` echo dedup) — every line of that broadcast becomes redundant the day the legacy chain leaves the tree. `serializeToJson` and `decodeDocState` stay forever (rollback + GDPR export + debug). Separate follow-ups worth filing: rename `src/lib/yjs-spike/` → `src/lib/yjs/`, consolidate `src/hooks/allotment/yjs-helpers.ts` with the now-internal `assignDefined` in `allotment-yjs.ts`, and tighten the still-`addInitScript`-pattern Playwright seeds (homepage / onboarding / boost-this-bed) to also clear Yjs IDB if those tests start contaminating each other later.
 
+### Preserving section — foundation shipped, data authoring planned (branch `claude/food-preservation-section-akmsdt`)
+
+New `/preserving` section: rich per-crop preservation guides (method how-tos,
+storage life, fetch-verified free resource links, recipe ideas including cakes
+and glut bakes) building on the lightweight `Vegetable.storage` chips from
+Milestone C. Foundation shipped: `src/types/preservation.ts`,
+`src/lib/preservation/` (aggregator + shared verified resources + 14
+per-category data files), the `/preserving` page (search, method/category
+filters, expandable cards), a "Preserving" link in the More menu, and data
+integrity unit tests. `cucurbits.ts` is fully authored (7 crops) as the
+exemplar. Remaining: ~149 crops across 10 parallel-safe authoring sessions
+(one data file each) plus a final integration session —
+see `docs/plans/food-preservation-plan.md` for the session goals, authoring
+spec, and verified resource library.
+
 ### Research-Driven Improvements: Backlog
 
 Soil temperature, Aitor opt-in polish, and backup reminders all shipped earlier; the Gemini free tier above closes the cost-line risk that was previously parked here.

--- a/docs/plans/food-preservation-plan.md
+++ b/docs/plans/food-preservation-plan.md
@@ -1,0 +1,150 @@
+# Preserving Section — Data Authoring Plan
+
+Status: **foundation shipped** on `claude/food-preservation-section-akmsdt`.
+This plan defines the remaining work as independent goals that can run as
+**parallel sessions** — each session owns exactly one data file, so there are
+no merge conflicts between them.
+
+## What already exists (do not rebuild)
+
+- `src/types/preservation.ts` — `PreservationGuide`, `PreservationMethodGuide`, `PreservationResource`
+- `src/lib/preservation/index.ts` — aggregator, `getPreservationGuide()`, method labels
+- `src/lib/preservation/resources.ts` — **shared, fetch-verified free resources** (NCHFP, USDA, RHS, Garden Organic, FSA, Penn State, UMN, BBC Food/Good Food helpers, River Cottage, Wikibooks)
+- `src/lib/preservation/data/*.ts` — one file per category; **cucurbits.ts is fully authored and is the exemplar to copy**
+- `/preserving` page (search + method/category filters, expandable cards) linked from the "More" nav menu
+- `src/__tests__/lib/preservation-data.test.ts` — integrity tests (real plant ids, unique ids, non-empty how-tos, https URLs)
+
+Related but separate: `Vegetable.storage` (lightweight method chips + one tip,
+already on ~149 crops) stays as-is; guides go deeper and link out.
+
+## Authoring spec (every session follows this)
+
+For each crop in your file, add one `PreservationGuide`:
+
+1. **`plantId`** — must match `src/lib/vegetables/index.ts` exactly.
+2. **`summary`** — one orienting sentence (glut warning, best use, keeper vs eat-fresh).
+3. **`methods`** — 2–4 entries covering the realistic options, from simplest
+   (fresh/fridge) to preserves (freeze, dry, cure, store-cool, pickle, ferment,
+   jam/chutney). Use only `StorageMethod` values. Check the crop's existing
+   `storage.methods` in `src/lib/vegetables/data/<category>.ts` and stay
+   consistent with it (you may add methods it omits, with good reason).
+   - `how`: 1–3 practical sentences, Scottish-allotment voice (match cucurbits.ts).
+   - `storageLife`: plain-English duration where known (e.g. "8–12 months frozen").
+   - `resources`: 0–2 links per method, **preferring the shared constants** in
+     `../resources` (NCHFP per-method pages, Garden Organic storing, UMN
+     harvest/storage, RHS fruit storing, PSU Let's Preserve).
+4. **`recipeIdeas`** — 1–3 links for eating the glut (cakes, bakes, soups,
+   cordials): BBC Food ingredient hubs first, then BBC Good Food collections,
+   River Cottage for preserves-heavy crops.
+
+### Link rules (important)
+
+- **Free resources only** — no paywalls, no sign-up walls. Ad-supported is fine.
+- **Verify every URL you add** returns 200 before committing:
+  `curl -s -o /dev/null -w "%{http_code}" -A "Mozilla/5.0" "<url>"`
+- BBC Food hub pattern: `https://www.bbc.co.uk/food/<slug>` — lowercase,
+  singular, underscores for spaces (`runner_bean`, `jerusalem_artichoke`).
+  Verified working: courgette, rhubarb, beetroot, kohlrabi, blackcurrant,
+  gooseberry, raspberry, runner_bean, jerusalem_artichoke, squash, pumpkin,
+  butternut_squash. Spot-check all others.
+- BBC Good Food collections: only verified slugs. There is **no**
+  `chutney-recipes` or `glut-recipes` collection; use
+  `pickles-jams-and-chutneys-recipes` and `garden-glut-cake-recipes`
+  (both already in `resources.ts` as `BBC_GOOD_FOOD.*`).
+- lovefoodhatewaste.com and allotment-garden.org block automated fetches
+  (403) but are genuinely free sites — only add their URLs if you can verify
+  them another way, and note it in the PR.
+- Food-safety guardrails: never suggest home-canning low-acid vegetables
+  without pressure canning; pumpkin/squash purée is freeze-only; when in
+  doubt link NCHFP and keep instructions to fridge/freeze/dry/pickle/ferment.
+
+### Definition of done (per session)
+
+- Every crop listed for the file has a guide (delete the TODO comment).
+- `npx vitest run src/__tests__/lib/preservation-data.test.ts` passes.
+- `npm run lint` and `npm run type-check` pass.
+- All new URLs curl-verified 200 (paste the check output in the PR description).
+- Commit to a fresh branch, push, open a PR.
+
+## Parallel session goals
+
+Each goal is self-contained: it touches only its own data file. Run any or all
+concurrently. Suggested session prompt: *"Fill `src/lib/preservation/data/<file>.ts`
+following the authoring spec in `docs/plans/food-preservation-plan.md`."*
+
+| # | File | Crops (count) |
+|---|------|----------------|
+| 1 | `leafy-greens.ts` | lettuce, spinach, perpetual-spinach, kale, cavolo-nero, chard, rocket, pak-choi, mizuna, land-cress, corn-salad, winter-purslane, mustard-greens, watercress, salad-burnet, orache, new-zealand-spinach, good-king-henry, radicchio, endive, ice-plant (21) |
+| 2 | `root-vegetables.ts` | carrot, beetroot, parsnip, turnip, swede, radish, jerusalem-artichoke, celeriac, salsify, hamburg-parsley, florence-fennel, mooli, black-radish, scorzonera, horseradish, chinese-artichoke, yacon, skirret, oca, ulluco (20) |
+| 3 | `brassicas.ts` | broccoli, cabbage, cauliflower, brussels-sprouts, kohlrabi, savoy-cabbage, red-cabbage, chinese-broccoli, romanesco, turnip-tops, mibuna, seakale, purple-sprouting-broccoli (13) |
+| 4 | `legumes.ts` | peas, runner-beans, broad-beans, french-beans, climbing-french-beans, borlotti-beans, edamame, mangetout, sugar-snap-peas, asparagus-peas, black-turtle-beans, fenugreek, ground-nut (13) |
+| 5 | `solanaceae.ts` | potato, early-potato, second-early-potato, maincrop-potato, cherry-tomato, plum-tomato, blight-resistant-tomato, tomatillo (8) |
+| 6 | `alliums.ts` | onion, garlic, leek, spring-onion, shallot, welsh-onion, elephant-garlic, walking-onion, potato-onion, garlic-chives, ramps (11) |
+| 7 | `herbs.ts` | parsley, coriander, mint, thyme, rosemary, chives, lovage, sorrel, oregano, sage, french-tarragon, dill, herb-fennel, lemon-balm, marjoram, bay, borage, chamomile, winter-savory, hyssop (20) |
+| 8 | `berries.ts` | strawberry, raspberry, blackcurrant, redcurrant, gooseberry, blueberry, blackberry, tayberry, loganberry, jostaberry, honeyberry, goji-berry, aronia, elderberry, sea-buckthorn (15) |
+| 9 | `fruit-trees.ts` | apple-tree, pear-tree, plum-tree, cherry-tree, damson-tree, greengage-tree, medlar-tree, quince-tree, fig-tree, mulberry-tree (10) |
+| 10 | `other.ts` + `mushrooms.ts` + `edible-extras.ts` | sweetcorn, asparagus, globe-artichoke, rhubarb, celery, cardoon, mashua; oyster-mushroom, shiitake, lions-mane, king-oyster, button-mushroom; nasturtium, calendula, lavender, bergamot, hardy-kiwi, hops (18) |
+
+`cucurbits.ts` (7) — ✅ done (exemplar).
+
+Category-specific hints:
+
+- **Leafy greens**: most are fridge/fresh; cooking greens (kale, chard, spinach)
+  blanch-and-freeze; mustard/pak-choi can ferment (kimchi-style — link
+  `UMN_SAUERKRAUT` + `NCHFP.fermenting`).
+- **Roots**: damp-sand boxes / in-ground storage are the star methods
+  (`GARDEN_ORGANIC_STORING`); beetroot pickles; horseradish/mooli ferment.
+- **Brassicas**: sauerkraut for cabbages (`UMN_SAUERKRAUT`); freeze florets
+  blanched; red cabbage pickles.
+- **Legumes**: pod beans freeze after blanching; borlotti/black turtle dry on
+  the vine; runner-bean chutney is a classic.
+- **Solanaceae**: potatoes = cure + paper sacks, never fridge; tomatoes =
+  passata/freeze whole, oven-dry; green-tomato chutney; tomatillo salsa verde.
+- **Alliums**: cure and plait/net (`RHS_ONIONS`); leeks stay in the ground;
+  garlic keeps 6–10 months.
+- **Herbs**: soft herbs freeze in oil/ice cubes; woody herbs dry
+  (`NCHFP.drying`); herb vinegars and butters.
+- **Berries**: open-freeze on trays; jams (`NCHFP.jams`, `BBC_GOOD_FOOD.jams`);
+  blackcurrant cordial; elderberry must be cooked.
+- **Fruit trees**: `RHS_STORING_FRUIT` for apples/pears/quince/medlar; wrap
+  and tray-store apples; plums/damsons freeze stoned and make jam/gin;
+  membrillo for quince; medlar bletting.
+- **Other/mushrooms/extras**: sweetcorn blanch-freeze same day; rhubarb
+  freezes raw + crumbles/cordial; mushrooms dry brilliantly (`NCHFP.drying`);
+  lavender/chamomile dry for tea; hops dry for brewing.
+
+## Final integration session (after data sessions merge)
+
+1. Cross-link: on `/plants/[id]`, when `getPreservationGuide(id)` exists, link
+   the Storage & Preserving panel to `/preserving?plant=<id>` (add query-param
+   support to expand that crop).
+2. Coverage test: assert every plant with `storage.methods` containing a
+   preserve method (freeze/jam/pickle/ferment/dry) has a `PreservationGuide`.
+3. E2E: `tests/preserving.spec.ts` — page loads, search filters, a card
+   expands, external links have `target="_blank"`.
+4. Consider promoting Preserving from the "More" menu to primary nav based on use.
+5. Update `docs/plans/current-plan.md`, then delete this file (doc hygiene).
+
+## Verified resource library (fetched 2026-07-04)
+
+All in `src/lib/preservation/resources.ts`. For reference:
+
+| Resource | URL | Notes |
+|---|---|---|
+| NCHFP methods hub | https://nchfp.uga.edu/ | Gold standard; per-method pages under `/how/<method>/` |
+| USDA canning guide | https://nchfp.uga.edu/resources/category/usda-guide | Free PDFs |
+| RHS storing fruit | https://www.rhs.org.uk/fruit/fruit-trees/storing | Apples, pears, quince, medlar |
+| RHS onions | https://www.rhs.org.uk/vegetables/onions/grow-your-own | Harvest + storing section |
+| Garden Organic | https://www.gardenorganic.org.uk/expert-advice/garden-management/harvesting-and-storage/harvesting-and-storing-vegetables | Best UK allotment storing page |
+| FSA fact checker | https://www.gov.uk/government/publications/home-food-fact-checker | UK food-safety storage Q&A |
+| PSU Let's Preserve | https://extension.psu.edu/food-safety-and-quality/home-food-preservation-and-safety/lets-preserve | 26 crop-by-crop fact sheets |
+| UMN preserving | https://extension.umn.edu/food-safety/preserving-and-preparing | All methods landing page |
+| UMN harvest/storage | https://extension.umn.edu/planting-and-growing-guides/harvesting-and-storing-home-garden-vegetables | 30+ crops, storage conditions |
+| UMN sauerkraut | https://extension.umn.edu/preserving-and-preparing/how-make-your-own-sauerkraut | Best free fermentation primer |
+| BBC Food hubs | https://www.bbc.co.uk/food/<ingredient> | Per-ingredient recipes, no ads |
+| BBC Good Food | https://www.bbcgoodfood.com/recipes/collection/<slug> | Verified slugs only; recipes checked non-premium |
+| River Cottage | https://www.rivercottage.net/recipes | Free, strong preserves coverage |
+| Wikibooks Cookbook | https://en.wikibooks.org/wiki/Cookbook:Table_of_Contents | CC technique reference |
+
+Known bot-blocked (free but unverifiable by curl): lovefoodhatewaste.com,
+allotment-garden.org.

--- a/src/__tests__/lib/preservation-data.test.ts
+++ b/src/__tests__/lib/preservation-data.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { preservationGuides, getPreservationGuide, getMethodsInUse, PRESERVATION_METHOD_LABELS } from '@/lib/preservation'
+import { vegetableIndex } from '@/lib/vegetables/index'
+
+describe('Preservation Data Integrity', () => {
+  const indexIds = new Set(vegetableIndex.map(v => v.id))
+
+  it('every guide references a real plant id', () => {
+    const unknown = preservationGuides.filter(g => !indexIds.has(g.plantId))
+    expect(unknown.map(g => g.plantId)).toEqual([])
+  })
+
+  it('plant ids are unique across all category files', () => {
+    const seen = new Set<string>()
+    const duplicates: string[] = []
+    for (const g of preservationGuides) {
+      if (seen.has(g.plantId)) duplicates.push(g.plantId)
+      seen.add(g.plantId)
+    }
+    expect(duplicates).toEqual([])
+  })
+
+  it('every guide has at least one method with instructions', () => {
+    for (const g of preservationGuides) {
+      expect(g.methods.length, `${g.plantId} has no methods`).toBeGreaterThan(0)
+      for (const m of g.methods) {
+        expect(m.how.trim().length, `${g.plantId}/${m.method} has empty instructions`).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('methods are not repeated within a guide', () => {
+    for (const g of preservationGuides) {
+      const methods = g.methods.map(m => m.method)
+      expect(new Set(methods).size, `${g.plantId} repeats a method`).toBe(methods.length)
+    }
+  })
+
+  it('all resource links are well-formed https URLs', () => {
+    for (const g of preservationGuides) {
+      const resources = [
+        ...g.methods.flatMap(m => m.resources ?? []),
+        ...(g.recipeIdeas ?? []),
+      ]
+      for (const r of resources) {
+        expect(r.url, `${g.plantId}: ${r.title}`).toMatch(/^https:\/\//)
+        expect(() => new URL(r.url), `${g.plantId}: invalid URL ${r.url}`).not.toThrow()
+        expect(r.title.trim().length, `${g.plantId} has a resource without a title`).toBeGreaterThan(0)
+        expect(r.source.trim().length, `${g.plantId}: ${r.title} has no source`).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('getPreservationGuide looks up by plant id', () => {
+    if (preservationGuides.length === 0) return
+    const first = preservationGuides[0]
+    expect(getPreservationGuide(first.plantId)).toBe(first)
+    expect(getPreservationGuide('not-a-real-plant')).toBeUndefined()
+  })
+
+  it('getMethodsInUse returns only methods present in guides, in label order', () => {
+    const inUse = getMethodsInUse()
+    const labelOrder = Object.keys(PRESERVATION_METHOD_LABELS)
+    expect(inUse).toEqual(labelOrder.filter(m => inUse.includes(m as never)))
+    const allMethods = new Set(preservationGuides.flatMap(g => g.methods.map(m => m.method)))
+    expect(new Set(inUse)).toEqual(allMethods)
+  })
+})

--- a/src/app/preserving/page.tsx
+++ b/src/app/preserving/page.tsx
@@ -36,7 +36,7 @@ function ResourceLinks({ resources }: { resources: PreservationResource[] }) {
 function GuideCard({ guide, name }: { guide: PreservationGuide; name: string }) {
   return (
     <details className="group px-4 py-3">
-      <summary className="flex flex-wrap items-center gap-2 cursor-pointer list-none min-h-[44px]">
+      <summary className="flex flex-wrap items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden min-h-[44px]">
         <span className="text-sm text-zen-ink-700 font-medium">{name}</span>
         <span className="flex flex-wrap gap-1.5">
           {guide.methods.map(m => (
@@ -152,12 +152,14 @@ export default function PreservingPage() {
               value={search}
               onChange={e => setSearch(e.target.value)}
               className="zen-input pl-10"
+              aria-label="Search crops"
             />
           </div>
           <select
             value={selectedMethod}
             onChange={e => setSelectedMethod(e.target.value as StorageMethod | 'all')}
             className="zen-select sm:w-48"
+            aria-label="Filter by preservation method"
           >
             <option value="all">All methods</option>
             {methodsInUse.map(m => (
@@ -168,6 +170,7 @@ export default function PreservingPage() {
             value={selectedCategory}
             onChange={e => setSelectedCategory(e.target.value as VegetableCategory | 'all')}
             className="zen-select sm:w-48"
+            aria-label="Filter by category"
           >
             <option value="all">All categories</option>
             {categoriesInUse.map(c => (

--- a/src/app/preserving/page.tsx
+++ b/src/app/preserving/page.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import Link from 'next/link'
+import { Search, ExternalLink } from 'lucide-react'
+import { vegetableIndex } from '@/lib/vegetables/index'
+import { CATEGORY_INFO, type StorageMethod, type VegetableCategory } from '@/types/garden-planner'
+import {
+  preservationGuides,
+  getMethodsInUse,
+  PRESERVATION_METHOD_LABELS,
+} from '@/lib/preservation'
+import type { PreservationGuide, PreservationResource } from '@/types/preservation'
+
+function ResourceLinks({ resources }: { resources: PreservationResource[] }) {
+  return (
+    <ul className="space-y-1">
+      {resources.map(r => (
+        <li key={r.url}>
+          <a
+            href={r.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-sm text-zen-water-700 hover:text-zen-water-800 hover:underline"
+          >
+            {r.title}
+            <ExternalLink className="w-3 h-3 shrink-0" />
+          </a>
+          <span className="text-xs text-zen-stone-400 ml-1.5">{r.source}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function GuideCard({ guide, name }: { guide: PreservationGuide; name: string }) {
+  return (
+    <details className="group px-4 py-3">
+      <summary className="flex flex-wrap items-center gap-2 cursor-pointer list-none min-h-[44px]">
+        <span className="text-sm text-zen-ink-700 font-medium">{name}</span>
+        <span className="flex flex-wrap gap-1.5">
+          {guide.methods.map(m => (
+            <span key={m.method} className="zen-badge-moss text-xs">
+              {PRESERVATION_METHOD_LABELS[m.method]}
+            </span>
+          ))}
+        </span>
+        <span className="ml-auto text-zen-stone-400 text-xs group-open:rotate-180 transition-transform">
+          ▾
+        </span>
+      </summary>
+
+      <div className="mt-3 space-y-4">
+        {guide.summary && (
+          <p className="text-sm text-zen-stone-600">{guide.summary}</p>
+        )}
+
+        {guide.methods.map(m => (
+          <div key={m.method}>
+            <h4 className="text-sm font-medium text-zen-ink-700 mb-1">
+              {PRESERVATION_METHOD_LABELS[m.method]}
+              {m.storageLife && (
+                <span className="font-normal text-zen-stone-500"> · keeps {m.storageLife}</span>
+              )}
+            </h4>
+            <p className="text-sm text-zen-ink-700 mb-1.5">{m.how}</p>
+            {m.resources && m.resources.length > 0 && (
+              <ResourceLinks resources={m.resources} />
+            )}
+          </div>
+        ))}
+
+        {guide.recipeIdeas && guide.recipeIdeas.length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium text-zen-ink-700 mb-1">Recipe ideas</h4>
+            <ResourceLinks resources={guide.recipeIdeas} />
+          </div>
+        )}
+
+        <Link
+          href={`/plants/${guide.plantId}`}
+          className="inline-block text-sm text-zen-moss-700 hover:text-zen-moss-800 hover:underline"
+        >
+          Growing guide for {name} →
+        </Link>
+      </div>
+    </details>
+  )
+}
+
+export default function PreservingPage() {
+  const [search, setSearch] = useState('')
+  const [selectedMethod, setSelectedMethod] = useState<StorageMethod | 'all'>('all')
+  const [selectedCategory, setSelectedCategory] = useState<VegetableCategory | 'all'>('all')
+
+  const indexById = useMemo(() => new Map(vegetableIndex.map(v => [v.id, v])), [])
+  const methodsInUse = useMemo(() => getMethodsInUse(), [])
+
+  // Categories that have at least one authored guide, in CATEGORY_INFO order
+  const categoriesInUse = useMemo(() => {
+    const inUse = new Set(
+      preservationGuides
+        .map(g => indexById.get(g.plantId)?.category)
+        .filter((c): c is VegetableCategory => c !== undefined)
+    )
+    return CATEGORY_INFO.filter(c => inUse.has(c.id))
+  }, [indexById])
+
+  const grouped = useMemo(() => {
+    const lowerSearch = search.toLowerCase()
+    const groups: Record<string, { guide: PreservationGuide; name: string }[]> = {}
+
+    for (const guide of preservationGuides) {
+      const entry = indexById.get(guide.plantId)
+      if (!entry) continue
+      if (selectedCategory !== 'all' && entry.category !== selectedCategory) continue
+      if (selectedMethod !== 'all' && !guide.methods.some(m => m.method === selectedMethod)) continue
+      if (
+        search &&
+        !entry.name.toLowerCase().includes(lowerSearch) &&
+        !guide.plantId.toLowerCase().includes(lowerSearch)
+      ) continue
+
+      if (!groups[entry.category]) groups[entry.category] = []
+      groups[entry.category].push({ guide, name: entry.name })
+    }
+    return groups
+  }, [search, selectedMethod, selectedCategory, indexById])
+
+  const categoryOrder = CATEGORY_INFO.filter(c => grouped[c.id]?.length)
+  const totalCount = Object.values(grouped).reduce((sum, g) => sum + g.length, 0)
+
+  return (
+    <div className="min-h-screen bg-zen-stone-50 zen-texture">
+      <div className="container mx-auto px-4 py-10 max-w-4xl">
+        <header className="mb-8">
+          <h1 className="text-zen-ink-900 mb-2">Preserving</h1>
+          <p className="text-zen-stone-500 text-lg">
+            How to store and preserve your harvest — from the fridge and freezer
+            to jams, chutneys, pickles, ferments and bakes. All linked resources
+            are free to read.
+          </p>
+        </header>
+
+        {/* Search and filters */}
+        <div className="flex flex-col sm:flex-row gap-3 mb-8">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zen-stone-400" />
+            <input
+              type="text"
+              placeholder="Search crops..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="zen-input pl-10"
+            />
+          </div>
+          <select
+            value={selectedMethod}
+            onChange={e => setSelectedMethod(e.target.value as StorageMethod | 'all')}
+            className="zen-select sm:w-48"
+          >
+            <option value="all">All methods</option>
+            {methodsInUse.map(m => (
+              <option key={m} value={m}>{PRESERVATION_METHOD_LABELS[m]}</option>
+            ))}
+          </select>
+          <select
+            value={selectedCategory}
+            onChange={e => setSelectedCategory(e.target.value as VegetableCategory | 'all')}
+            className="zen-select sm:w-48"
+          >
+            <option value="all">All categories</option>
+            {categoriesInUse.map(c => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <p className="text-sm text-zen-stone-500 mb-4">
+          {totalCount} {totalCount === 1 ? 'crop' : 'crops'} found
+        </p>
+
+        {categoryOrder.length === 0 ? (
+          <div className="zen-card p-8 text-center">
+            <p className="text-zen-stone-500">
+              {preservationGuides.length === 0
+                ? 'Preserving guides are on their way — check back soon.'
+                : 'No crops match your search.'}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {categoryOrder.map(cat => (
+              <section key={cat.id}>
+                <h2 className="text-lg mb-3">{cat.name}</h2>
+                <div className="zen-card divide-y divide-zen-stone-100">
+                  {grouped[cat.id]!.map(({ guide, name }) => (
+                    <GuideCard key={guide.plantId} guide={guide} name={name} />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -54,6 +54,7 @@ const primaryNavLinks = [
 // Secondary links shown in "More" dropdown
 export const secondaryLinks = [
   { href: '/seeds', label: 'Seeds', description: 'Inventory & varieties' },
+  { href: '/preserving', label: 'Preserving', description: 'Store & preserve your harvest' },
   { href: '/settings', label: 'Settings', description: 'Sync & preferences' },
 ]
 

--- a/src/lib/preservation/data/alliums.ts
+++ b/src/lib/preservation/data/alliums.ts
@@ -1,0 +1,11 @@
+/**
+ * Alliums — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: onion, garlic, leek, spring-onion,
+// shallot, welsh-onion, elephant-garlic, walking-onion, potato-onion,
+// garlic-chives, ramps
+export const alliumsPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/berries.ts
+++ b/src/lib/preservation/data/berries.ts
@@ -1,0 +1,12 @@
+/**
+ * Berries — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: strawberry, raspberry,
+// blackcurrant, redcurrant, gooseberry, blueberry, blackberry, tayberry,
+// loganberry, jostaberry, honeyberry, goji-berry, aronia, elderberry,
+// sea-buckthorn
+export const berriesPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/brassicas.ts
+++ b/src/lib/preservation/data/brassicas.ts
@@ -1,0 +1,11 @@
+/**
+ * Brassicas — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: broccoli, cabbage, cauliflower,
+// brussels-sprouts, kohlrabi, savoy-cabbage, red-cabbage, chinese-broccoli,
+// romanesco, turnip-tops, mibuna, seakale, purple-sprouting-broccoli
+export const brassicasPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/cucurbits.ts
+++ b/src/lib/preservation/data/cucurbits.ts
@@ -1,0 +1,203 @@
+/**
+ * Cucurbits — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ *
+ * This file is the exemplar for the other category files: short practical
+ * how-tos, storage life where known, shared resource constants from
+ * ../resources, and only URL slugs that have been verified to return 200.
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  GARDEN_ORGANIC_STORING,
+  UMN_HARVEST_STORAGE,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
+
+export const cucurbitsPreservation: PreservationGuide[] = [
+  {
+    plantId: 'courgette',
+    summary:
+      'The classic glut crop — one week in the fridge, then it is grate-and-freeze, chutney and cake territory.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in the salad drawer in a loose bag. Pick small and often — big marrows keep no better.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Grate raw and freeze in cake- or soup-sized portions, or blanch 1cm slices for 1 minute before bagging. Grated needs no blanching.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Courgette chutney is the best use for the ones that got away — cube, salt, then simmer with vinegar, sugar and spices.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [BBC_GOOD_FOOD.chutneys],
+      },
+      {
+        method: 'pickle',
+        how: 'Slice thinly, brine for an hour, then pack in a spiced sweet vinegar. Good in cheese sandwiches all winter.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('courgette', 'Courgette'),
+      bbcGoodFoodCollection('courgette-cake-recipes', 'Courgette cake recipes'),
+      BBC_GOOD_FOOD.glutCakes,
+    ],
+  },
+  {
+    plantId: 'squash',
+    summary: 'Cure well and winter squash will feed you until spring with no processing at all.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Cure in any late sun (or a greenhouse) for 10–14 days until the skin is too hard to mark with a thumbnail. Leave a stub of stalk on.',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store somewhere cool, dry and frost-free (10–15°C) with air around each fruit — a shelf, not a heap. Check monthly for soft spots.',
+        storageLife: '3–6 months depending on variety',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Roast or steam, mash, and freeze in tubs — ready for soup. Raw squash freezes badly.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('squash', 'Squash')],
+  },
+  {
+    plantId: 'pumpkin',
+    summary: 'Treat like winter squash: cure hard, store cool, and turn the flesh into soup and cakes.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Cure in the sun for 10–14 days until the skin hardens, keeping the stalk stub intact.',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store cool, dry and frost-free with space between fruits. Culinary varieties keep longer than carving types.',
+        storageLife: '2–4 months',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Cook and purée before freezing — perfect for soup, pie and baking. Never can pumpkin purée at home; freezing is the safe route.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('pumpkin', 'Pumpkin'),
+      bbcGoodFoodCollection('pumpkin-recipes', 'Pumpkin recipes'),
+    ],
+  },
+  {
+    plantId: 'patty-pan-squash',
+    summary: 'A summer squash like courgette — eat fresh and young, pickle the surplus.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in the salad drawer. Best picked small (5–8cm) and eaten within the week.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'pickle',
+        how: 'Small whole patty pans pickle beautifully in spiced vinegar — treat like gherkins.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling],
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch slices or halves for 1 minute, cool, and freeze flat on a tray before bagging.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [BBC_GOOD_FOOD.pickles],
+  },
+  {
+    plantId: 'butternut-squash',
+    summary: 'The best-keeping squash for Scottish kitchens if it ripens — cure hard and it stores for months.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Cure 10–14 days somewhere warm and airy until the skin dulls and hardens. Unripe green fruits still make good soup — use those first.',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store at 10–15°C, dry, with airflow. A spare-room shelf beats a cold shed — butternut dislikes storage below 10°C.',
+        storageLife: '3–6 months',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Roast and mash, or freeze raw cubes on a tray then bag — raw cubes hold together better than other squash.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('butternut_squash', 'Butternut squash')],
+  },
+  {
+    plantId: 'spaghetti-squash',
+    summary: 'Stores like other winter squash; the strands also freeze well once cooked.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Cure 10–14 days in sun or a greenhouse until the skin is hard and evenly yellow.',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store cool, dry and frost-free with space around each fruit.',
+        storageLife: '2–4 months',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Roast halves, fork out the strands, and freeze in meal-sized bags. Reheat from frozen in a pan.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('squash', 'Squash')],
+  },
+  {
+    plantId: 'acorn-squash',
+    summary: 'A shorter keeper than butternut — eat these first from the squash shelf.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Cure only briefly (5–7 days) — long curing shortens acorn squash storage rather than extending it.',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store cool and dry and plan to eat within a couple of months, before the flesh goes stringy.',
+        storageLife: '5–8 weeks',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Bake, scoop and mash before freezing in portions.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('squash', 'Squash')],
+  },
+]

--- a/src/lib/preservation/data/edible-extras.ts
+++ b/src/lib/preservation/data/edible-extras.ts
@@ -1,0 +1,11 @@
+/**
+ * Edible extras — Preserving guides
+ * Edible flowers and climbers that sit outside the vegetable/fruit categories.
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: nasturtium, calendula, lavender,
+// bergamot, hardy-kiwi, hops
+export const edibleExtrasPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/fruit-trees.ts
+++ b/src/lib/preservation/data/fruit-trees.ts
@@ -1,0 +1,11 @@
+/**
+ * Fruit Trees — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: apple-tree, pear-tree, plum-tree,
+// cherry-tree, damson-tree, greengage-tree, medlar-tree, quince-tree,
+// fig-tree, mulberry-tree
+export const fruitTreesPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/herbs.ts
+++ b/src/lib/preservation/data/herbs.ts
@@ -1,0 +1,12 @@
+/**
+ * Herbs — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: parsley, coriander, mint, thyme,
+// rosemary, chives, lovage, sorrel, oregano, sage, french-tarragon, dill,
+// herb-fennel, lemon-balm, marjoram, bay, borage, chamomile, winter-savory,
+// hyssop
+export const herbsPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/leafy-greens.ts
+++ b/src/lib/preservation/data/leafy-greens.ts
@@ -1,0 +1,12 @@
+/**
+ * Leafy Greens — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: lettuce, spinach, perpetual-spinach,
+// kale, cavolo-nero, chard, rocket, pak-choi, mizuna, land-cress, corn-salad,
+// winter-purslane, mustard-greens, watercress, salad-burnet, orache,
+// new-zealand-spinach, good-king-henry, radicchio, endive, ice-plant
+export const leafyGreensPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/legumes.ts
+++ b/src/lib/preservation/data/legumes.ts
@@ -1,0 +1,11 @@
+/**
+ * Legumes — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: peas, runner-beans, broad-beans,
+// french-beans, climbing-french-beans, borlotti-beans, edamame, mangetout,
+// sugar-snap-peas, asparagus-peas, black-turtle-beans, fenugreek, ground-nut
+export const legumesPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/mushrooms.ts
+++ b/src/lib/preservation/data/mushrooms.ts
@@ -1,0 +1,10 @@
+/**
+ * Mushrooms — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: oyster-mushroom, shiitake,
+// lions-mane, king-oyster, button-mushroom
+export const mushroomsPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/other.ts
+++ b/src/lib/preservation/data/other.ts
@@ -1,0 +1,10 @@
+/**
+ * Specialty Vegetables — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: sweetcorn, asparagus,
+// globe-artichoke, rhubarb, celery, cardoon, mashua
+export const otherPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/root-vegetables.ts
+++ b/src/lib/preservation/data/root-vegetables.ts
@@ -1,0 +1,12 @@
+/**
+ * Root Vegetables — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: carrot, beetroot, parsnip, turnip,
+// swede, radish, jerusalem-artichoke, celeriac, salsify, hamburg-parsley,
+// florence-fennel, mooli, black-radish, scorzonera, horseradish,
+// chinese-artichoke, yacon, skirret, oca, ulluco
+export const rootVegetablesPreservation: PreservationGuide[] = []

--- a/src/lib/preservation/data/solanaceae.ts
+++ b/src/lib/preservation/data/solanaceae.ts
@@ -1,0 +1,11 @@
+/**
+ * Solanaceae — Preserving guides
+ * Authoring spec: docs/plans/food-preservation-plan.md
+ */
+
+import { PreservationGuide } from '@/types/preservation'
+
+// TODO(preserving-data): author guides for: potato, early-potato,
+// second-early-potato, maincrop-potato, cherry-tomato, plum-tomato,
+// blight-resistant-tomato, tomatillo
+export const solanaceaePreservation: PreservationGuide[] = []

--- a/src/lib/preservation/index.ts
+++ b/src/lib/preservation/index.ts
@@ -1,0 +1,67 @@
+/**
+ * Preserving guides — aggregated data and lookups
+ *
+ * Rich per-crop preservation guidance (how-tos, storage life, free online
+ * resources, recipe ideas) for the /preserving section. Data is authored in
+ * per-category files under ./data so categories can be filled independently.
+ *
+ * This module is only imported by the /preserving route, so the dataset is
+ * code-split away from the rest of the app automatically.
+ */
+
+import { StorageMethod } from '@/types/garden-planner'
+import { PreservationGuide } from '@/types/preservation'
+import { leafyGreensPreservation } from './data/leafy-greens'
+import { rootVegetablesPreservation } from './data/root-vegetables'
+import { brassicasPreservation } from './data/brassicas'
+import { legumesPreservation } from './data/legumes'
+import { solanaceaePreservation } from './data/solanaceae'
+import { cucurbitsPreservation } from './data/cucurbits'
+import { alliumsPreservation } from './data/alliums'
+import { herbsPreservation } from './data/herbs'
+import { berriesPreservation } from './data/berries'
+import { fruitTreesPreservation } from './data/fruit-trees'
+import { otherPreservation } from './data/other'
+import { mushroomsPreservation } from './data/mushrooms'
+import { edibleExtrasPreservation } from './data/edible-extras'
+
+export const preservationGuides: PreservationGuide[] = [
+  ...leafyGreensPreservation,
+  ...rootVegetablesPreservation,
+  ...brassicasPreservation,
+  ...legumesPreservation,
+  ...solanaceaePreservation,
+  ...cucurbitsPreservation,
+  ...alliumsPreservation,
+  ...herbsPreservation,
+  ...berriesPreservation,
+  ...fruitTreesPreservation,
+  ...otherPreservation,
+  ...mushroomsPreservation,
+  ...edibleExtrasPreservation,
+]
+
+const guideById = new Map(preservationGuides.map(g => [g.plantId, g]))
+
+export function getPreservationGuide(plantId: string): PreservationGuide | undefined {
+  return guideById.get(plantId)
+}
+
+/** Human labels for each preservation method, shared across the UI */
+export const PRESERVATION_METHOD_LABELS: Record<StorageMethod, string> = {
+  fresh: 'Best fresh',
+  fridge: 'Fridge',
+  'store-cool': 'Store cool',
+  freeze: 'Freeze',
+  dry: 'Dry',
+  cure: 'Cure first',
+  pickle: 'Pickle',
+  jam: 'Jam / chutney',
+  ferment: 'Ferment',
+}
+
+/** Methods that appear in at least one authored guide, in label order */
+export function getMethodsInUse(): StorageMethod[] {
+  const inUse = new Set(preservationGuides.flatMap(g => g.methods.map(m => m.method)))
+  return (Object.keys(PRESERVATION_METHOD_LABELS) as StorageMethod[]).filter(m => inUse.has(m))
+}

--- a/src/lib/preservation/resources.ts
+++ b/src/lib/preservation/resources.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared free online resources for preserving guides.
+ *
+ * Every URL here was fetch-verified as free to read (no paywall or sign-up).
+ * Reuse these constants in the per-category data files rather than repeating
+ * URLs, so a moved page only needs fixing in one place.
+ *
+ * Verified: 2026-07-04
+ */
+
+import { PreservationResource } from '@/types/preservation'
+
+// --- Method guides (authoritative, research-based) ---
+
+/** National Center for Home Food Preservation (University of Georgia) */
+export const NCHFP = {
+  home: { title: 'Home food preservation methods', url: 'https://nchfp.uga.edu/', source: 'NCHFP' },
+  canning: { title: 'How do I? Can', url: 'https://nchfp.uga.edu/how/can/', source: 'NCHFP' },
+  freezing: { title: 'How do I? Freeze', url: 'https://nchfp.uga.edu/how/freeze/', source: 'NCHFP' },
+  drying: { title: 'How do I? Dry', url: 'https://nchfp.uga.edu/how/dry/', source: 'NCHFP' },
+  pickling: { title: 'How do I? Pickle', url: 'https://nchfp.uga.edu/how/pickle/', source: 'NCHFP' },
+  fermenting: { title: 'How do I? Ferment', url: 'https://nchfp.uga.edu/how/ferment/', source: 'NCHFP' },
+  jams: { title: 'How do I? Make jam & jelly', url: 'https://nchfp.uga.edu/how/make-jam-jelly/', source: 'NCHFP' },
+} satisfies Record<string, PreservationResource>
+
+/** USDA Complete Guide to Home Canning — free PDFs */
+export const USDA_CANNING_GUIDE: PreservationResource = {
+  title: 'USDA Complete Guide to Home Canning',
+  url: 'https://nchfp.uga.edu/resources/category/usda-guide',
+  source: 'USDA',
+}
+
+// --- UK storing & food-safety guidance ---
+
+export const RHS_STORING_FRUIT: PreservationResource = {
+  title: 'Storing apples, pears, quince and medlar',
+  url: 'https://www.rhs.org.uk/fruit/fruit-trees/storing',
+  source: 'RHS',
+}
+
+export const RHS_ONIONS: PreservationResource = {
+  title: 'Growing, harvesting and storing onions',
+  url: 'https://www.rhs.org.uk/vegetables/onions/grow-your-own',
+  source: 'RHS',
+}
+
+export const GARDEN_ORGANIC_STORING: PreservationResource = {
+  title: 'Harvesting and storing vegetables',
+  url: 'https://www.gardenorganic.org.uk/expert-advice/garden-management/harvesting-and-storage/harvesting-and-storing-vegetables',
+  source: 'Garden Organic',
+}
+
+export const FSA_FOOD_FACT_CHECKER: PreservationResource = {
+  title: 'Home food fact checker (storage & freezing safety)',
+  url: 'https://www.gov.uk/government/publications/home-food-fact-checker',
+  source: 'Food Standards Agency',
+}
+
+// --- University extension guides (US, free, crop-by-crop) ---
+
+export const PSU_LETS_PRESERVE: PreservationResource = {
+  title: "'Let's Preserve' fact sheets (crop by crop)",
+  url: 'https://extension.psu.edu/food-safety-and-quality/home-food-preservation-and-safety/lets-preserve',
+  source: 'Penn State Extension',
+}
+
+export const UMN_PRESERVING: PreservationResource = {
+  title: 'How to preserve your own food',
+  url: 'https://extension.umn.edu/food-safety/preserving-and-preparing',
+  source: 'UMN Extension',
+}
+
+export const UMN_HARVEST_STORAGE: PreservationResource = {
+  title: 'Harvesting and storing home garden vegetables',
+  url: 'https://extension.umn.edu/planting-and-growing-guides/harvesting-and-storing-home-garden-vegetables',
+  source: 'UMN Extension',
+}
+
+export const UMN_SAUERKRAUT: PreservationResource = {
+  title: 'How to make your own sauerkraut (fermentation basics)',
+  url: 'https://extension.umn.edu/preserving-and-preparing/how-make-your-own-sauerkraut',
+  source: 'UMN Extension',
+}
+
+// --- Recipe hubs (free, UK) ---
+
+/**
+ * BBC Food per-ingredient hub, e.g. bbcFoodIngredient('courgette', 'Courgette').
+ * Slug pattern: lowercase, singular, underscores for spaces ('runner_bean').
+ * Always spot-check the slug returns 200 before adding it to a guide.
+ */
+export function bbcFoodIngredient(slug: string, label: string): PreservationResource {
+  return {
+    title: `${label} recipes`,
+    url: `https://www.bbc.co.uk/food/${slug}`,
+    source: 'BBC Food',
+  }
+}
+
+/**
+ * BBC Good Food collection, e.g. bbcGoodFoodCollection('jam-recipes', 'Jam recipes').
+ * Only use slugs verified to return 200 — there is no generic 'chutney-recipes'
+ * or 'glut-recipes' collection.
+ */
+export function bbcGoodFoodCollection(slug: string, label: string): PreservationResource {
+  return {
+    title: label,
+    url: `https://www.bbcgoodfood.com/recipes/collection/${slug}`,
+    source: 'BBC Good Food',
+  }
+}
+
+/** Verified BBC Good Food collections useful across many crops */
+export const BBC_GOOD_FOOD = {
+  jams: bbcGoodFoodCollection('jam-recipes', 'Jam recipes'),
+  pickles: bbcGoodFoodCollection('pickle-recipes', 'Pickle recipes'),
+  chutneys: bbcGoodFoodCollection('pickles-jams-and-chutneys-recipes', 'Pickles, jams & chutneys'),
+  glutCakes: bbcGoodFoodCollection('garden-glut-cake-recipes', 'Garden glut cakes'),
+} satisfies Record<string, PreservationResource>
+
+export const RIVER_COTTAGE_RECIPES: PreservationResource = {
+  title: 'River Cottage recipes (filter by Preserves)',
+  url: 'https://www.rivercottage.net/recipes',
+  source: 'River Cottage',
+}
+
+export const WIKIBOOKS_COOKBOOK: PreservationResource = {
+  title: 'Wikibooks Cookbook (canning, fermenting, pickling techniques)',
+  url: 'https://en.wikibooks.org/wiki/Cookbook:Table_of_Contents',
+  source: 'Wikibooks',
+}

--- a/src/types/garden-planner.ts
+++ b/src/types/garden-planner.ts
@@ -378,6 +378,7 @@ export const CATEGORY_INFO: CategoryInfo[] = [
   { id: 'herbs', name: 'Herbs', icon: 'Flower', color: 'emerald' },
   { id: 'berries', name: 'Berries', icon: 'Cherry', color: 'pink' },
   { id: 'fruit-trees', name: 'Fruit Trees', icon: 'TreeDeciduous', color: 'rose' },
+  { id: 'other', name: 'Specialty Vegetables', icon: 'Sprout', color: 'slate' },
   { id: 'annual-flowers', name: 'Annual Flowers', icon: 'Flower2', color: 'fuchsia' },
   { id: 'perennial-flowers', name: 'Perennial Flowers', icon: 'Sparkles', color: 'violet' },
   { id: 'bulbs', name: 'Bulbs', icon: 'Droplet', color: 'indigo' },

--- a/src/types/preservation.ts
+++ b/src/types/preservation.ts
@@ -1,0 +1,39 @@
+/**
+ * Preserving guide types (Preserving section)
+ *
+ * Rich per-plant preservation guidance that builds on the lightweight
+ * `Vegetable.storage` field (Milestone C). Where `storage` answers
+ * "which methods work?", a PreservationGuide answers "how do I actually
+ * do it, how long does it keep, and where can I read more?".
+ */
+
+import { StorageMethod } from './garden-planner'
+
+/** A free online resource (guide or recipe) — no paywalls, no sign-up walls */
+export interface PreservationResource {
+  title: string
+  url: string
+  /** Publisher, e.g. 'NCHFP', 'BBC Good Food', 'RHS' */
+  source: string
+}
+
+/** How to apply one preservation method to one crop */
+export interface PreservationMethodGuide {
+  method: StorageMethod
+  /** Short practical instructions (1-3 sentences) */
+  how: string
+  /** How long it keeps this way, e.g. '10-12 months in the freezer' */
+  storageLife?: string
+  resources?: PreservationResource[]
+}
+
+/** Full preserving guide for one crop */
+export interface PreservationGuide {
+  /** Matches a `vegetableIndex` id */
+  plantId: string
+  /** One-line orientation, e.g. glut warning or best-use advice */
+  summary?: string
+  methods: PreservationMethodGuide[]
+  /** Ways to eat it up — cakes, bakes, soups, cordials, glut recipes */
+  recipeIdeas?: PreservationResource[]
+}

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -112,6 +112,25 @@ test.describe('Accessibility - Compost Page', () => {
   })
 })
 
+test.describe('Accessibility - Preserving Page', () => {
+  test('preserving page should have no critical accessibility violations', async ({ page }) => {
+    await page.goto('/preserving')
+    await disableTours(page)
+    await checkA11y(page)
+  })
+
+  test('preserving page with expanded card should be accessible', async ({ page }) => {
+    await page.goto('/preserving')
+    await disableTours(page)
+    const summary = page.locator('details summary').first()
+    if (await summary.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await summary.click()
+      await page.waitForTimeout(200)
+      await checkA11y(page)
+    }
+  })
+})
+
 test.describe('Accessibility - Navigation', () => {
   // Helper to skip onboarding by marking setup as complete
   async function skipOnboarding(page: import('@playwright/test').Page) {

--- a/tests/preserving.spec.ts
+++ b/tests/preserving.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test'
+
+async function disableTours(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    localStorage.setItem('bonnie-wee-plot-tours', JSON.stringify({ disabled: true, completed: [], dismissed: [], pageVisits: {} }))
+  })
+}
+
+test.describe('Preserving Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/preserving')
+    await disableTours(page)
+  })
+
+  test('should load with heading and crop guides', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Preserving', exact: true })).toBeVisible()
+    // Cucurbits are authored — courgette should be listed
+    await expect(page.locator('details summary').filter({ hasText: 'Courgette' })).toBeVisible()
+    await expect(page.getByText(/\d+ crops? found/)).toBeVisible()
+  })
+
+  test('search should filter crops', async ({ page }) => {
+    await page.getByLabel('Search crops').fill('pumpkin')
+    await expect(page.locator('details summary').filter({ hasText: 'Pumpkin' })).toBeVisible()
+    await expect(page.locator('details summary').filter({ hasText: 'Courgette' })).toBeHidden()
+
+    await page.getByLabel('Search crops').fill('zzz-no-such-crop')
+    await expect(page.getByText('No crops match your search.')).toBeVisible()
+  })
+
+  test('method filter should narrow the list', async ({ page }) => {
+    await page.getByLabel('Filter by preservation method').selectOption('cure')
+    // Courgette has no cure method; winter squash does
+    await expect(page.locator('details summary').filter({ hasText: 'Winter Squash' })).toBeVisible()
+    await expect(page.locator('details summary').filter({ hasText: 'Courgette' })).toBeHidden()
+  })
+
+  test('card should expand with method details and external links', async ({ page }) => {
+    const card = page.locator('details').filter({
+      has: page.locator('summary', { hasText: 'Courgette' }),
+    })
+    await card.locator('summary').click()
+
+    await expect(card.getByText(/grate raw and freeze/i)).toBeVisible()
+
+    // External resource links open in a new tab
+    const externalLink = card.locator('a[href^="https://"]').first()
+    await expect(externalLink).toHaveAttribute('target', '_blank')
+    await expect(externalLink).toHaveAttribute('rel', /noopener/)
+
+    // Cross-link to the plant guide
+    await expect(card.locator('a[href="/plants/courgette"]')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

New `/preserving` section: rich per-crop guides on how to store and preserve the harvest — fridge/freezer, drying, curing, pickling, fermenting, jams/chutneys — plus recipe ideas (glut cakes, bakes, soups), each linked to fetch-verified **free** online resources (NCHFP, USDA, RHS, Garden Organic, FSA, Penn State/UMN extensions, BBC Food, BBC Good Food, River Cottage, Wikibooks). Builds on the lightweight `Vegetable.storage` chips from Milestone C.

**What's in this PR:**
- `PreservationGuide` types (`src/types/preservation.ts`)
- `src/lib/preservation/`: aggregator + shared verified-resource constants + 14 per-category data files, structured so each remaining category can be filled by an **independent parallel session with no merge conflicts**
- `cucurbits.ts` fully authored (7 crops) as the exemplar authoring pattern
- `/preserving` page (search, method/category filters, expandable cards, cross-links to `/plants/[id]`) and a "Preserving" link in the More menu
- Data-integrity unit tests (real plant ids, unique ids, non-empty how-tos, https-only URLs)
- `docs/plans/food-preservation-plan.md`: authoring spec, link-verification rules, verified resource library, and **10 parallel session goals** covering the ~149 remaining edible crops, plus a final integration session

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes (lint, type-check, 1124 unit tests, production build, homepage + accessibility Playwright specs on chromium, and a rendered-page smoke check of `/preserving`)
- [x] I have updated documentation if needed (CLAUDE.md architecture note, current-plan.md, new plan doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H51oQNQdLEC4pjPsX1g1E2

---
_Generated by [Claude Code](https://claude.ai/code/session_01H51oQNQdLEC4pjPsX1g1E2)_