### PR TITLE
Preserving final integration: plant-page cross-links, coverage test, authoring spec relocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Rich per-crop preservation guidance (method how-tos, storage life, free online r
 - `src/lib/preservation/resources.ts` - shared fetch-verified free resources (NCHFP, RHS, Garden Organic, BBC Food, etc.)
 - `src/lib/preservation/data/*.ts` - per-category guide files (parallel-authoring-safe)
 
-Authoring spec and per-category session goals: `docs/plans/food-preservation-plan.md`.
+Authoring spec and per-category session goals: `src/lib/preservation/data/README.md`. Plant detail pages cross-link to `/preserving?plant=<id>` (deep link expands that crop's card) when a guide exists. A coverage test (`src/__tests__/lib/preservation-coverage.test.ts`) asserts every crop whose `storage.methods` include a preserve method (freeze/jam/pickle/ferment/dry) has a guide, with a shrinking `PENDING_GUIDES` list for the categories not yet authored.
 
 ### Key Type Definitions
 

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,6 @@
 # Current Plan
 
-Last updated: 2026-05-19 (ADR 027 Yjs Step 3 Phase 1 cutover live — PR-A.2 wired cloud sync into the Yjs doc, PR-C flipped `USE_YJS_STORAGE` to default-on, the deployment-runbook `UPDATE allotments SET data = data` ran against production Supabase seeding pre-cutover history rows for both users; soak window now open, Step 5 cleanup is the next deliberate work)
+Last updated: 2026-07-05 (Preserving final integration session — plant-page ↔ /preserving cross-links with `?plant=` deep link, guide coverage test with shrinking `PENDING_GUIDES` list, Preserving stays in the More menu, authoring spec relocated to `src/lib/preservation/data/README.md` and the plan file deleted; the 10 data-authoring sessions are still to run)
 
 ## What's Been Completed
 
@@ -584,20 +584,49 @@ the full unit suite (1124) pass.
 
 The soak window is open. Success criterion is qualitative for the two-user cohort: both real users use the app on the flag for ~3–5 days each, run at least one manual cross-device conflict (edit on phone and laptop, watch the conflict-replace path actually re-hydrate the Yjs doc from cloud), and report no data anomalies. The Yjs binary on each device is the source of truth from this point; the legacy `allotment-unified-data` localStorage key is being mirrored from Yjs and is the rollback floor. Step 5 then deletes `useSyncedStorage`, the legacy branch of every domain-hook method, `useYjsToLegacyMirror`, the `bwp-storage-flag` BroadcastChannel, the legacy localStorage key, and the same-tab broadcast apparatus from PR #369 (the `bonnie:storage-update` CustomEvent, the `instanceId`/`sameTabSeq` bookkeeping, the `recordSavedState`/`recordAdoptedState` helpers, the `recentSavesRef` echo dedup) — every line of that broadcast becomes redundant the day the legacy chain leaves the tree. `serializeToJson` and `decodeDocState` stay forever (rollback + GDPR export + debug). Separate follow-ups worth filing: rename `src/lib/yjs-spike/` → `src/lib/yjs/`, consolidate `src/hooks/allotment/yjs-helpers.ts` with the now-internal `assignDefined` in `allotment-yjs.ts`, and tighten the still-`addInitScript`-pattern Playwright seeds (homepage / onboarding / boost-this-bed) to also clear Yjs IDB if those tests start contaminating each other later.
 
-### Preserving section — foundation shipped, data authoring planned (branch `claude/food-preservation-section-akmsdt`)
+### Preserving section — foundation + integration shipped, data authoring remaining
 
 New `/preserving` section: rich per-crop preservation guides (method how-tos,
 storage life, fetch-verified free resource links, recipe ideas including cakes
 and glut bakes) building on the lightweight `Vegetable.storage` chips from
-Milestone C. Foundation shipped: `src/types/preservation.ts`,
+Milestone C. Foundation shipped in #448: `src/types/preservation.ts`,
 `src/lib/preservation/` (aggregator + shared verified resources + 14
 per-category data files), the `/preserving` page (search, method/category
-filters, expandable cards), a "Preserving" link in the More menu, and data
-integrity unit tests. `cucurbits.ts` is fully authored (7 crops) as the
-exemplar. Remaining: ~149 crops across 10 parallel-safe authoring sessions
-(one data file each) plus a final integration session —
-see `docs/plans/food-preservation-plan.md` for the session goals, authoring
-spec, and verified resource library.
+filters, expandable cards), a "Preserving" link in the More menu, data
+integrity unit tests, and `tests/preserving.spec.ts`. `cucurbits.ts` is fully
+authored (7 crops) as the exemplar.
+
+The final integration session (branch
+`claude/food-preservation-integration-qgn705`) ran ahead of the data sessions
+since all its pieces are forward-compatible:
+
+- **Cross-link:** the Storage & Preserving panel on `/plants/[id]` links to
+  `/preserving?plant=<id>` whenever a guide exists (server-side lookup, so the
+  preservation dataset stays out of other client bundles). The `/preserving`
+  page reads the `plant` query param (via `useSearchParams` in a Suspense
+  boundary) and renders that crop's card expanded and scrolled into view. E2E
+  coverage added for both directions.
+- **Coverage test:** `src/__tests__/lib/preservation-coverage.test.ts` asserts
+  every crop whose `storage.methods` include a preserve method
+  (`PRESERVE_METHODS` — freeze/jam/pickle/ferment/dry, now exported from
+  `task-generator.ts`) has a `PreservationGuide`. Because the 10 data-authoring
+  sessions had not merged yet, the 103 currently-unauthored crops sit in an
+  explicit `PENDING_GUIDES` list; a companion test fails on stale entries, so
+  each data session must delete its crops from the list and the check tightens
+  automatically to full enforcement when the list empties.
+- **Nav decision:** Preserving **stays in the More menu** for now. Only 7 of
+  ~110 preserve-method crops have guides, primary nav is already at five slots,
+  and the Simplicity First principle says don't promote until usage earns it.
+  Revisit once the data sessions land and there is usage evidence.
+- **Doc hygiene:** `docs/plans/food-preservation-plan.md` deleted. The
+  authoring spec, session table, link rules, and verified resource library the
+  pending sessions still need moved to `src/lib/preservation/data/README.md`
+  (colocated with the data files); CLAUDE.md pointer updated. Sunflower (dry
+  seeds, missed by the original plan) was added to session 10's crop list.
+
+Remaining: ~103 crops across 10 parallel-safe authoring sessions (one data
+file each) — see `src/lib/preservation/data/README.md` for session goals,
+authoring spec, and the verified resource library.
 
 ### Research-Driven Improvements: Backlog
 

--- a/src/__tests__/lib/preservation-coverage.test.ts
+++ b/src/__tests__/lib/preservation-coverage.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { vegetables } from '@/lib/vegetable-database'
+import { preservationGuides } from '@/lib/preservation'
+import { PRESERVE_METHODS } from '@/lib/task-generator'
+
+/**
+ * Crops whose PreservationGuide is still to be authored. Each parallel
+ * authoring session (see src/lib/preservation/data/README.md) removes its
+ * crops from this list as it fills its data file — the "no stale entries"
+ * test below fails if an authored crop is left behind here. When the list is
+ * empty, delete it and inline `[]`.
+ *
+ * Grouped by authoring session for easy removal; the grouping comments are
+ * navigational only (e.g. radish lives in the root-vegetables session even
+ * though its database category is brassicas).
+ */
+const PENDING_GUIDES = new Set<string>([
+  // leafy-greens session
+  'spinach',
+  'perpetual-spinach',
+  'kale',
+  'cavolo-nero',
+  'chard',
+  'pak-choi',
+  'mustard-greens',
+  'orache',
+  'new-zealand-spinach',
+  'good-king-henry',
+  // root-vegetables session
+  'beetroot',
+  'radish',
+  'mooli',
+  'horseradish',
+  // brassicas session
+  'cabbage',
+  'broccoli',
+  'purple-sprouting-broccoli',
+  'cauliflower',
+  'brussels-sprouts',
+  'kohlrabi',
+  'savoy-cabbage',
+  'red-cabbage',
+  'chinese-broccoli',
+  'romanesco',
+  'turnip-tops',
+  // legumes session
+  'peas',
+  'runner-beans',
+  'broad-beans',
+  'french-beans',
+  'climbing-french-beans',
+  'borlotti-beans',
+  'edamame',
+  'mangetout',
+  'sugar-snap-peas',
+  'asparagus-peas',
+  'black-turtle-beans',
+  'fenugreek',
+  // solanaceae session
+  'cherry-tomato',
+  'plum-tomato',
+  'blight-resistant-tomato',
+  'tomatillo',
+  // alliums session
+  'spring-onion',
+  'welsh-onion',
+  'garlic-chives',
+  'ramps',
+  // herbs session
+  'parsley',
+  'coriander',
+  'mint',
+  'thyme',
+  'rosemary',
+  'chives',
+  'lovage',
+  'sorrel',
+  'oregano',
+  'sage',
+  'french-tarragon',
+  'dill',
+  'herb-fennel',
+  'lemon-balm',
+  'marjoram',
+  'bay',
+  'chamomile',
+  'winter-savory',
+  'hyssop',
+  // berries session
+  'strawberry',
+  'raspberry',
+  'blackcurrant',
+  'redcurrant',
+  'gooseberry',
+  'blueberry',
+  'blackberry',
+  'tayberry',
+  'loganberry',
+  'jostaberry',
+  'honeyberry',
+  'goji-berry',
+  'aronia',
+  'elderberry',
+  'sea-buckthorn',
+  // fruit-trees session
+  'apple-tree',
+  'pear-tree',
+  'plum-tree',
+  'cherry-tree',
+  'damson-tree',
+  'greengage-tree',
+  'medlar-tree',
+  'quince-tree',
+  'fig-tree',
+  'mulberry-tree',
+  // other + mushrooms + edible-extras session
+  'sweetcorn',
+  'asparagus',
+  'globe-artichoke',
+  'rhubarb',
+  'celery',
+  'oyster-mushroom',
+  'shiitake',
+  'nasturtium',
+  'calendula',
+  'lavender',
+  'bergamot',
+  'hardy-kiwi',
+  'hops',
+  'sunflower',
+])
+
+describe('Preservation guide coverage', () => {
+  const preserveMethodSet = new Set(PRESERVE_METHODS)
+  const preserveCrops = vegetables.filter(v =>
+    v.storage?.methods.some(m => preserveMethodSet.has(m))
+  )
+  const covered = new Set(preservationGuides.map(g => g.plantId))
+
+  it('every crop with a preserve storage method has a guide (or is pending authoring)', () => {
+    const missing = preserveCrops
+      .filter(v => !covered.has(v.id) && !PENDING_GUIDES.has(v.id))
+      .map(v => v.id)
+    expect(
+      missing,
+      'These crops advertise a preserve method (freeze/jam/pickle/ferment/dry) in ' +
+        'Vegetable.storage but have no PreservationGuide. Author one in ' +
+        'src/lib/preservation/data/ following data/README.md.'
+    ).toEqual([])
+  })
+
+  it('pending list has no stale entries for crops that now have guides', () => {
+    const stale = [...PENDING_GUIDES].filter(id => covered.has(id))
+    expect(
+      stale,
+      'These crops have guides now — remove them from PENDING_GUIDES in this test.'
+    ).toEqual([])
+  })
+
+  it('pending list only contains real crops with a preserve storage method', () => {
+    const preserveIds = new Set(preserveCrops.map(v => v.id))
+    const bogus = [...PENDING_GUIDES].filter(id => !preserveIds.has(id))
+    expect(
+      bogus,
+      'These PENDING_GUIDES entries are not preserve-method crops (typo or storage data changed).'
+    ).toEqual([])
+  })
+
+  it('the coverage check is non-vacuous', () => {
+    expect(preserveCrops.length).toBeGreaterThan(50)
+    expect(covered.size).toBeGreaterThan(0)
+  })
+})

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { Metadata } from 'next'
 import { getVegetableById } from '@/lib/vegetable-database'
 import { vegetableIndex } from '@/lib/vegetables/index'
+import { getPreservationGuide } from '@/lib/preservation'
 import {
   MONTH_NAMES_SHORT,
   CATEGORY_INFO,
@@ -153,6 +154,7 @@ const STORAGE_METHOD_LABELS: Record<StorageMethod, string> = {
 function StoragePanel({ plant }: { plant: Vegetable }) {
   if (!plant.storage) return null
   const { methods, freshDays, tip } = plant.storage
+  const hasGuide = getPreservationGuide(plant.id) !== undefined
 
   return (
     <div>
@@ -172,6 +174,14 @@ function StoragePanel({ plant }: { plant: Vegetable }) {
         </p>
       )}
       {tip && <p className="text-sm text-zen-ink-700">{tip}</p>}
+      {hasGuide && (
+        <Link
+          href={`/preserving?plant=${plant.id}`}
+          className="inline-block mt-3 text-sm text-zen-moss-700 hover:text-zen-moss-800 hover:underline"
+        >
+          Preserving guide for {plant.name} →
+        </Link>
+      )}
     </div>
   )
 }

--- a/src/app/preserving/page.tsx
+++ b/src/app/preserving/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect, useRef, Suspense } from 'react'
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
 import { Search, ExternalLink } from 'lucide-react'
 import { vegetableIndex } from '@/lib/vegetables/index'
 import { CATEGORY_INFO, type StorageMethod, type VegetableCategory } from '@/types/garden-planner'
@@ -33,9 +34,24 @@ function ResourceLinks({ resources }: { resources: PreservationResource[] }) {
   )
 }
 
-function GuideCard({ guide, name }: { guide: PreservationGuide; name: string }) {
+function GuideCard({
+  guide,
+  name,
+  defaultOpen = false,
+}: {
+  guide: PreservationGuide
+  name: string
+  defaultOpen?: boolean
+}) {
+  const detailsRef = useRef<HTMLDetailsElement>(null)
+
+  // Deep links (/preserving?plant=<id>) land expanded and scrolled into view
+  useEffect(() => {
+    if (defaultOpen) detailsRef.current?.scrollIntoView({ block: 'start' })
+  }, [defaultOpen])
+
   return (
-    <details className="group px-4 py-3">
+    <details ref={detailsRef} open={defaultOpen || undefined} className="group px-4 py-3">
       <summary className="flex flex-wrap items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden min-h-[44px]">
         <span className="text-sm text-zen-ink-700 font-medium">{name}</span>
         <span className="flex flex-wrap gap-1.5">
@@ -88,10 +104,12 @@ function GuideCard({ guide, name }: { guide: PreservationGuide; name: string }) 
   )
 }
 
-export default function PreservingPage() {
+function PreservingContent() {
   const [search, setSearch] = useState('')
   const [selectedMethod, setSelectedMethod] = useState<StorageMethod | 'all'>('all')
   const [selectedCategory, setSelectedCategory] = useState<VegetableCategory | 'all'>('all')
+  // ?plant=<id> deep link from the plant detail page expands that crop's card
+  const highlightedPlantId = useSearchParams().get('plant')
 
   const indexById = useMemo(() => new Map(vegetableIndex.map(v => [v.id, v])), [])
   const methodsInUse = useMemo(() => getMethodsInUse(), [])
@@ -198,7 +216,12 @@ export default function PreservingPage() {
                 <h2 className="text-lg mb-3">{cat.name}</h2>
                 <div className="zen-card divide-y divide-zen-stone-100">
                   {grouped[cat.id]!.map(({ guide, name }) => (
-                    <GuideCard key={guide.plantId} guide={guide} name={name} />
+                    <GuideCard
+                      key={guide.plantId}
+                      guide={guide}
+                      name={name}
+                      defaultOpen={guide.plantId === highlightedPlantId}
+                    />
                   ))}
                 </div>
               </section>
@@ -207,5 +230,14 @@ export default function PreservingPage() {
         )}
       </div>
     </div>
+  )
+}
+
+// useSearchParams requires a Suspense boundary during static generation
+export default function PreservingPage() {
+  return (
+    <Suspense fallback={null}>
+      <PreservingContent />
+    </Suspense>
   )
 }

--- a/src/app/preserving/page.tsx
+++ b/src/app/preserving/page.tsx
@@ -45,13 +45,19 @@ function GuideCard({
 }) {
   const detailsRef = useRef<HTMLDetailsElement>(null)
 
-  // Deep links (/preserving?plant=<id>) land expanded and scrolled into view
+  // Deep links (/preserving?plant=<id>) land expanded and scrolled into view.
+  // Opened imperatively (not via the `open` prop) so the <details> stays
+  // uncontrolled — the user can close it and React never re-applies the
+  // attribute — and so the prerendered (param-less) HTML matches hydration.
   useEffect(() => {
-    if (defaultOpen) detailsRef.current?.scrollIntoView({ block: 'start' })
+    if (defaultOpen && detailsRef.current) {
+      detailsRef.current.open = true
+      detailsRef.current.scrollIntoView({ block: 'start' })
+    }
   }, [defaultOpen])
 
   return (
-    <details ref={detailsRef} open={defaultOpen || undefined} className="group px-4 py-3">
+    <details ref={detailsRef} className="group px-4 py-3">
       <summary className="flex flex-wrap items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden min-h-[44px]">
         <span className="text-sm text-zen-ink-700 font-medium">{name}</span>
         <span className="flex flex-wrap gap-1.5">
@@ -108,8 +114,16 @@ function PreservingContent() {
   const [search, setSearch] = useState('')
   const [selectedMethod, setSelectedMethod] = useState<StorageMethod | 'all'>('all')
   const [selectedCategory, setSelectedCategory] = useState<VegetableCategory | 'all'>('all')
-  // ?plant=<id> deep link from the plant detail page expands that crop's card
+  // ?plant=<id> deep link from the plant detail page expands that crop's card.
+  // The param is consumed (stripped from the URL) once the card has opened —
+  // child effects run first — so later re-renders, remounts, and reloads
+  // don't re-expand or re-scroll a card the user has closed.
   const highlightedPlantId = useSearchParams().get('plant')
+  useEffect(() => {
+    if (highlightedPlantId) {
+      window.history.replaceState(null, '', window.location.pathname)
+    }
+  }, [highlightedPlantId])
 
   const indexById = useMemo(() => new Map(vegetableIndex.map(v => [v.id, v])), [])
   const methodsInUse = useMemo(() => getMethodsInUse(), [])

--- a/src/lib/preservation/data/README.md
+++ b/src/lib/preservation/data/README.md
@@ -1,23 +1,11 @@
-# Preserving Section — Data Authoring Plan
+# Preserving guides — authoring spec
 
-Status: **foundation shipped** on `claude/food-preservation-section-akmsdt`.
-This plan defines the remaining work as independent goals that can run as
-**parallel sessions** — each session owns exactly one data file, so there are
-no merge conflicts between them.
+One `PreservationGuide[]` file per vegetable category. **`cucurbits.ts` is
+fully authored and is the exemplar to copy.** Each remaining file can be
+filled in its own independent session — a session owns exactly one data file,
+so parallel sessions never conflict.
 
-## What already exists (do not rebuild)
-
-- `src/types/preservation.ts` — `PreservationGuide`, `PreservationMethodGuide`, `PreservationResource`
-- `src/lib/preservation/index.ts` — aggregator, `getPreservationGuide()`, method labels
-- `src/lib/preservation/resources.ts` — **shared, fetch-verified free resources** (NCHFP, USDA, RHS, Garden Organic, FSA, Penn State, UMN, BBC Food/Good Food helpers, River Cottage, Wikibooks)
-- `src/lib/preservation/data/*.ts` — one file per category; **cucurbits.ts is fully authored and is the exemplar to copy**
-- `/preserving` page (search + method/category filters, expandable cards) linked from the "More" nav menu
-- `src/__tests__/lib/preservation-data.test.ts` — integrity tests (real plant ids, unique ids, non-empty how-tos, https URLs)
-
-Related but separate: `Vegetable.storage` (lightweight method chips + one tip,
-already on ~149 crops) stays as-is; guides go deeper and link out.
-
-## Authoring spec (every session follows this)
+## Spec (every session follows this)
 
 For each crop in your file, add one `PreservationGuide`:
 
@@ -37,7 +25,7 @@ For each crop in your file, add one `PreservationGuide`:
    cordials): BBC Food ingredient hubs first, then BBC Good Food collections,
    River Cottage for preserves-heavy crops.
 
-### Link rules (important)
+## Link rules (important)
 
 - **Free resources only** — no paywalls, no sign-up walls. Ad-supported is fine.
 - **Verify every URL you add** returns 200 before committing:
@@ -58,19 +46,21 @@ For each crop in your file, add one `PreservationGuide`:
   without pressure canning; pumpkin/squash purée is freeze-only; when in
   doubt link NCHFP and keep instructions to fridge/freeze/dry/pickle/ferment.
 
-### Definition of done (per session)
+## Definition of done (per session)
 
 - Every crop listed for the file has a guide (delete the TODO comment).
-- `npx vitest run src/__tests__/lib/preservation-data.test.ts` passes.
+- Remove your crops from `PENDING_GUIDES` in
+  `src/__tests__/lib/preservation-coverage.test.ts` (the test fails with a
+  stale-entry message if you forget).
+- `npx vitest run src/__tests__/lib/preservation-data.test.ts src/__tests__/lib/preservation-coverage.test.ts` passes.
 - `npm run lint` and `npm run type-check` pass.
 - All new URLs curl-verified 200 (paste the check output in the PR description).
 - Commit to a fresh branch, push, open a PR.
 
-## Parallel session goals
+## Session goals
 
-Each goal is self-contained: it touches only its own data file. Run any or all
-concurrently. Suggested session prompt: *"Fill `src/lib/preservation/data/<file>.ts`
-following the authoring spec in `docs/plans/food-preservation-plan.md`."*
+Suggested session prompt: *"Fill `src/lib/preservation/data/<file>.ts`
+following the authoring spec in `src/lib/preservation/data/README.md`."*
 
 | # | File | Crops (count) |
 |---|------|----------------|
@@ -83,7 +73,7 @@ following the authoring spec in `docs/plans/food-preservation-plan.md`."*
 | 7 | `herbs.ts` | parsley, coriander, mint, thyme, rosemary, chives, lovage, sorrel, oregano, sage, french-tarragon, dill, herb-fennel, lemon-balm, marjoram, bay, borage, chamomile, winter-savory, hyssop (20) |
 | 8 | `berries.ts` | strawberry, raspberry, blackcurrant, redcurrant, gooseberry, blueberry, blackberry, tayberry, loganberry, jostaberry, honeyberry, goji-berry, aronia, elderberry, sea-buckthorn (15) |
 | 9 | `fruit-trees.ts` | apple-tree, pear-tree, plum-tree, cherry-tree, damson-tree, greengage-tree, medlar-tree, quince-tree, fig-tree, mulberry-tree (10) |
-| 10 | `other.ts` + `mushrooms.ts` + `edible-extras.ts` | sweetcorn, asparagus, globe-artichoke, rhubarb, celery, cardoon, mashua; oyster-mushroom, shiitake, lions-mane, king-oyster, button-mushroom; nasturtium, calendula, lavender, bergamot, hardy-kiwi, hops (18) |
+| 10 | `other.ts` + `mushrooms.ts` + `edible-extras.ts` | sweetcorn, asparagus, globe-artichoke, rhubarb, celery, cardoon, mashua; oyster-mushroom, shiitake, lions-mane, king-oyster, button-mushroom; nasturtium, calendula, lavender, bergamot, hardy-kiwi, hops, sunflower (19) |
 
 `cucurbits.ts` (7) — ✅ done (exemplar).
 
@@ -111,19 +101,7 @@ Category-specific hints:
   membrillo for quince; medlar bletting.
 - **Other/mushrooms/extras**: sweetcorn blanch-freeze same day; rhubarb
   freezes raw + crumbles/cordial; mushrooms dry brilliantly (`NCHFP.drying`);
-  lavender/chamomile dry for tea; hops dry for brewing.
-
-## Final integration session (after data sessions merge)
-
-1. Cross-link: on `/plants/[id]`, when `getPreservationGuide(id)` exists, link
-   the Storage & Preserving panel to `/preserving?plant=<id>` (add query-param
-   support to expand that crop).
-2. Coverage test: assert every plant with `storage.methods` containing a
-   preserve method (freeze/jam/pickle/ferment/dry) has a `PreservationGuide`.
-3. E2E: `tests/preserving.spec.ts` — page loads, search filters, a card
-   expands, external links have `target="_blank"`.
-4. Consider promoting Preserving from the "More" menu to primary nav based on use.
-5. Update `docs/plans/current-plan.md`, then delete this file (doc hygiene).
+  lavender/chamomile dry for tea; hops dry for brewing; sunflower seeds dry.
 
 ## Verified resource library (fetched 2026-07-04)
 

--- a/src/lib/preservation/index.ts
+++ b/src/lib/preservation/index.ts
@@ -5,8 +5,9 @@
  * resources, recipe ideas) for the /preserving section. Data is authored in
  * per-category files under ./data so categories can be filled independently.
  *
- * This module is only imported by the /preserving route, so the dataset is
- * code-split away from the rest of the app automatically.
+ * This module is imported by the /preserving route and by the statically
+ * rendered /plants/[id] pages (server-side only, to decide whether to show
+ * the cross-link), so the dataset stays out of every other client bundle.
  */
 
 import { StorageMethod } from '@/types/garden-planner'

--- a/src/lib/task-generator.ts
+++ b/src/lib/task-generator.ts
@@ -352,7 +352,7 @@ function generateCareTipTasks(
  * keeping fresh). When a crop with one of these is in its harvest window we
  * nudge the user to preserve some — reusing the care-tip plumbing (C3).
  */
-const PRESERVE_METHODS: StorageMethod[] = ['freeze', 'jam', 'pickle', 'ferment', 'dry']
+export const PRESERVE_METHODS: StorageMethod[] = ['freeze', 'jam', 'pickle', 'ferment', 'dry']
 
 /**
  * Whether the current month falls in a planting's harvest window. Prefers the

--- a/tests/preserving.spec.ts
+++ b/tests/preserving.spec.ts
@@ -65,6 +65,19 @@ test.describe('Preserving Page', () => {
       has: page.locator('summary', { hasText: 'Pumpkin' }),
     })
     await expect(pumpkin).not.toHaveAttribute('open', '')
+
+    // The card stays user-controlled after the deep link: closing it and then
+    // re-rendering (typing in search) or filtering it out and back in must
+    // not pop it open again
+    await card.locator('summary').click()
+    await expect(card).not.toHaveAttribute('open', '')
+    await page.getByLabel('Search crops').fill('cour')
+    await expect(card).not.toHaveAttribute('open', '')
+    await page.getByLabel('Search crops').fill('pumpkin')
+    await expect(card).toHaveCount(0)
+    await page.getByLabel('Search crops').fill('')
+    await expect(card.locator('summary')).toBeVisible()
+    await expect(card).not.toHaveAttribute('open', '')
   })
 
   test('plant detail page should link to the preserving guide', async ({ page }) => {
@@ -72,7 +85,8 @@ test.describe('Preserving Page', () => {
     const link = page.locator('a[href="/preserving?plant=courgette"]')
     await expect(link).toBeVisible()
     await link.click()
-    await expect(page).toHaveURL(/\/preserving\?plant=courgette/)
+    // The ?plant= param is consumed once the card has expanded
+    await expect(page).toHaveURL(/\/preserving/)
     const card = page.locator('details').filter({
       has: page.locator('summary', { hasText: 'Courgette' }),
     })

--- a/tests/preserving.spec.ts
+++ b/tests/preserving.spec.ts
@@ -51,4 +51,31 @@ test.describe('Preserving Page', () => {
     // Cross-link to the plant guide
     await expect(card.locator('a[href="/plants/courgette"]')).toBeVisible()
   })
+
+  test('?plant= deep link should expand that crop', async ({ page }) => {
+    await page.goto('/preserving?plant=courgette')
+
+    const card = page.locator('details').filter({
+      has: page.locator('summary', { hasText: 'Courgette' }),
+    })
+    await expect(card).toHaveAttribute('open', '')
+    await expect(card.getByText(/grate raw and freeze/i)).toBeVisible()
+    // Other cards stay collapsed
+    const pumpkin = page.locator('details').filter({
+      has: page.locator('summary', { hasText: 'Pumpkin' }),
+    })
+    await expect(pumpkin).not.toHaveAttribute('open', '')
+  })
+
+  test('plant detail page should link to the preserving guide', async ({ page }) => {
+    await page.goto('/plants/courgette')
+    const link = page.locator('a[href="/preserving?plant=courgette"]')
+    await expect(link).toBeVisible()
+    await link.click()
+    await expect(page).toHaveURL(/\/preserving\?plant=courgette/)
+    const card = page.locator('details').filter({
+      has: page.locator('summary', { hasText: 'Courgette' }),
+    })
+    await expect(card).toHaveAttribute('open', '')
+  })
 })


### PR DESCRIPTION
## Summary

Runs the "Final integration session" from the food-preservation plan. Since the 10 parallel data-authoring sessions haven't merged yet (only cucurbits is authored), everything here is built forward-compatible so it works now and tightens automatically as data lands.

- **Cross-link both ways:** the Storage & Preserving panel on `/plants/[id]` now links to `/preserving?plant=<id>` whenever a `PreservationGuide` exists. The lookup happens server-side during static generation, so the preservation dataset stays out of other client bundles. `/preserving` reads the `plant` query param (`useSearchParams` inside a Suspense boundary) and renders that crop's card expanded and scrolled into view.
- **Coverage test:** `src/__tests__/lib/preservation-coverage.test.ts` asserts every crop whose `storage.methods` include a preserve method (freeze/jam/pickle/ferment/dry — `PRESERVE_METHODS`, now exported from `task-generator.ts` as the single source of truth) has a guide. The 103 not-yet-authored crops sit in an explicit `PENDING_GUIDES` list grouped by authoring session; a companion test fails on stale entries, so each data session must delete its crops from the list, and the check becomes full enforcement when the list empties. A third test guards against typos in the pending list itself.
- **Nav decision:** Preserving **stays in the More menu**. Only 7 of ~110 preserve-method crops have guides, primary nav is already at five slots, and Simplicity First says don't promote until usage earns it. Revisit after the data sessions land.
- **Doc hygiene:** `docs/plans/food-preservation-plan.md` deleted. The authoring spec, session table, link rules, and verified resource library that the pending sessions still need moved to `src/lib/preservation/data/README.md`, colocated with the data files; CLAUDE.md and `current-plan.md` pointers updated. Sunflower (dry seeds, missed by the original plan) added to session 10's crop list.
- **E2E:** two new tests in `tests/preserving.spec.ts` — deep link expands the right card (and only that card), and the plant page → preserving navigation works end to end.

## Related issue

Follow-up to #448 (Preserving foundation).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes
- [x] I have updated documentation if needed

Verification: `type-check` and `lint` clean; full unit suite 1135 passed / 4 skipped; production build succeeds (`/preserving` still static, plant pages still SSG); e2e specs touching the changed pages (preserving, accessibility, allotment, variety-management) all pass — 42/42. Three `data-management.spec.ts` failures seen during a full-suite run reproduce identically on a clean checkout in this environment (`networkidle` never settles on `/settings`), so they're pre-existing/environmental, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wxxFCUHd2gx8aWBt8Pxfs

---
_Generated by [Claude Code](https://claude.ai/code/session_012wxxFCUHd2gx8aWBt8Pxfs)_