### PR TITLE
Complete preservation guide coverage (157/157) and retire PENDING_GUIDES

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Rich per-crop preservation guidance (method how-tos, storage life, free online r
 - `src/lib/preservation/resources.ts` - shared fetch-verified free resources (NCHFP, RHS, Garden Organic, BBC Food, etc.)
 - `src/lib/preservation/data/*.ts` - per-category guide files (parallel-authoring-safe)
 
-Authoring spec and per-category session goals: `src/lib/preservation/data/README.md`. Plant detail pages cross-link to `/preserving?plant=<id>` (deep link expands that crop's card) when a guide exists. A coverage test (`src/__tests__/lib/preservation-coverage.test.ts`) asserts every crop whose `storage.methods` include a preserve method (freeze/jam/pickle/ferment/dry) has a guide, with a shrinking `PENDING_GUIDES` list for the categories not yet authored.
+Authoring spec: `src/lib/preservation/data/README.md`. All categories are fully authored (~157 crops). Plant detail pages cross-link to `/preserving?plant=<id>` (deep link expands that crop's card) when a guide exists. A coverage test (`src/__tests__/lib/preservation-coverage.test.ts`) asserts every crop whose `storage.methods` include a preserve method (freeze/jam/pickle/ferment/dry) has a guide.
 
 ### Key Type Definitions
 

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -657,9 +657,11 @@ section.)**
 
 All 10 authoring sessions from the README table ran as one batch of parallel
 subagent sessions, each owning exactly one data file per the
-parallel-authoring design. **150 guides added** (leafy-greens 21, roots 20,
-herbs 20, other/mushrooms/edible-extras 19, berries 15, brassicas 13, legumes
-13, alliums 11, fruit trees 10, solanaceae 8), bringing coverage to **157/157
+parallel-authoring design. **150 guides added** (leafy-greens 21 — landed
+separately via #451, which authored the same file in parallel and merged
+first; this branch kept the #451 version — roots 20, herbs 20,
+other/mushrooms/edible-extras 19, berries 15, brassicas 13, legumes 13,
+alliums 11, fruit trees 10, solanaceae 8), bringing coverage to **157/157
 crops** across all 14 category files (cucurbits was the pre-existing
 exemplar). Every guide follows the spec: 2–4 methods simplest-first in the
 Scottish-allotment voice, storage life, shared verified resource constants,

--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,6 @@
 # Current Plan
 
-Last updated: 2026-07-05 (Preserving final integration session — plant-page ↔ /preserving cross-links with `?plant=` deep link, guide coverage test with shrinking `PENDING_GUIDES` list, Preserving stays in the More menu, authoring spec relocated to `src/lib/preservation/data/README.md` and the plan file deleted; the 10 data-authoring sessions are still to run)
+Last updated: 2026-07-05 (Preserving data authoring complete — all 10 authoring sessions run as one parallel batch, 150 new guides bringing coverage to 157/157, `PENDING_GUIDES` deleted so the coverage test now enforces fully, Preserving stays in the More menu pending usage evidence)
 
 ## What's Been Completed
 
@@ -650,7 +650,48 @@ since all its pieces are forward-compatible:
 
 Remaining: ~103 crops across 10 parallel-safe authoring sessions (one data
 file each) — see `src/lib/preservation/data/README.md` for session goals,
-authoring spec, and the verified resource library.
+authoring spec, and the verified resource library. **(Done — see next
+section.)**
+
+### Preserving data authoring complete (branch `claude/preservation-coverage-complete-qnryr7`)
+
+All 10 authoring sessions from the README table ran as one batch of parallel
+subagent sessions, each owning exactly one data file per the
+parallel-authoring design. **150 guides added** (leafy-greens 21, roots 20,
+herbs 20, other/mushrooms/edible-extras 19, berries 15, brassicas 13, legumes
+13, alliums 11, fruit trees 10, solanaceae 8), bringing coverage to **157/157
+crops** across all 14 category files (cucurbits was the pre-existing
+exemplar). Every guide follows the spec: 2–4 methods simplest-first in the
+Scottish-allotment voice, storage life, shared verified resource constants,
+and food-safety guardrails (no home-canning of low-acid veg anywhere;
+botulism warnings on garlic/herb oils; kidney-bean boil warnings on dried
+haricots; elderberry cooked-only). All new BBC Food/Good Food URLs were
+curl-verified 200 during authoring; 404 slug candidates were dropped rather
+than guessed (several BBC hubs turned out plural — `damsons`, `greengages`,
+`mulberries`, `medlars`, `cherry_tomatoes`, `new_potatoes` — noted here
+because the README's slug rule says singular).
+
+Follow-through from the integration session:
+
+- **`PENDING_GUIDES` deleted.** The coverage test now unconditionally asserts
+  every crop with a preserve storage method has a guide, and its non-vacuous
+  floor was raised from `covered.size > 0` to `> 100`. The two
+  list-housekeeping tests (stale/bogus entries) went with the list.
+- **Authoring README updated** — session table replaced with a coverage note;
+  the spec, link rules, and verified resource library remain as the reference
+  for future crops.
+- **Nav decision reconsidered as planned — Preserving stays in the More
+  menu.** Coverage completeness removes one of the two blockers, but the
+  other (usage evidence) still stands, and the supporting reasons are
+  unchanged: primary nav is already at five slots, Seeds (a more core
+  planning surface) also lives in More, and Preserving is a seasonal
+  destination that the Today dashboard already surfaces contextually via
+  glut nudges in harvest windows. Promote only if usage shows people
+  reaching for it — the flip is a one-line move of the link object in
+  `src/components/Navigation.tsx`.
+
+Verification: full unit suite (1135 passed), type-check, lint, and
+`tests/preserving.spec.ts` (chromium) all green.
 
 ### Research-Driven Improvements: Backlog
 

--- a/src/__tests__/lib/preservation-coverage.test.ts
+++ b/src/__tests__/lib/preservation-coverage.test.ts
@@ -3,133 +3,6 @@ import { vegetables } from '@/lib/vegetable-database'
 import { preservationGuides } from '@/lib/preservation'
 import { PRESERVE_METHODS } from '@/lib/task-generator'
 
-/**
- * Crops whose PreservationGuide is still to be authored. Each parallel
- * authoring session (see src/lib/preservation/data/README.md) removes its
- * crops from this list as it fills its data file — the "no stale entries"
- * test below fails if an authored crop is left behind here. When the list is
- * empty, delete it and inline `[]`.
- *
- * Grouped by authoring session for easy removal; the grouping comments are
- * navigational only (e.g. radish lives in the root-vegetables session even
- * though its database category is brassicas).
- */
-const PENDING_GUIDES = new Set<string>([
-  // leafy-greens session
-  'spinach',
-  'perpetual-spinach',
-  'kale',
-  'cavolo-nero',
-  'chard',
-  'pak-choi',
-  'mustard-greens',
-  'orache',
-  'new-zealand-spinach',
-  'good-king-henry',
-  // root-vegetables session
-  'beetroot',
-  'radish',
-  'mooli',
-  'horseradish',
-  // brassicas session
-  'cabbage',
-  'broccoli',
-  'purple-sprouting-broccoli',
-  'cauliflower',
-  'brussels-sprouts',
-  'kohlrabi',
-  'savoy-cabbage',
-  'red-cabbage',
-  'chinese-broccoli',
-  'romanesco',
-  'turnip-tops',
-  // legumes session
-  'peas',
-  'runner-beans',
-  'broad-beans',
-  'french-beans',
-  'climbing-french-beans',
-  'borlotti-beans',
-  'edamame',
-  'mangetout',
-  'sugar-snap-peas',
-  'asparagus-peas',
-  'black-turtle-beans',
-  'fenugreek',
-  // solanaceae session
-  'cherry-tomato',
-  'plum-tomato',
-  'blight-resistant-tomato',
-  'tomatillo',
-  // alliums session
-  'spring-onion',
-  'welsh-onion',
-  'garlic-chives',
-  'ramps',
-  // herbs session
-  'parsley',
-  'coriander',
-  'mint',
-  'thyme',
-  'rosemary',
-  'chives',
-  'lovage',
-  'sorrel',
-  'oregano',
-  'sage',
-  'french-tarragon',
-  'dill',
-  'herb-fennel',
-  'lemon-balm',
-  'marjoram',
-  'bay',
-  'chamomile',
-  'winter-savory',
-  'hyssop',
-  // berries session
-  'strawberry',
-  'raspberry',
-  'blackcurrant',
-  'redcurrant',
-  'gooseberry',
-  'blueberry',
-  'blackberry',
-  'tayberry',
-  'loganberry',
-  'jostaberry',
-  'honeyberry',
-  'goji-berry',
-  'aronia',
-  'elderberry',
-  'sea-buckthorn',
-  // fruit-trees session
-  'apple-tree',
-  'pear-tree',
-  'plum-tree',
-  'cherry-tree',
-  'damson-tree',
-  'greengage-tree',
-  'medlar-tree',
-  'quince-tree',
-  'fig-tree',
-  'mulberry-tree',
-  // other + mushrooms + edible-extras session
-  'sweetcorn',
-  'asparagus',
-  'globe-artichoke',
-  'rhubarb',
-  'celery',
-  'oyster-mushroom',
-  'shiitake',
-  'nasturtium',
-  'calendula',
-  'lavender',
-  'bergamot',
-  'hardy-kiwi',
-  'hops',
-  'sunflower',
-])
-
 describe('Preservation guide coverage', () => {
   const preserveMethodSet = new Set(PRESERVE_METHODS)
   const preserveCrops = vegetables.filter(v =>
@@ -137,10 +10,8 @@ describe('Preservation guide coverage', () => {
   )
   const covered = new Set(preservationGuides.map(g => g.plantId))
 
-  it('every crop with a preserve storage method has a guide (or is pending authoring)', () => {
-    const missing = preserveCrops
-      .filter(v => !covered.has(v.id) && !PENDING_GUIDES.has(v.id))
-      .map(v => v.id)
+  it('every crop with a preserve storage method has a guide', () => {
+    const missing = preserveCrops.filter(v => !covered.has(v.id)).map(v => v.id)
     expect(
       missing,
       'These crops advertise a preserve method (freeze/jam/pickle/ferment/dry) in ' +
@@ -149,25 +20,8 @@ describe('Preservation guide coverage', () => {
     ).toEqual([])
   })
 
-  it('pending list has no stale entries for crops that now have guides', () => {
-    const stale = [...PENDING_GUIDES].filter(id => covered.has(id))
-    expect(
-      stale,
-      'These crops have guides now — remove them from PENDING_GUIDES in this test.'
-    ).toEqual([])
-  })
-
-  it('pending list only contains real crops with a preserve storage method', () => {
-    const preserveIds = new Set(preserveCrops.map(v => v.id))
-    const bogus = [...PENDING_GUIDES].filter(id => !preserveIds.has(id))
-    expect(
-      bogus,
-      'These PENDING_GUIDES entries are not preserve-method crops (typo or storage data changed).'
-    ).toEqual([])
-  })
-
   it('the coverage check is non-vacuous', () => {
     expect(preserveCrops.length).toBeGreaterThan(50)
-    expect(covered.size).toBeGreaterThan(0)
+    expect(covered.size).toBeGreaterThan(100)
   })
 })

--- a/src/lib/preservation/data/README.md
+++ b/src/lib/preservation/data/README.md
@@ -1,13 +1,16 @@
 # Preserving guides — authoring spec
 
-One `PreservationGuide[]` file per vegetable category. **`cucurbits.ts` is
-fully authored and is the exemplar to copy.** Each remaining file can be
-filled in its own independent session — a session owns exactly one data file,
-so parallel sessions never conflict.
+One `PreservationGuide[]` file per vegetable category. **All category files
+are fully authored (2026-07-05).** This spec remains the reference for
+authoring a guide for any new crop added to the vegetable database — the
+coverage test (`src/__tests__/lib/preservation-coverage.test.ts`) fails for
+any crop whose `storage.methods` include a preserve method
+(freeze/jam/pickle/ferment/dry) but has no guide. `cucurbits.ts` was the
+exemplar; copy its tone and structure.
 
-## Spec (every session follows this)
+## Spec (every guide follows this)
 
-For each crop in your file, add one `PreservationGuide`:
+For each crop, add one `PreservationGuide`:
 
 1. **`plantId`** — must match `src/lib/vegetables/index.ts` exactly.
 2. **`summary`** — one orienting sentence (glut warning, best use, keeper vs eat-fresh).
@@ -46,38 +49,20 @@ For each crop in your file, add one `PreservationGuide`:
   without pressure canning; pumpkin/squash purée is freeze-only; when in
   doubt link NCHFP and keep instructions to fridge/freeze/dry/pickle/ferment.
 
-## Definition of done (per session)
+## Definition of done
 
-- Every crop listed for the file has a guide (delete the TODO comment).
-- Remove your crops from `PENDING_GUIDES` in
-  `src/__tests__/lib/preservation-coverage.test.ts` (the test fails with a
-  stale-entry message if you forget).
 - `npx vitest run src/__tests__/lib/preservation-data.test.ts src/__tests__/lib/preservation-coverage.test.ts` passes.
 - `npm run lint` and `npm run type-check` pass.
 - All new URLs curl-verified 200 (paste the check output in the PR description).
 - Commit to a fresh branch, push, open a PR.
 
-## Session goals
+## Coverage
 
-Suggested session prompt: *"Fill `src/lib/preservation/data/<file>.ts`
-following the authoring spec in `src/lib/preservation/data/README.md`."*
+All 14 category files are authored (~157 crops, 2026-07-05). A new crop only
+needs a guide here when it gets a `storage` field with a preserve method —
+the coverage test enforces that automatically.
 
-| # | File | Crops (count) |
-|---|------|----------------|
-| 1 | `leafy-greens.ts` | lettuce, spinach, perpetual-spinach, kale, cavolo-nero, chard, rocket, pak-choi, mizuna, land-cress, corn-salad, winter-purslane, mustard-greens, watercress, salad-burnet, orache, new-zealand-spinach, good-king-henry, radicchio, endive, ice-plant (21) |
-| 2 | `root-vegetables.ts` | carrot, beetroot, parsnip, turnip, swede, radish, jerusalem-artichoke, celeriac, salsify, hamburg-parsley, florence-fennel, mooli, black-radish, scorzonera, horseradish, chinese-artichoke, yacon, skirret, oca, ulluco (20) |
-| 3 | `brassicas.ts` | broccoli, cabbage, cauliflower, brussels-sprouts, kohlrabi, savoy-cabbage, red-cabbage, chinese-broccoli, romanesco, turnip-tops, mibuna, seakale, purple-sprouting-broccoli (13) |
-| 4 | `legumes.ts` | peas, runner-beans, broad-beans, french-beans, climbing-french-beans, borlotti-beans, edamame, mangetout, sugar-snap-peas, asparagus-peas, black-turtle-beans, fenugreek, ground-nut (13) |
-| 5 | `solanaceae.ts` | potato, early-potato, second-early-potato, maincrop-potato, cherry-tomato, plum-tomato, blight-resistant-tomato, tomatillo (8) |
-| 6 | `alliums.ts` | onion, garlic, leek, spring-onion, shallot, welsh-onion, elephant-garlic, walking-onion, potato-onion, garlic-chives, ramps (11) |
-| 7 | `herbs.ts` | parsley, coriander, mint, thyme, rosemary, chives, lovage, sorrel, oregano, sage, french-tarragon, dill, herb-fennel, lemon-balm, marjoram, bay, borage, chamomile, winter-savory, hyssop (20) |
-| 8 | `berries.ts` | strawberry, raspberry, blackcurrant, redcurrant, gooseberry, blueberry, blackberry, tayberry, loganberry, jostaberry, honeyberry, goji-berry, aronia, elderberry, sea-buckthorn (15) |
-| 9 | `fruit-trees.ts` | apple-tree, pear-tree, plum-tree, cherry-tree, damson-tree, greengage-tree, medlar-tree, quince-tree, fig-tree, mulberry-tree (10) |
-| 10 | `other.ts` + `mushrooms.ts` + `edible-extras.ts` | sweetcorn, asparagus, globe-artichoke, rhubarb, celery, cardoon, mashua; oyster-mushroom, shiitake, lions-mane, king-oyster, button-mushroom; nasturtium, calendula, lavender, bergamot, hardy-kiwi, hops, sunflower (19) |
-
-`cucurbits.ts` (7) — ✅ done (exemplar).
-
-Category-specific hints:
+Category-specific hints (kept for future guides):
 
 - **Leafy greens**: most are fridge/fresh; cooking greens (kale, chard, spinach)
   blanch-and-freeze; mustard/pak-choi can ferment (kimchi-style — link

--- a/src/lib/preservation/data/alliums.ts
+++ b/src/lib/preservation/data/alliums.ts
@@ -1,11 +1,296 @@
 /**
  * Alliums — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  RHS_ONIONS,
+  GARDEN_ORGANIC_STORING,
+  UMN_HARVEST_STORAGE,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: onion, garlic, leek, spring-onion,
-// shallot, welsh-onion, elephant-garlic, walking-onion, potato-onion,
-// garlic-chives, ramps
-export const alliumsPreservation: PreservationGuide[] = []
+export const alliumsPreservation: PreservationGuide[] = [
+  {
+    plantId: 'onion',
+    summary:
+      'Cure them hard and a good onion harvest carries the kitchen from autumn to spring — pickle the small ones.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Once the tops flop, lift and dry for 2–3 weeks in sun or a greenhouse until the necks are papery and the skins rustle. Skip the curing and they will not keep.',
+        resources: [RHS_ONIONS],
+      },
+      {
+        method: 'store-cool',
+        how: 'Plait, net or tray them somewhere cool, dry and airy — a shed or spare room, never a steamy kitchen. Use any thick-necked ones first and check monthly for softies.',
+        storageLife: '4–8 months depending on variety',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'pickle',
+        how: 'The undersized ones are your pickling onions — peel, brine overnight, then pack in spiced malt vinegar. The safe classic for low-acid alliums.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling, BBC_GOOD_FOOD.pickles],
+      },
+      {
+        method: 'jam',
+        how: 'Onion marmalade — slow-cooked with sugar and vinegar — turns a glut of poor keepers into the best thing on a cheese board.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [BBC_GOOD_FOOD.chutneys],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('onion', 'Onion'),
+      bbcGoodFoodCollection('onion-recipes', 'Onion recipes'),
+    ],
+  },
+  {
+    plantId: 'garlic',
+    summary:
+      'Well-cured garlic needs no preserving at all — hardnecks see you to midwinter, softnecks to late spring.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Lift when the lower leaves yellow and dry whole plants for 2–4 weeks somewhere airy under cover. Handle gently — bruised bulbs rot first.',
+        resources: [RHS_ONIONS],
+      },
+      {
+        method: 'store-cool',
+        how: 'Plait softnecks or net the bulbs and hang cool, dry and dark. Not the fridge — cold, damp storage makes cloves sprout.',
+        storageLife: '6–10 months (softnecks keep longest)',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Peel and freeze whole cloves, or blitz with a little water and freeze in ice-cube trays. Do not store garlic in oil at room temperature — it is a botulism risk; keep any garlic oil in the fridge and use it within days.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('garlic', 'Garlic'),
+      bbcGoodFoodCollection('garlic-recipes', 'Garlic recipes'),
+    ],
+  },
+  {
+    plantId: 'leek',
+    summary:
+      'The plot is the store — leeks stand happily in the ground all winter, so lift only what the pot needs.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave them standing where they grew and lift as needed right through to spring — they shrug off Scottish frosts. Heel a few into a spare corner if the bed is needed.',
+        storageLife: 'in the ground until March–April',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'fridge',
+        how: 'Once pulled, trim the roots and keep unwashed in a bag in the salad drawer.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Wash well (grit hides deep), slice into rings and freeze flat on a tray before bagging. Frozen leeks go soft, so save them for soup, stock and pies.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('leek', 'Leek'),
+      bbcGoodFoodCollection('leek-recipes', 'Leek recipes'),
+    ],
+  },
+  {
+    plantId: 'spring-onion',
+    summary:
+      'Sown little and often there should never be a glut — but chopped-and-frozen surplus is handy for cooking.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in a bag in the salad drawer, or stand the bunch roots-down in a jar of water where they stay perky for longer.',
+        storageLife: 'about 10 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Chop whites and greens, freeze loose on a tray and bag — no blanching needed. Scatter straight from frozen into stir-fries, eggs and soups.',
+        storageLife: '3–6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('spring_onion', 'Spring onion')],
+  },
+  {
+    plantId: 'shallot',
+    summary:
+      'Better keepers than onions and the classic pickling allium — cure well and they last to spring.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Lift when the tops die back, split the clusters and dry for 2–3 weeks until the skins are papery.',
+        resources: [RHS_ONIONS],
+      },
+      {
+        method: 'store-cool',
+        how: 'Net or tray somewhere cool, dry and airy. Set aside the best bulbs for replanting next spring — one set becomes a cluster.',
+        storageLife: '6–9 months',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'pickle',
+        how: 'Pickled shallots beat pickled onions for sweetness — peel, brine overnight, then jar in spiced vinegar for Christmas.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling, BBC_GOOD_FOOD.pickles],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('shallot', 'Shallot'),
+      BBC_GOOD_FOOD.pickles,
+    ],
+  },
+  {
+    plantId: 'welsh-onion',
+    summary:
+      'A perennial cut-and-come-again clump — the plant itself is the store, standing green nearly year-round.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Cut stems as needed and let the clump regrow — in most Scottish winters it stays pickable. Use within a few days of cutting.',
+        storageLife: 'about 1 week cut; year-round on the plant',
+      },
+      {
+        method: 'freeze',
+        how: 'Chop any surplus like spring onions and freeze loose in bags — straight into cooked dishes from frozen.',
+        storageLife: '3–6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('spring_onion', 'Spring onion')],
+  },
+  {
+    plantId: 'elephant-garlic',
+    summary:
+      'Mild, roastable and huge — but a shorter keeper than true garlic, so eat these bulbs first.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Lift carefully (the bulbs sit deep), and dry whole for 3–4 weeks somewhere airy — the big cloves take longer to cure than true garlic.',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Hang in nets somewhere cool, dry and dark. It does not keep as long as true garlic, so use elephant bulbs before your main crop.',
+        storageLife: '3–5 months',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Roast whole cloves until soft, then freeze the sweet paste in ice-cube trays — instant garlic butter and mash all winter.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('garlic', 'Garlic')],
+  },
+  {
+    plantId: 'walking-onion',
+    summary:
+      'Two harvests in one: fresh green tops through the season and topset bulbils that cure, store and pickle.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Use the green stems fresh like spring onions — cut, bag and keep in the salad drawer.',
+        storageLife: 'about 10 days',
+      },
+      {
+        method: 'cure',
+        how: 'Gather the topset bulbils when the stalks dry, and cure for a week or two until the skins are papery. Keep a handful back for replanting — or let them walk.',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store cured bulbils in a paper bag or net somewhere cool and dry, and use them like tiny shallots.',
+        storageLife: '3–6 months',
+      },
+      {
+        method: 'pickle',
+        how: 'The fiddly-but-worth-it classic: peel the bulbils and pickle in spiced vinegar like cocktail onions.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling],
+      },
+    ],
+  },
+  {
+    plantId: 'potato-onion',
+    summary:
+      'A heritage multiplier bred for the store cupboard — among the longest-keeping onions you can grow.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Lift the clusters when the tops die down, split, and dry for 2–3 weeks until the skins rustle.',
+        resources: [RHS_ONIONS],
+      },
+      {
+        method: 'store-cool',
+        how: 'Net or tray somewhere cool, dry and airy — well-cured potato onions can still be sound when the new crop comes in. Save the mid-sized bulbs for replanting.',
+        storageLife: '8–12 months',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'pickle',
+        how: 'The smallest bulbs make grand pickling onions — brine, then jar in spiced vinegar.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('onion', 'Onion')],
+  },
+  {
+    plantId: 'garlic-chives',
+    summary:
+      'Best snipped fresh from the clump — freeze the surplus, as drying loses the garlicky punch.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Wrap cut leaves in damp kitchen paper in a bag in the salad drawer, and use the pretty white flowers fresh in salads.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Snip finely and freeze loose in a tub, or pack into ice-cube trays with a splash of water — no blanching needed. Add frozen at the end of cooking.',
+        storageLife: '4–6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('chives', 'Chives')],
+  },
+  {
+    plantId: 'ramps',
+    summary:
+      'A fleeting spring treat — the leaves wilt in days, so turn the surplus into pesto for the freezer.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick leaves sparingly (take a leaf, not the plant) and use within a few days, wrapped damp in the fridge.',
+        storageLife: '3–4 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blitz the leaves into pesto or butter and freeze in ice-cube trays, or blanch whole leaves for 30 seconds and freeze flat in bags.',
+        storageLife: '6–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'pickle',
+        how: 'Pickle the small bulbs or the flower buds in a light vinegar brine — but lift bulbs only from a well-established patch, as they are slow to regrow.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('wild_garlic', 'Wild garlic')],
+  },
+]

--- a/src/lib/preservation/data/berries.ts
+++ b/src/lib/preservation/data/berries.ts
@@ -1,12 +1,400 @@
 /**
  * Berries — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import { NCHFP, BBC_GOOD_FOOD, bbcFoodIngredient, bbcGoodFoodCollection } from '../resources'
 
-// TODO(preserving-data): author guides for: strawberry, raspberry,
-// blackcurrant, redcurrant, gooseberry, blueberry, blackberry, tayberry,
-// loganberry, jostaberry, honeyberry, goji-berry, aronia, elderberry,
-// sea-buckthorn
-export const berriesPreservation: PreservationGuide[] = []
+export const berriesPreservation: PreservationGuide[] = [
+  {
+    plantId: 'strawberry',
+    summary:
+      'Eat them fresh in the June rush — anything left over should be frozen or jammed the day it is picked.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick dry, keep unwashed and unhulled in a single layer in the fridge, and wash only just before eating. They fade fast.',
+        storageLife: '2–3 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Hull, then open-freeze whole on a tray before bagging so they stay loose. Frozen strawberries collapse on thawing — use them for smoothies, sauces and jam.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Strawberries are low in pectin, so use jam sugar with added pectin or a good squeeze of lemon juice to get a set. A soft set is traditional — do not boil it to toffee chasing a firm one.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('strawberry', 'Strawberry'),
+      bbcGoodFoodCollection('strawberries-recipes', 'Strawberry recipes'),
+    ],
+  },
+  {
+    plantId: 'raspberry',
+    summary:
+      'The great Scottish berry — a summer and autumn glut crop that freezes almost as well as it eats fresh.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick into shallow trays so they do not crush, and eat within a day or two. Do not wash until just before serving.',
+        storageLife: '1–2 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze on trays then pour into bags — they stay separate so you can shake out a handful all winter. No blanching, no prep beyond a check for beasties.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'A short rolling boil keeps the fresh flavour — raspberry jam sets more easily than strawberry. Sieve half the pulp if the seeds annoy you, or make seedless raspberry jelly.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('raspberry', 'Raspberry'),
+      bbcGoodFoodCollection('raspberry-recipes', 'Raspberry recipes'),
+    ],
+  },
+  {
+    plantId: 'blackcurrant',
+    summary:
+      'Too sharp to eat fresh in quantity — this is the cordial and jam bush, and the berries freeze whole with no fuss.',
+    methods: [
+      {
+        method: 'freeze',
+        how: 'Strip the berries off the strigs with a fork, open-freeze on a tray and bag. Frozen currants are actually easier to destalk — freeze on the strig and shake.',
+        storageLife: '12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Blackcurrants are loaded with pectin so jam sets readily — simmer with water first to soften the skins before adding sugar. The classic Scottish move is cordial: simmer, strain through a jelly bag, sweeten and bottle.',
+        storageLife: 'jam 1 year+; cordial 2–3 weeks in the fridge or freeze in bottles',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+      {
+        method: 'fridge',
+        how: 'Fresh currants keep a few days loosely covered in the fridge — longer than most soft fruit thanks to their tough skins.',
+        storageLife: '4–7 days in the fridge',
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('blackcurrant', 'Blackcurrant'),
+      bbcGoodFoodCollection('blackcurrant-recipes', 'Blackcurrant recipes'),
+      bbcGoodFoodCollection('cordial-recipes', 'Cordial recipes'),
+    ],
+  },
+  {
+    plantId: 'redcurrant',
+    summary:
+      'The jelly-maker of the fruit cage — sky-high pectin means redcurrant jelly sets almost by itself.',
+    methods: [
+      {
+        method: 'freeze',
+        how: 'Freeze whole sprigs on a tray, then shake the frozen berries off the strigs into bags — far quicker than destalking fresh.',
+        storageLife: '12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Redcurrant jelly is the obvious preserve: simmer, drip through a jelly bag overnight and boil briefly with sugar — the pectin is so high it sets fast. Brilliant with lamb, in gravies and glazing tarts.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+      {
+        method: 'fridge',
+        how: 'Keep on the strig, loosely covered, and pull off berries as needed. A few sprigs also look grand on a pudding.',
+        storageLife: '4–7 days in the fridge',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('redcurrant', 'Redcurrant')],
+  },
+  {
+    plantId: 'gooseberry',
+    summary:
+      'A heavy cropper that freezes brilliantly — top and tail in front of the telly and the freezer does the rest.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Firm underripe berries keep better than most soft fruit — a week in the fridge is fine. Dessert varieties for eating, culinary ones for cooking.',
+        storageLife: 'up to 1 week in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Top and tail, open-freeze on trays and bag. You can also freeze them untrimmed and top-and-tail from frozen when the ends snap off cleanly.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Gooseberries are rich in pectin so jam and chutney both set well — no jam sugar needed. Pick slightly underripe for the best set and the proper sharp flavour.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.chutneys],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('gooseberry', 'Gooseberry'),
+      bbcGoodFoodCollection('gooseberry-recipes', 'Gooseberry recipes'),
+    ],
+  },
+  {
+    plantId: 'blueberry',
+    summary:
+      'One of the better keepers among the soft fruit — a week in the fridge, and they freeze without turning to mush.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in a covered tub in the fridge — the waxy bloom protects them. Wash just before eating.',
+        storageLife: 'up to 1 week in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze unwashed on a tray then bag; the berries stay separate and hold their shape better than most soft fruit. Use straight from frozen in porridge, muffins and pancakes.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Blueberries are lowish in pectin, so add lemon juice or pair with an apple for a reliable set. A gentle simmer keeps the whole-berry texture.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('blueberry', 'Blueberry'),
+      bbcGoodFoodCollection('blueberry-recipes', 'Blueberry recipes'),
+    ],
+  },
+  {
+    plantId: 'blackberry',
+    summary:
+      'Free food from the hedge or trained canes — freeze the gluts and turn the rest into bramble jelly and gin.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Eat within a day or two of picking — brambles go mouldy fast in a warm kitchen. Keep them cold and unwashed until needed.',
+        storageLife: '1–3 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze on trays then bag. Frozen brambles are perfect for crumbles and jelly through the winter — texture matters less once cooked.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Bramble jelly solves the seed problem: simmer with a chopped apple for pectin, strain through a jelly bag and boil with sugar. Whole-fruit bramble jam works too if the seeds do not bother you.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('blackberry', 'Blackberry'),
+      bbcGoodFoodCollection('blackberry-recipes', 'Blackberry recipes'),
+      bbcGoodFoodCollection('flavoured-gin-recipes', 'Flavoured gin recipes'),
+    ],
+  },
+  {
+    plantId: 'tayberry',
+    summary:
+      'A Scottish-bred raspberry-bramble cross — softer than either parent, so it is freezer and jam pan territory within days.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick fully ripe and handle gently — tayberries bruise even faster than raspberries. Eat within a day or two.',
+        storageLife: '1–2 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze on trays the day you pick, then bag. They collapse on thawing, so plan on cooked uses — crumbles, sauces and jam.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Treat like raspberry jam with a squeeze of lemon for insurance — the flavour is richer and winier than either parent. A short boil keeps it bright.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('tayberry', 'Tayberry')],
+  },
+  {
+    plantId: 'loganberry',
+    summary:
+      'Sharper than a raspberry and softer too — best cooked, so freeze the picking and jam the glut.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Eat dead ripe or not at all — underripe loganberries are mouth-puckering. Keep cold and use within a couple of days.',
+        storageLife: '1–2 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze on trays then bag. Their sharpness is an asset in cooked puddings, so the freezer is arguably where loganberries belong.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Loganberry jam is a classic — sharper and deeper than raspberry, with enough acid to set well with ordinary sugar. Sieve for a seedless jelly if you prefer.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('loganberry', 'Loganberry')],
+  },
+  {
+    plantId: 'jostaberry',
+    summary:
+      'A gooseberry-blackcurrant cross that crops heavily — use it like either parent: freeze whole, or cook into a dark, well-set jam.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Tougher skinned than most soft fruit, so a few days in the fridge is no bother. Ripe berries eat fresh like a mild blackcurrant.',
+        storageLife: '4–5 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze on trays and bag — no topping and tailing needed, unlike the gooseberry parent. Use from frozen in crumbles and compotes.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Jostaberries inherit high pectin from both parents, so jam sets easily with ordinary sugar. Any blackcurrant or gooseberry jam recipe works unchanged.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+  },
+  {
+    plantId: 'honeyberry',
+    summary:
+      'The first berry of the Scottish year — eat the earlies fresh and treat any glut like a soft-skinned blueberry.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick when fully blue right through — outwardly ripe berries can still be green and sharp inside. Eat within a few days.',
+        storageLife: '3–4 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze on trays then bag. The soft skins mean they thaw softer than blueberries, so use frozen berries for baking, porridge and sauces.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Haskap jam tastes somewhere between blueberry and blackcurrant — add lemon juice or jam sugar as the pectin is modest. Small batches suit the small harvests of young bushes.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+  },
+  {
+    plantId: 'goji-berry',
+    summary:
+      'Traditionally a dried berry — dry the harvest like the ones you buy, and freeze or nibble the rest fresh.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Eat a few straight off the bush — fresh goji berries are mildly bitter-sweet and divide opinion. Handle gently; they bruise and darken fast.',
+        storageLife: '2–3 days in the fridge',
+      },
+      {
+        method: 'dry',
+        how: 'Dry whole berries in a dehydrator or a very low oven until leathery like a raisin — this is how goji is used worldwide. Store in an airtight jar and scatter on porridge or steep in tea.',
+        storageLife: '6–12 months in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze on a tray and bag for smoothies and baking — simpler than drying if you only have a handful.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'aronia',
+    summary:
+      'Chokeberries are mouth-dryingly astringent raw — this is a crop you freeze, juice, jam or dry, never a bowl fruit.',
+    methods: [
+      {
+        method: 'freeze',
+        how: 'Open-freeze on trays then bag — freezing also mellows the astringency, so many growers freeze first on principle before cooking.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Cook into juice, jelly or jam, ideally blended with apple or blackcurrant to soften the tannic edge. The colour is spectacularly dark and the pectin is decent.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+      {
+        method: 'dry',
+        how: 'Dry whole berries until hard and raisin-like for teas and winter porridge — drying concentrates the sweetness and tames the pucker.',
+        storageLife: '6–12 months in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+    ],
+  },
+  {
+    plantId: 'elderberry',
+    summary:
+      'Always cook elderberries before eating — raw berries, stems and leaves are mildly toxic. Cooked, they make superb cordial, jelly and winter syrup.',
+    methods: [
+      {
+        method: 'jam',
+        how: 'Strip berries off the stalks with a fork, discard every bit of stem, and simmer well — cooking destroys the mildly toxic compounds in raw elderberries. Strain for cordial or syrup, or set with apple as elderberry jelly.',
+        storageLife: 'jelly 1 year+ in sealed jars; cordial 2–3 weeks in the fridge or freeze',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze whole sprays on a tray, then shake the frozen berries off the stems into bags — much faster than forking them off fresh. Remember they still need cooking before eating.',
+        storageLife: '12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Dry destemmed berries in a dehydrator or low oven until hard, and store in a jar for winter teas and syrups. As with fresh, always simmer dried elderberries before consuming — never eat them raw.',
+        storageLife: '6–12 months in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('elderflower', 'Elderflower'),
+      bbcGoodFoodCollection('cordial-recipes', 'Cordial recipes'),
+    ],
+  },
+  {
+    plantId: 'sea-buckthorn',
+    summary:
+      'Ferociously sharp orange berries on ferociously thorny branches — freeze to harvest, then turn the juice into cordial and jam.',
+    methods: [
+      {
+        method: 'freeze',
+        how: 'The classic trick is to cut small berry-laden twigs, freeze them, then shake or knock the frozen berries off — far kinder to your hands than picking the squashy fruit among thorns. Bag the loose berries and keep frozen.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Simmer and sieve for an intensely sharp, vitamin-C-rich juice, then sweeten well for cordial, jelly or jam — think citrus levels of sugar. It pairs beautifully with apple, which adds pectin for the set.',
+        storageLife: 'jam and jelly 1 year+ in sealed jars; cordial 2–3 weeks in the fridge or freeze',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+  },
+]

--- a/src/lib/preservation/data/brassicas.ts
+++ b/src/lib/preservation/data/brassicas.ts
@@ -1,11 +1,335 @@
 /**
  * Brassicas — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  GARDEN_ORGANIC_STORING,
+  UMN_HARVEST_STORAGE,
+  UMN_SAUERKRAUT,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: broccoli, cabbage, cauliflower,
-// brussels-sprouts, kohlrabi, savoy-cabbage, red-cabbage, chinese-broccoli,
-// romanesco, turnip-tops, mibuna, seakale, purple-sprouting-broccoli
-export const brassicasPreservation: PreservationGuide[] = []
+export const brassicasPreservation: PreservationGuide[] = [
+  {
+    plantId: 'broccoli',
+    summary:
+      'Heads all come at once — eat the main head fresh, blanch and freeze the rest before the buds open.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in a loose bag in the salad drawer and eat within the week — the buds yellow fast once cut.',
+        storageLife: 'up to 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Cut into even florets, blanch 3 minutes, cool in iced water and freeze flat on a tray before bagging. Soak in salted water first to evict any caterpillars.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('broccoli', 'Broccoli'),
+      bbcGoodFoodCollection('broccoli-recipes', 'Broccoli recipes'),
+    ],
+  },
+  {
+    plantId: 'cabbage',
+    summary:
+      'The great keeper of the plot — solid heads store for months in a cool shed, and the surplus makes sauerkraut.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'A whole head keeps for weeks in the fridge; wrap a cut face in a bag and use within days.',
+        storageLife: '2–4 weeks whole in the fridge',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lift solid winter heads with a stub of stem, strip loose leaves, and store cool and frost-free — netted, on slatted shelves, or nested in straw. Check monthly and peel off any spoiled outer leaves.',
+        storageLife: '2–4 months in a cool store',
+        resources: [GARDEN_ORGANIC_STORING, UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'ferment',
+        how: 'Shred, salt at 2–2.5% by weight, pack tight under its own brine and let it work at room temperature for 1–4 weeks. Keep everything below the brine and it looks after itself.',
+        storageLife: 'several months refrigerated once fermented',
+        resources: [UMN_SAUERKRAUT, NCHFP.fermenting],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('cabbage', 'Cabbage'),
+      bbcGoodFoodCollection('cabbage-recipes', 'Cabbage recipes'),
+    ],
+  },
+  {
+    plantId: 'cauliflower',
+    summary:
+      'Curds refuse to stagger themselves — freeze florets for the freezer and pickle the rest as piccalilli.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep the whole head unwashed in a bag in the fridge, leaves on to protect the curd.',
+        storageLife: 'up to 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Break into walnut-sized florets, blanch 3 minutes, cool and open-freeze on a tray before bagging. Frozen cauliflower goes soft — save it for soup, curry and cauliflower cheese.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'pickle',
+        how: 'Brine small florets overnight, then pack in spiced vinegar — the backbone of a proper piccalilli along with any spare beans and onions.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling, BBC_GOOD_FOOD.pickles],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('cauliflower', 'Cauliflower'),
+      bbcGoodFoodCollection('cauliflower-recipes', 'Cauliflower recipes'),
+    ],
+  },
+  {
+    plantId: 'brussels-sprouts',
+    summary:
+      'The plant is its own larder — leave sprouts standing through the frosts and pick as needed, freezing any big flush.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave them on the plant and pick from the bottom up as they firm — frost sweetens them. A whole cut stalk stands for a week or two in a cold shed or bucket of water.',
+        storageLife: 'standing on the plant all winter',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'fridge',
+        how: 'Picked sprouts keep unwashed in a bag in the salad drawer.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Trim, blanch small sprouts 3 minutes and larger ones 4–5, cool fast and open-freeze on a tray before bagging.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('brussels_sprouts', 'Brussels sprouts')],
+  },
+  {
+    plantId: 'kohlrabi',
+    summary:
+      'Pick at tennis-ball size for eating fresh — the late ones store like a root crop in damp sand.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Twist off the leaves and keep the bulbs in a bag in the salad drawer — they hold their crunch for weeks.',
+        storageLife: '2–4 weeks',
+      },
+      {
+        method: 'store-cool',
+        how: 'Late sowings can be lifted, topped and packed in boxes of just-damp sand in a cool shed, same as carrots and beetroot.',
+        storageLife: '1–2 months in sand',
+        resources: [GARDEN_ORGANIC_STORING, UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Peel, cube, blanch 2–3 minutes and freeze in bags — destined for soups and stews rather than salads.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('kohlrabi', 'Kohlrabi'),
+      bbcGoodFoodCollection('kohlrabi-recipes', 'Kohlrabi recipes'),
+    ],
+  },
+  {
+    plantId: 'savoy-cabbage',
+    summary:
+      'The hardiest cabbage on the plot — leave it standing through winter and cut heads as you need them.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Savoys shrug off Scottish frost — leave them in the ground and cut fresh from November to March. That is the whole storage plan for most plots.',
+        storageLife: 'standing in the ground all winter',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'If the bed is needed, lift whole heads with roots on and hang or shelve them somewhere cold and frost-free.',
+        storageLife: '3–6 weeks lifted',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Shred, blanch 90 seconds, cool and bag in meal-sized portions for winter soups and stovies.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('savoy_cabbage', 'Savoy cabbage')],
+  },
+  {
+    plantId: 'red-cabbage',
+    summary:
+      'The pickling cabbage — solid heads keep for months in a cool store, and jars of spiced pickled red cabbage see you to Christmas and beyond.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'A dense head keeps for weeks in the fridge; bag any cut face and use it within days.',
+        storageLife: '3–4 weeks whole in the fridge',
+      },
+      {
+        method: 'store-cool',
+        how: 'Red cabbage is one of the best storing brassicas — lift solid heads, strip loose leaves and keep cool, dry and frost-free on slatted shelves.',
+        storageLife: '2–4 months in a cool store',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'pickle',
+        how: 'Shred finely, dry-salt for 24 hours, rinse and pack in spiced vinegar. Ready in a week and a classic with cold meat and cheese.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling, BBC_GOOD_FOOD.pickles],
+      },
+      {
+        method: 'ferment',
+        how: 'Ferments exactly like white cabbage and turns a startling magenta — shred, salt at 2–2.5% and keep it under the brine.',
+        storageLife: 'several months refrigerated once fermented',
+        resources: [UMN_SAUERKRAUT],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('red_cabbage', 'Red cabbage')],
+  },
+  {
+    plantId: 'chinese-broccoli',
+    summary:
+      'A cut-and-cook green — stems and leaves wilt fast, so eat within days and blanch-freeze any surplus.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Stand the stems in a jar of water or bag them unwashed in the salad drawer, and cook within a few days.',
+        storageLife: '4–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch whole stems 2 minutes, cool fast and freeze flat in bags — straight from freezer to stir-fry or steamer.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'romanesco',
+    summary:
+      'Treat the fractal curds like cauliflower — eat the head fresh and blanch-freeze florets before they loosen.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep the head whole and unwashed in a bag in the fridge, wrapper leaves on.',
+        storageLife: 'up to 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Break into florets, blanch 3 minutes, cool and open-freeze on a tray before bagging. Best used cooked — soups, gratins and pasta.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'pickle',
+        how: 'The pointed florets pickle as well as cauliflower and look far better in the jar — brine overnight, then cover with spiced vinegar.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [
+      bbcGoodFoodCollection('cauliflower-recipes', 'Cauliflower recipes (romanesco works the same)'),
+    ],
+  },
+  {
+    plantId: 'turnip-tops',
+    summary:
+      'A quick spring green with no shelf life to speak of — cook it fast or freeze it blanched like spinach.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Bag the shoots unwashed and keep in the salad drawer — they flop within days, so cook them soon.',
+        storageLife: '3–4 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch the shoots and leaves 2 minutes, cool in iced water, squeeze out and freeze in fist-sized balls — ready for pasta, orecchiette-style, or greens with garlic.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'mibuna',
+    summary:
+      'A cut-and-come-again mustard green — the plant in the ground is the store, with a kimchi-style ferment for any big cut.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick little and often straight into the salad bowl — the standing plant keeps far better than anything you cut.',
+        storageLife: 'cut-and-come-again from the plant',
+      },
+      {
+        method: 'fridge',
+        how: 'Wash, spin dry and keep in a box or bag with a sheet of kitchen paper to catch the damp.',
+        storageLife: '4–5 days',
+      },
+      {
+        method: 'ferment',
+        how: 'Like other mustard greens, mibuna takes well to a kimchi-style ferment — salt the leaves, add garlic, ginger and chilli, and keep everything under the brine.',
+        storageLife: 'several months refrigerated once fermented',
+        resources: [NCHFP.fermenting, UMN_SAUERKRAUT],
+      },
+    ],
+  },
+  {
+    plantId: 'seakale',
+    summary:
+      'A forced spring delicacy — the blanched shoots are for eating within days, not preserving.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Cut the forced shoots at 15–20cm and treat like asparagus — steam or butter-fry the same day for the true flavour.',
+        storageLife: 'best eaten the day it is cut',
+      },
+      {
+        method: 'fridge',
+        how: 'Wrap the shoots in damp kitchen paper inside a bag and keep in the salad drawer — quality drops quickly.',
+        storageLife: '2–3 days',
+      },
+    ],
+  },
+  {
+    plantId: 'purple-sprouting-broccoli',
+    summary:
+      'The hungry-gap hero — pick spears every few days to keep them coming, and freeze the gluts blanched.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick the central spear first, then the side shoots every few days — regular picking keeps the plant producing for weeks. Best cooked the day it is cut.',
+        storageLife: 'weeks of repeat picking from the plant',
+      },
+      {
+        method: 'fridge',
+        how: 'Stand spears in a jar of water like a bunch of flowers, or bag them unwashed in the salad drawer.',
+        storageLife: '3–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch spears 2–3 minutes, cool fast and open-freeze on a tray before bagging so they stay loose.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('purple_sprouting_broccoli', 'Purple sprouting broccoli'),
+    ],
+  },
+]

--- a/src/lib/preservation/data/edible-extras.ts
+++ b/src/lib/preservation/data/edible-extras.ts
@@ -1,11 +1,154 @@
 /**
  * Edible extras — Preserving guides
  * Edible flowers and climbers that sit outside the vegetable/fruit categories.
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import { NCHFP, BBC_GOOD_FOOD, bbcFoodIngredient } from '../resources'
 
-// TODO(preserving-data): author guides for: nasturtium, calendula, lavender,
-// bergamot, hardy-kiwi, hops
-export const edibleExtrasPreservation: PreservationGuide[] = []
+export const edibleExtrasPreservation: PreservationGuide[] = [
+  {
+    plantId: 'nasturtium',
+    summary:
+      'Leaves and flowers are strictly eat-fresh; the green seed pods pickle into poor mans capers that keep all winter.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick leaves and flowers just before eating — they wilt within hours. A short spell in a bag in the fridge with a damp towel buys a day or two at most.',
+        storageLife: '1–3 days at best',
+      },
+      {
+        method: 'pickle',
+        how: 'Gather plump green seed pods, brine them for a day, then jar in cold spiced vinegar — the classic poor mans capers. Give them a few weeks to mellow before opening.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('nasturtium', 'Nasturtium')],
+  },
+  {
+    plantId: 'calendula',
+    summary:
+      'Petals scatter fresh over summer salads and dry easily for tea and winter colour in the store cupboard.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pull petals from freshly opened heads and use the same day over salads, rice and bakes. The green flower base is bitter — petals only.',
+        storageLife: 'use the day of picking',
+      },
+      {
+        method: 'dry',
+        how: 'Pick whole heads on a dry morning, pull the petals and dry them on paper somewhere warm and airy out of direct sun. Store airtight in the dark for tea or as a saffron-coloured kitchen stand-in.',
+        storageLife: '6–12 months airtight in the dark',
+        resources: [NCHFP.drying],
+      },
+    ],
+  },
+  {
+    plantId: 'lavender',
+    summary:
+      'Cut just as the flowers open and dry in bunches — a jar of dried buds covers baking, tea and sleep sachets for the year.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Fresh sprigs flavour sugar, shortbread and cordials — use sparingly, as a little goes a long way. Stems keep a few days in water.',
+        storageLife: 'a few days in water',
+      },
+      {
+        method: 'dry',
+        how: 'Cut stems as the first flowers open, hang in small bunches upside down somewhere warm, dark and airy for 2–4 weeks, then rub the buds off into a jar. Culinary varieties (English lavender) taste best.',
+        storageLife: '1 year+ airtight in the dark',
+        resources: [NCHFP.drying],
+      },
+    ],
+  },
+  {
+    plantId: 'bergamot',
+    summary:
+      'Bee balm is a tea crop at heart — dry leaves and flowers for a bergamot-scented brew, and freeze chopped leaves for cooking.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick young leaves and fresh flowers for salads and tea as you need them. Sprigs keep a couple of days in a glass of water.',
+        storageLife: '2–3 days in water',
+      },
+      {
+        method: 'dry',
+        how: 'Hang stems in small bunches or dry leaves and petals flat somewhere warm and airy, then crumble into jars. The Earl-Grey-like scent holds well dried — this is the winter tea supply.',
+        storageLife: '6–12 months airtight in the dark',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Chop fresh leaves and freeze in ice-cube trays topped up with water, then bag the cubes for teas and summer drinks.',
+        storageLife: '6–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'hardy-kiwi',
+    summary:
+      'The grape-sized fruits ripen in a rush — fridge the firm ones, freeze the ripe ones whole, and jam the rest.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Pick firm and ripen a few at a time in the fruit bowl; the rest keep weeks in the fridge. Bring out batches as you need them — they soften in a day or two at room temperature.',
+        storageLife: '2–6 weeks in the fridge picked firm',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze ripe fruits whole on a tray — no peeling needed, the skins are smooth — then bag. Eat half-thawed like little sorbets or blitz into smoothies.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'A glut cooks down into a sharp green jam — halve the fruits and simmer with sugar and a squeeze of lemon. Low in pectin, so use jam sugar for a set.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('kiwi_fruit', 'Kiwi fruit')],
+  },
+  {
+    plantId: 'hops',
+    summary:
+      'A brewing crop — dry the cones fast after picking and get them airtight or frozen before the aroma fades.',
+    methods: [
+      {
+        method: 'dry',
+        how: 'Pick cones when papery and springy, then dry in a thin layer somewhere warm and airy (or a dehydrator on low) for a day or two until the central stem snaps. Store airtight in the dark — light and air kill the aroma.',
+        storageLife: '6–12 months airtight; longer if also frozen',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Vacuum-pack or tightly bag the dried cones and freeze — the brewers trick for keeping the bittering oils fresh between harvests. Fresh cones can also go straight in the freezer for a green-hop brew.',
+        storageLife: '1–2 years frozen airtight',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'sunflower',
+    summary:
+      'One good head gives a jarful of seeds — dry them hard for the cupboard, and freeze what you shell for the long haul.',
+    methods: [
+      {
+        method: 'dry',
+        how: 'Cut heads when the backs turn brown and yellow, hang somewhere dry and airy (netted against birds and mice), then rub out the seeds and dry them fully before jarring. Roast salted for snacking or keep raw for sowing and porridge.',
+        storageLife: '2–3 months at room temperature; longer kept cool',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Shelled seeds go rancid at room temperature within a few months — bag them airtight and freeze for the long haul.',
+        storageLife: 'about 1 year frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('sunflower_seed', 'Sunflower seed')],
+  },
+]

--- a/src/lib/preservation/data/edible-extras.ts
+++ b/src/lib/preservation/data/edible-extras.ts
@@ -11,7 +11,7 @@ export const edibleExtrasPreservation: PreservationGuide[] = [
   {
     plantId: 'nasturtium',
     summary:
-      'Leaves and flowers are strictly eat-fresh; the green seed pods pickle into poor mans capers that keep all winter.',
+      'Leaves and flowers are strictly eat-fresh; the green seed pods pickle into a fine caper substitute that keeps all winter.',
     methods: [
       {
         method: 'fresh',
@@ -20,7 +20,7 @@ export const edibleExtrasPreservation: PreservationGuide[] = [
       },
       {
         method: 'pickle',
-        how: 'Gather plump green seed pods, brine them for a day, then jar in cold spiced vinegar — the classic poor mans capers. Give them a few weeks to mellow before opening.',
+        how: 'Gather plump green seed pods, brine them for a day, then jar in cold spiced vinegar — the classic allotment caper substitute. Give them a few weeks to mellow before opening.',
         storageLife: '6–12 months in sealed jars',
         resources: [NCHFP.pickling],
       },

--- a/src/lib/preservation/data/fruit-trees.ts
+++ b/src/lib/preservation/data/fruit-trees.ts
@@ -1,11 +1,305 @@
 /**
  * Fruit Trees — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  RHS_STORING_FRUIT,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: apple-tree, pear-tree, plum-tree,
-// cherry-tree, damson-tree, greengage-tree, medlar-tree, quince-tree,
-// fig-tree, mulberry-tree
-export const fruitTreesPreservation: PreservationGuide[] = []
+export const fruitTreesPreservation: PreservationGuide[] = [
+  {
+    plantId: 'apple-tree',
+    summary:
+      'The great keeper of the plot — sound late apples wrapped and tray-stored will see you through to spring.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Eaters keep for weeks in the salad drawer in a loose bag. Use up early varieties first — they never store long.',
+        storageLife: '2–6 weeks in the fridge',
+      },
+      {
+        method: 'store-cool',
+        how: 'Only tray-store perfect, unblemished late-season keepers — one bruise spoils the box. Wrap each fruit in newspaper and lay in single layers somewhere cool, dark and frost-free, checking monthly.',
+        storageLife: '2–6 months depending on variety',
+        resources: [RHS_STORING_FRUIT],
+      },
+      {
+        method: 'freeze',
+        how: 'Peel, slice and freeze on trays before bagging, or stew to a purée first. Frozen slices go straight into crumbles; the windfalls and bruised fruit all end up here.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Apple chutney is the classic glut-buster — apples also lend their pectin to any low-set fruit jam or a herb jelly.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [BBC_GOOD_FOOD.chutneys],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('apple', 'Apple'),
+      bbcGoodFoodCollection('apple-recipes', 'Apple recipes'),
+      bbcGoodFoodCollection('apple-crumble-recipes', 'Apple crumble recipes'),
+    ],
+  },
+  {
+    plantId: 'pear-tree',
+    summary:
+      'Pears ripen off the tree — pick them hard, store them cold, and bring them indoors a few at a time.',
+    methods: [
+      {
+        method: 'store-cool',
+        how: 'Pick while still hard and lay unwrapped in single layers somewhere cold and frost-free. Bring a few indoors every week to finish ripening — a ripe pear waits for no one.',
+        storageLife: '1–3 months depending on variety',
+        resources: [RHS_STORING_FRUIT],
+      },
+      {
+        method: 'fridge',
+        how: 'The fridge holds hard pears in suspended animation and slows ripe ones. Keep them away from strong-smelling food.',
+        storageLife: '2–4 weeks in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Poach quarters in a light syrup and freeze in tubs — raw pears go woolly in the freezer.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Pear and ginger jam or a spiced pear chutney soaks up the fruit that all ripened in the same week.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [BBC_GOOD_FOOD.chutneys],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('pear', 'Pear'),
+      bbcGoodFoodCollection('pear-recipes', 'Pear recipes'),
+    ],
+  },
+  {
+    plantId: 'plum-tree',
+    summary:
+      'A plum tree gives you everything in a fortnight — eat what you can, then stone and freeze or jam the rest.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Ripe plums keep only a few days in a cool room, a little longer in the fridge. Eat the ripest first and check daily for softening.',
+        storageLife: '3–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Halve and stone before freezing — stones turn the flavour bitter and are a menace later. Open-freeze the halves on trays, then bag for crumbles and compotes.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Plum jam sets easily and plum chutney is even more forgiving. Stone the fruit first; whole ripe plums also steep well in gin with sugar for a winter bottle.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('plum', 'Plum'),
+      bbcGoodFoodCollection('plum-recipes', 'Plum recipes'),
+    ],
+  },
+  {
+    plantId: 'cherry-tree',
+    summary:
+      'The birds want them as much as you do — pick ripe, eat fresh, and open-freeze the surplus stoned.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Keep unwashed in the fridge with the stalks on and wash just before eating. They fade fast once picked.',
+        storageLife: 'up to 1 week in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Stone them first — a cherry stoner earns its keep in one evening — then open-freeze on trays and bag. Frozen cherries go straight into pies and compotes.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Cherry jam is low in pectin, so add lemon juice or mix with a sharper fruit for a set. Always stone the fruit before it goes in the pan.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('cherry', 'Cherry'),
+      bbcGoodFoodCollection('cherry-recipes', 'Cherry recipes'),
+    ],
+  },
+  {
+    plantId: 'damson-tree',
+    summary:
+      'Too sharp to eat from the tree but the best preserving plum there is — jam, gin and the freezer take the lot.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Damsons keep a few days in the fridge but few people eat them raw — they are a cooking fruit through and through.',
+        storageLife: '3–5 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Halve and stone before freezing, or freeze whole and sieve the stones out after cooking. A freezer full of damsons means jam-making on your own schedule.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Damson jam is the classic — high pectin, deep flavour, easy set. For damson gin, prick whole fruit and steep in gin with sugar for three months, shaking weekly.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('damsons', 'Damson'),
+      bbcGoodFoodCollection('damson-recipes', 'Damson recipes'),
+    ],
+  },
+  {
+    plantId: 'greengage-tree',
+    summary:
+      'The finest-flavoured plum of all — eat as many fresh as you can and preserve the rest like any plum.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'A ripe greengage is the reward for growing the tree — eat within days. They bruise easily, so pick gently into shallow trays.',
+        storageLife: '3–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Halve and stone, then open-freeze on trays before bagging. They hold their honeyed flavour well for compotes and tarts.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Greengage jam is a quiet luxury — stone the fruit and add a squeeze of lemon to help the set.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('greengages', 'Greengage')],
+  },
+  {
+    plantId: 'medlar-tree',
+    summary:
+      'Medlars must be bletted — softened in storage until the flesh turns brown and datey — before they are any use at all.',
+    methods: [
+      {
+        method: 'store-cool',
+        how: 'Pick after the first frosts and lay eye-down in single layers somewhere cool. Wait 2–3 weeks until the flesh softens and browns — that is bletting, a controlled ripening, not rot, and the fruit is inedible before it.',
+        storageLife: '2–3 weeks to blet, then use promptly',
+        resources: [RHS_STORING_FRUIT],
+      },
+      {
+        method: 'jam',
+        how: 'Bletted medlars make an amber jelly that is very good with cheese and game — simmer whole, strain overnight through a jelly bag, and boil the juice with sugar.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('medlars', 'Medlar')],
+  },
+  {
+    plantId: 'quince-tree',
+    summary:
+      'Rock-hard and inedible raw, but cooked quince turns fragrant and pink — store cool, then make membrillo and jelly.',
+    methods: [
+      {
+        method: 'store-cool',
+        how: 'Store unwrapped in single layers somewhere cool and dark, away from other fruit — the perfume is strong enough to flavour your apples. Use as the fruits turn fully yellow.',
+        storageLife: '2–3 months',
+        resources: [RHS_STORING_FRUIT],
+      },
+      {
+        method: 'jam',
+        how: 'Quince is loaded with pectin: membrillo (quince paste for cheese) and quince jelly both set beautifully. Long slow cooking turns the flesh from cream to deep pink.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+      {
+        method: 'freeze',
+        how: 'Poach peeled quarters until tender and freeze in their syrup — ready to drop into apple crumbles all winter.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('quince', 'Quince'),
+      bbcGoodFoodCollection('quince-recipes', 'Quince recipes'),
+    ],
+  },
+  {
+    plantId: 'fig-tree',
+    summary:
+      'A ripe fig barely keeps a day or two — deal with the harvest the same day it is picked.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick only when fully ripe and drooping — figs never ripen off the tree. Eat within a day or two; the fridge buys you a little time at the cost of some flavour.',
+        storageLife: '1–2 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze whole ripe figs on a tray the day you pick them, then bag. Thawed figs are soft, so use them for baking, compotes and jam rather than eating raw.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Fig jam is rich and sets with a little lemon juice — the best home for a sudden warm-spell glut.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+      {
+        method: 'dry',
+        how: 'Halve and dry in a dehydrator or the lowest oven until leathery — Scottish sunshine will not do it alone. Store the dried halves in an airtight jar.',
+        storageLife: '6–12 months dried, in airtight jars',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('fig', 'Fig'),
+      bbcGoodFoodCollection('fig-recipes', 'Fig recipes'),
+    ],
+  },
+  {
+    plantId: 'mulberry-tree',
+    summary:
+      'Mulberries are too fragile to sell, which is why you grow them — pick into shallow tubs and freeze or jam the same day.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Eat on the day of picking — they collapse and stain everything within hours. Lay a sheet under the tree and shake gently for the ripest fruit.',
+        storageLife: '1 day, briefly longer in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze on trays the same day, then bag. Frozen mulberries hold their flavour well for pies, compotes and later jam sessions.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Mulberry jam is a deep, winey treat — low in pectin, so add lemon juice or a grated apple for the set.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.jams],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('mulberries', 'Mulberry'),
+      BBC_GOOD_FOOD.jams,
+    ],
+  },
+]

--- a/src/lib/preservation/data/herbs.ts
+++ b/src/lib/preservation/data/herbs.ts
@@ -1,12 +1,461 @@
 /**
  * Herbs — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: parsley, coriander, mint, thyme,
-// rosemary, chives, lovage, sorrel, oregano, sage, french-tarragon, dill,
-// herb-fennel, lemon-balm, marjoram, bay, borage, chamomile, winter-savory,
-// hyssop
-export const herbsPreservation: PreservationGuide[] = []
+export const herbsPreservation: PreservationGuide[] = [
+  {
+    plantId: 'parsley',
+    summary:
+      'Cut-and-come-again all season — freeze the surplus, because frozen parsley beats dried every time.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Stand stems in a jar of water in the fridge like a bunch of flowers, loosely covered with a bag.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Chop and pack into ice-cube trays, top up with water, and freeze. Drop cubes straight into soups and sauces.',
+        storageLife: '6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Dries quickly on a tray in a warm airy room, but expect it to lose most of its flavour — freezing is the better keep.',
+        storageLife: '6–12 months in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('parsley', 'Parsley')],
+  },
+  {
+    plantId: 'coriander',
+    summary:
+      'Bolts before you can blink — freeze the leaves fast and let a few plants run to seed for the spice jar.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Wrap in damp kitchen paper inside a bag in the salad drawer. Use within days — it fades fast.',
+        storageLife: '4–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blitz leaves with a little oil and freeze in ice-cube trays for curry bases. Keep oil cubes frozen — never store herb oils at room temperature.',
+        storageLife: '6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Skip drying the leaves — dry the ripe seed heads instead. Hang in a paper bag until the seeds rattle free.',
+        storageLife: 'seeds keep 1 year+ airtight',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('coriander', 'Coriander')],
+  },
+  {
+    plantId: 'mint',
+    summary:
+      'Grows faster than you can drink tea — freeze cubes for sauce and dry bundles for the winter teapot.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Stand sprigs in a glass of water on the worktop or in the fridge door.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Chop into ice-cube trays with water — ready-made portions for mint sauce and summer drinks.',
+        storageLife: '6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Hang small bunches somewhere warm and airy, then crumble into a jar for tea. Cut just before flowering for the strongest flavour.',
+        storageLife: '1 year in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('mint', 'Mint'),
+      bbcGoodFoodCollection('mint-recipes', 'Mint recipes'),
+    ],
+  },
+  {
+    plantId: 'thyme',
+    summary: 'A woody herb that dries brilliantly — one good summer harvest stocks the jar for a year.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Sprigs keep well in a bag in the fridge — thyme is tougher than the soft herbs.',
+        storageLife: 'about 2 weeks',
+      },
+      {
+        method: 'dry',
+        how: 'Hang bundles in an airy spot for a week or two, then strip the leaves from the stems straight into a jar.',
+        storageLife: '1 year+ in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze whole sprigs in a bag and crumble them frozen into the pot — no chopping needed.',
+        storageLife: '6–12 months frozen',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('thyme', 'Thyme')],
+  },
+  {
+    plantId: 'rosemary',
+    summary: 'Evergreen, so fresh sprigs are there most of the year — dry a batch anyway for when snow buries the bush.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Cut sprigs keep a fortnight in a bag in the fridge, though picking fresh is usually easier.',
+        storageLife: 'about 2 weeks',
+      },
+      {
+        method: 'dry',
+        how: 'Hang sprigs in an airy spot until the needles snap, then strip into a jar. Holds its punch better dried than most herbs.',
+        storageLife: '1 year+ in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Open-freeze sprigs on a tray, then bag — the needles stay separate for winter roasts.',
+        storageLife: '6–12 months frozen',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('rosemary', 'Rosemary')],
+  },
+  {
+    plantId: 'chives',
+    summary: 'Snip, freeze, repeat — chives lose everything when dried, so the freezer is the only preserve worth doing.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep snipped chives in a tub in the fridge and use within the week.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Snip into short lengths and freeze loose in a tub — no blanching, no fuss. Chive butter frozen in a log is even better.',
+        storageLife: '6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('chives', 'Chives')],
+  },
+  {
+    plantId: 'lovage',
+    summary: 'One plant makes more celery flavour than a family can use — freeze it chopped as instant stock seasoning.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Cut stems keep in a bag in the salad drawer for a few days.',
+        storageLife: '4–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Chop leaves and young stems and freeze in small bags or cubes — one cube seasons a pot of soup or stock.',
+        storageLife: '6–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Dry leaves on a tray and crumble into a jar — a homemade stock powder with real depth.',
+        storageLife: '6–12 months in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('lovage', 'Lovage')],
+  },
+  {
+    plantId: 'sorrel',
+    summary: 'Wilts within hours of picking — eat it fresh, and cook the glut down into a puree for the freezer.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick young leaves just before use — sorrel collapses fast and does not travel.',
+        storageLife: 'use the same day; 2–3 days in the fridge at best',
+      },
+      {
+        method: 'freeze',
+        how: 'Wilt a big panful in butter until it turns khaki (it always does), then freeze the puree in small tubs for sauces and soup.',
+        storageLife: '6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('sorrel', 'Sorrel')],
+  },
+  {
+    plantId: 'oregano',
+    summary: 'One of the few herbs that improves with drying — the flavour actually intensifies in the jar.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Sprigs keep well in a bag in the fridge for a week or more.',
+        storageLife: '1–2 weeks',
+      },
+      {
+        method: 'dry',
+        how: 'Cut whole stems just as flower buds show and hang in bundles. Strip and jar once crackly — dried oregano beats fresh in most cooking.',
+        storageLife: '1 year+ in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze chopped leaves in oil-filled ice-cube trays for pizza and pasta sauces. Keep the cubes frozen — herb oils are not safe stored at room temperature.',
+        storageLife: '6 months frozen',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('oregano', 'Oregano')],
+  },
+  {
+    plantId: 'sage',
+    summary: 'Evergreen and generous — dry a jarful for stuffing season and freeze a few leaves in butter.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Leaves keep a fortnight wrapped in kitchen paper in a bag.',
+        storageLife: 'about 2 weeks',
+      },
+      {
+        method: 'dry',
+        how: 'Dry leaves slowly on a rack out of direct sun — rush it and they go musty. Store whole and crumble as needed.',
+        storageLife: '1 year in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Mash chopped sage into butter, roll into a log and freeze — slice off rounds for roast squash and Sunday birds.',
+        storageLife: '3–6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('sage', 'Sage')],
+  },
+  {
+    plantId: 'french-tarragon',
+    summary: 'Too good to waste and useless dried — freeze sprigs and make the classic tarragon vinegar.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Wrap sprigs in damp kitchen paper in a bag; use within the week.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze whole sprigs in a bag or chop into butter for a freezer log — drying kills the aniseed flavour entirely.',
+        storageLife: '3–6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'pickle',
+        how: 'Steep a few sprigs in a bottle of white wine vinegar for 2–3 weeks, then strain — tarragon vinegar is the backbone of bearnaise. Keep in the fridge for the best flavour.',
+        storageLife: '3–4 months refrigerated',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('tarragon', 'Tarragon')],
+  },
+  {
+    plantId: 'dill',
+    summary: 'Freeze the fronds for fish, dry the seed heads for the pickle pan — one plant, two harvests.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Stand stems in water in the fridge; the fronds fade within days.',
+        storageLife: '4–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Chop fronds into ice-cube trays with water, or freeze whole sprigs flat in a bag for gravadlax and potato salads.',
+        storageLife: '6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Hang ripe seed heads upside down in a paper bag until the seeds drop — dill seed is the essential pickling spice.',
+        storageLife: 'seeds keep 1 year+ airtight',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('dill', 'Dill'), BBC_GOOD_FOOD.pickles],
+  },
+  {
+    plantId: 'herb-fennel',
+    summary: 'The feathery leaves freeze for fish; the seeds dry for sausages, bread and tea.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Fronds keep a few days in a bag in the salad drawer — treat like dill.',
+        storageLife: '4–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Chop fronds into ice-cube trays with water and drop straight into fish dishes and sauces.',
+        storageLife: '6 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Cut seed heads as they turn brown and dry in a paper bag until the seeds shake loose. Far more useful dried than the leaves.',
+        storageLife: 'seeds keep 1 year+ airtight',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('fennel', 'Fennel')],
+  },
+  {
+    plantId: 'lemon-balm',
+    summary: 'A rampant grower best turned into tea — dry it gently and use the jar within months, before the lemon scent fades.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Sprigs keep a few days in a bag, but the scent is strongest straight off the plant.',
+        storageLife: '4–5 days',
+      },
+      {
+        method: 'dry',
+        how: 'Dry leaves fast in a warm airy room out of the sun, then jar whole. The lemon oils fade, so make small batches often.',
+        storageLife: 'best within 6 months airtight',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze chopped leaves in water-filled ice-cube trays — good dropped into summer drinks or a winter teapot.',
+        storageLife: '6 months frozen',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('lemon_balm', 'Lemon balm')],
+  },
+  {
+    plantId: 'marjoram',
+    summary: 'The sweeter cousin of oregano — dries just as well and holds its gentler flavour in the jar.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Sprigs keep a week or more in a bag in the fridge.',
+        storageLife: '1–2 weeks',
+      },
+      {
+        method: 'dry',
+        how: 'Hang bundles somewhere warm and airy just before the flowers open, then strip the dried leaves into a jar.',
+        storageLife: '1 year in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Chop and freeze in water cubes for tomato sauces — handy since the plant rarely survives a Scottish winter outside.',
+        storageLife: '6 months frozen',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('marjoram', 'Marjoram')],
+  },
+  {
+    plantId: 'bay',
+    summary: 'The easiest preserve on the plot — pick leaves any day of the year, and dry a handful flat for the jar.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Fresh-picked leaves keep a fortnight in a bag, though with an evergreen bush outside you rarely need to store them.',
+        storageLife: 'about 2 weeks',
+      },
+      {
+        method: 'dry',
+        how: 'Dry whole leaves flat between sheets of kitchen paper under a light weight so they do not curl. Jar once brittle.',
+        storageLife: '1 year+ in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('bay_leaf', 'Bay leaf')],
+  },
+  {
+    plantId: 'borage',
+    summary: 'Grown for the blue flowers — use them the day you pick them, or freeze them into ice cubes for summer drinks.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick flowers and young leaves just before use — they wilt within hours. Scatter flowers over salads and puddings.',
+        storageLife: 'use the same day',
+      },
+      {
+        method: 'freeze',
+        how: 'Set a single flower in each ice-cube tray compartment, top with water and freeze — the classic garnish for a jug of Pimms.',
+        storageLife: '6 months frozen',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('borage', 'Borage')],
+  },
+  {
+    plantId: 'chamomile',
+    summary: 'A tea crop, pure and simple — pick the open flowers on a dry morning and dry them the same day.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Fresh flowers make a delicate tea — steep a small handful in just-boiled water for 5 minutes.',
+        storageLife: 'use the same day',
+      },
+      {
+        method: 'dry',
+        how: 'Spread flower heads in a single layer on a tray in a warm airy room for a week, then store airtight. About a teaspoon of dried flowers per cup.',
+        storageLife: '1 year in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+    ],
+  },
+  {
+    plantId: 'winter-savory',
+    summary: 'The bean herb — evergreen through most winters, and its peppery leaves dry without losing their bite.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Sprigs keep a fortnight in a bag, though the bush usually offers fresh pickings most of the year.',
+        storageLife: 'about 2 weeks',
+      },
+      {
+        method: 'dry',
+        how: 'Hang bundles to dry and strip the leaves into a jar — made for winter pots of dried beans and lentils.',
+        storageLife: '1 year in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze whole sprigs in a bag and crumble frozen into stews.',
+        storageLife: '6–12 months frozen',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('savory', 'Savory')],
+  },
+  {
+    plantId: 'hyssop',
+    summary: 'Minty-bitter leaves that the bees love — dry a small jarful for teas and hearty stews.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Sprigs keep well in a bag in the fridge — it is a tough little shrub.',
+        storageLife: 'about 2 weeks',
+      },
+      {
+        method: 'dry',
+        how: 'Hang flowering stems in an airy spot, then strip leaves and flowers into a jar. Use sparingly — the flavour is strong.',
+        storageLife: '1 year in an airtight jar',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze chopped leaves in water cubes for slow-cooked bean and game dishes.',
+        storageLife: '6 months frozen',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('hyssop', 'Hyssop')],
+  },
+]

--- a/src/lib/preservation/data/leafy-greens.ts
+++ b/src/lib/preservation/data/leafy-greens.ts
@@ -1,12 +1,469 @@
 /**
  * Leafy Greens — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  GARDEN_ORGANIC_STORING,
+  UMN_SAUERKRAUT,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: lettuce, spinach, perpetual-spinach,
-// kale, cavolo-nero, chard, rocket, pak-choi, mizuna, land-cress, corn-salad,
-// winter-purslane, mustard-greens, watercress, salad-burnet, orache,
-// new-zealand-spinach, good-king-henry, radicchio, endive, ice-plant
-export const leafyGreensPreservation: PreservationGuide[] = []
+export const leafyGreensPreservation: PreservationGuide[] = [
+  {
+    plantId: 'lettuce',
+    summary:
+      'Lettuce does not preserve — sow little and often, eat it fresh, and braise or blitz the bolters into soup.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick in the cool of the morning and eat the same day for the best crunch. Cut-and-come-again varieties keep producing if you take outer leaves only.',
+        storageLife: 'best eaten the day it is picked',
+      },
+      {
+        method: 'fridge',
+        how: 'Wash, spin dry and keep in a box or bag with a sheet of kitchen paper to catch the damp. Whole heads keep longer than loose leaves.',
+        storageLife: '5–7 days',
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('lettuce', 'Lettuce'),
+      bbcGoodFoodCollection('salad-recipes', 'Salad recipes'),
+    ],
+  },
+  {
+    plantId: 'spinach',
+    summary:
+      'Wilts within days but freezes brilliantly — a spring glut becomes a freezer drawer of green portions for curries and pies.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick young leaves and eat within a day or two — spinach loses sweetness fast off the plant.',
+        storageLife: '2–3 days',
+      },
+      {
+        method: 'fridge',
+        how: 'Store unwashed in a loose bag in the salad drawer and wash just before use.',
+        storageLife: '3–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch for 1–2 minutes, cool in iced water, squeeze into fist-sized balls and bag them. One ball is a portion for a curry or pie filling.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('spinach', 'Spinach'),
+      bbcGoodFoodCollection('spinach-recipes', 'Spinach recipes'),
+    ],
+  },
+  {
+    plantId: 'perpetual-spinach',
+    summary:
+      'A leaf beet that crops for months — pick as you need it, and blanch-and-freeze whatever gets ahead of you.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in a loose bag in the salad drawer. It is tougher than true spinach and keeps a little longer.',
+        storageLife: '5–7 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Treat exactly like spinach: blanch for 2 minutes, squeeze dry and freeze in portion-sized balls. Cooked from frozen it is indistinguishable in pies and curries.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('spinach', 'Spinach')],
+  },
+  {
+    plantId: 'kale',
+    summary:
+      'The plot is the store — kale stands happily through a Scottish winter, so freeze only what you must.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave plants standing and pick leaves as needed right through winter — frost actually sweetens them. This beats any other storage method.',
+        storageLife: 'in the ground all winter',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'fridge',
+        how: 'Picked leaves keep in a bag in the salad drawer. Strip the tough midribs before cooking.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Strip out the midribs, blanch the leaves for 2 minutes, cool, squeeze and bag flat. Handy for soups and stews when the plot is under snow.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('kale', 'Kale'),
+      bbcGoodFoodCollection('kale-recipes', 'Kale recipes'),
+    ],
+  },
+  {
+    plantId: 'cavolo-nero',
+    summary:
+      'Stands through winter like kale — pick fresh from the plant for months, freeze the surplus for ribollita.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave plants in the ground and pick from the bottom up all winter. The flavour deepens after frost.',
+        storageLife: 'in the ground all winter',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'fridge',
+        how: 'Keep picked leaves in a loose bag in the salad drawer, unwashed.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Strip the midribs, blanch 2 minutes, squeeze dry and freeze in bags pressed flat. Goes straight from freezer to soup pot.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('cavolo_nero', 'Cavolo nero')],
+  },
+  {
+    plantId: 'chard',
+    summary:
+      'Two crops in one — freeze the leaves like spinach and treat the stems as a separate vegetable.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Plants stand for months and often overwinter — pick outer leaves as needed and they keep coming.',
+        storageLife: 'in the ground for months',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'fridge',
+        how: 'Store unwashed in a loose bag. Leaves wilt before the stems do, so use leaves first.',
+        storageLife: '4–7 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Separate leaves from stems: blanch leaves 2 minutes and stems 3 minutes, then freeze in separate bags. Stems are lovely gratinated; leaves go in anything spinach would.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('chard', 'Chard')],
+  },
+  {
+    plantId: 'rocket',
+    summary:
+      'A fast, peppery salad leaf that does not keep — eat it fresh, and blitz a bolting patch into pesto for the freezer.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick young leaves before the plant bolts and eat the same day — the pepper builds as leaves age.',
+        storageLife: 'best the day it is picked',
+      },
+      {
+        method: 'fridge',
+        how: 'Wash, dry well and keep in a box with kitchen paper in the salad drawer.',
+        storageLife: '3–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blitz a glut into a rocket pesto with oil, nuts and cheese, and freeze in ice-cube trays. Raw leaves do not freeze, but the pesto keeps the pepper.',
+        storageLife: '3–6 months frozen as pesto',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('rocket', 'Rocket')],
+  },
+  {
+    plantId: 'pak-choi',
+    summary:
+      'Best straight into the wok — and the classic base for a kimchi-style ferment when a sowing all hearts up at once.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep whole heads unwashed in a loose bag in the salad drawer. Baby heads wilt faster than full-sized ones.',
+        storageLife: '4–7 days',
+      },
+      {
+        method: 'ferment',
+        how: 'Salt quartered heads, rinse, then pack with chilli, garlic and ginger paste for a kimchi-style ferment. Keep everything under the brine and ferment cool for a few days before moving to the fridge.',
+        storageLife: 'several months in the fridge',
+        resources: [UMN_SAUERKRAUT, NCHFP.fermenting],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('pak_choi', 'Pak choi'),
+      bbcGoodFoodCollection('kimchi-recipes', 'Kimchi recipes'),
+    ],
+  },
+  {
+    plantId: 'mizuna',
+    summary:
+      'A cut-and-come-again winter salad — the plant itself is the store, so pick small and often.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Cut leaves as needed and the stumps resprout for weeks — under a cloche it crops most of the winter.',
+        storageLife: 'cut-and-come-again for weeks',
+      },
+      {
+        method: 'fridge',
+        how: 'Wash, dry thoroughly and keep in a box lined with kitchen paper. Larger leaves also wilt nicely into stir-fries.',
+        storageLife: '4–5 days',
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('salad_leaves', 'Salad leaves'),
+      bbcGoodFoodCollection('stir-fry-recipes', 'Stir-fry recipes'),
+    ],
+  },
+  {
+    plantId: 'land-cress',
+    summary:
+      'A hardy watercress stand-in that crops through winter — treat the bed as the larder and pick as needed.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick outer leaves as needed — plants stand through frost and keep producing where watercress would sulk.',
+        storageLife: 'in the ground through winter',
+      },
+      {
+        method: 'fridge',
+        how: 'Keep in a loose bag in the salad drawer and use within a few days. Older, hotter leaves are better cooked into soup than eaten raw.',
+        storageLife: '3–4 days',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('watercress', 'Watercress')],
+  },
+  {
+    plantId: 'corn-salad',
+    summary:
+      'The classic winter salad standby — it does not store, but then it does not need to, cropping outdoors when little else will.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Cut whole rosettes at soil level as needed through autumn and winter. The plants shrug off frost, so harvest to order.',
+        storageLife: 'in the ground all winter',
+      },
+      {
+        method: 'fridge',
+        how: 'Wash carefully — the rosettes trap grit — dry well and keep in a box with kitchen paper.',
+        storageLife: '4–5 days',
+      },
+    ],
+    recipeIdeas: [bbcGoodFoodCollection('winter-salad-recipes', 'Winter salad recipes')],
+  },
+  {
+    plantId: 'winter-purslane',
+    summary:
+      'A succulent winter salad that laughs at frost — pick fresh all season rather than trying to store it.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Cut leaves and stems as needed from autumn to spring — it regrows quickly and even the flowers are edible.',
+        storageLife: 'cut-and-come-again all winter',
+      },
+      {
+        method: 'fridge',
+        how: 'The fleshy leaves hold up better than lettuce in the fridge. Keep washed and dried in a lidded box.',
+        storageLife: '4–5 days',
+      },
+    ],
+    recipeIdeas: [bbcGoodFoodCollection('winter-salad-recipes', 'Winter salad recipes')],
+  },
+  {
+    plantId: 'mustard-greens',
+    summary:
+      'Hot leaves that mellow with cooking — freeze the big autumn flush and ferment a batch into a fiery kimchi.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in a loose bag in the salad drawer. Small leaves for salads, big ones for the pan.',
+        storageLife: '5–7 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch whole leaves for 2 minutes, squeeze dry and freeze in portions. Freezing tames the heat — good in dals and stir-fries.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'ferment',
+        how: 'Salt-wilt the leaves, then ferment with garlic, ginger and chilli for a mustard-green kimchi. Keep the leaves submerged and ferment cool before refrigerating.',
+        storageLife: 'several months in the fridge',
+        resources: [UMN_SAUERKRAUT, NCHFP.fermenting],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('mustard_leaves', 'Mustard leaves'),
+      bbcGoodFoodCollection('kimchi-recipes', 'Kimchi recipes'),
+    ],
+  },
+  {
+    plantId: 'watercress',
+    summary:
+      'Fades fast once picked — eat it within days, and turn any surplus into soup for the freezer.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick just before eating. Stems stood in a jar of water on the windowsill stay perky for a day or two.',
+        storageLife: '1–2 days',
+      },
+      {
+        method: 'fridge',
+        how: 'Keep bunched stems in a jar of water in the fridge, loosely covered with a bag, and change the water daily.',
+        storageLife: '3–4 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Raw leaves collapse when frozen, so cook a glut into watercress soup and freeze that in tubs instead.',
+        storageLife: '3–6 months frozen as soup',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('watercress', 'Watercress')],
+  },
+  {
+    plantId: 'salad-burnet',
+    summary:
+      'An evergreen cucumber-flavoured herb-cum-salad-leaf — the plant stores itself, staying green through most winters.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick the young ferny leaves as needed year-round — old leaves turn bitter, so keep cutting to force new growth.',
+        storageLife: 'evergreen — pick year-round',
+      },
+      {
+        method: 'fridge',
+        how: 'Keep sprigs in a lidded box with damp kitchen paper. Use in salads, soft cheeses and summer drinks within a few days.',
+        storageLife: '3–4 days',
+      },
+    ],
+    recipeIdeas: [bbcGoodFoodCollection('salad-recipes', 'Salad recipes')],
+  },
+  {
+    plantId: 'orache',
+    summary:
+      'Mountain spinach in name and in the kitchen — eat the young leaves fresh and blanch-and-freeze the summer surplus.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep picked leaves unwashed in a loose bag in the salad drawer and use within a few days.',
+        storageLife: '4–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Treat like spinach: blanch for 1–2 minutes, squeeze dry and freeze in balls. It holds its colour well — the red varieties do bleed a little.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('spinach', 'Spinach')],
+  },
+  {
+    plantId: 'new-zealand-spinach',
+    summary:
+      'A sprawling summer spinach substitute that keeps cropping in heat — cook it before eating, and freeze it the same way.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'The fleshy leaves keep better than true spinach — store unwashed in a loose bag in the salad drawer.',
+        storageLife: '5–7 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Always blanch before freezing — 2 minutes, then squeeze dry and bag in portions. Blanching also deals with the oxalates, so do not skip it.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('spinach', 'Spinach')],
+  },
+  {
+    plantId: 'good-king-henry',
+    summary:
+      'A perennial spinach for the margins — spring shoots are the prize, and the leaf glut freezes like any other pot herb.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep picked shoots and leaves in a loose bag in the salad drawer. Young growth is far better than the bitter older leaves.',
+        storageLife: '5–7 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch leaves for 2 minutes, squeeze and freeze in balls like spinach. The asparagus-like spring shoots can be blanched 2–3 minutes and frozen too.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('spinach', 'Spinach')],
+  },
+  {
+    plantId: 'radicchio',
+    summary:
+      'The best-keeping salad on the plot — tight winter heads sit happily in the fridge for weeks.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Hardy varieties stand outside well into winter — leave heads on the plant and cut as needed.',
+        storageLife: 'in the ground into winter',
+      },
+      {
+        method: 'fridge',
+        how: 'Cut whole heads, strip the ragged outer leaves and keep wrapped in the salad drawer. Peel off leaves as you need them and the heart keeps on.',
+        storageLife: '2–3 weeks',
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('radicchio', 'Radicchio'),
+      bbcGoodFoodCollection('winter-salad-recipes', 'Winter salad recipes'),
+    ],
+  },
+  {
+    plantId: 'endive',
+    summary:
+      'A bitter autumn salad that keeps better than lettuce — blanch heads under a pot for a sweeter heart, then fridge them whole.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Cover a maturing head with a plate or flowerpot for 10 days before cutting to blanch the heart pale and mild. Cut as needed — plants stand well in autumn.',
+        storageLife: 'stands in the ground through autumn',
+      },
+      {
+        method: 'fridge',
+        how: 'Keep whole heads wrapped in the salad drawer and strip leaves as needed. Bitter outer leaves are good braised or grilled rather than binned.',
+        storageLife: '1–2 weeks',
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('endive', 'Endive'),
+      bbcGoodFoodCollection('winter-salad-recipes', 'Winter salad recipes'),
+    ],
+  },
+  {
+    plantId: 'ice-plant',
+    summary:
+      'Grown for its crunchy, salty, frosted-looking leaves — strictly an eat-fresh crop, picked as you need it.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick young leaves and stem tips as needed through summer — regular picking keeps the plant producing. The salty crunch is the whole point, so eat soon after cutting.',
+        storageLife: 'best the day it is picked',
+      },
+      {
+        method: 'fridge',
+        how: 'The succulent leaves hold their crunch for a few days in a lidded box in the salad drawer — no washing until you use them.',
+        storageLife: '3–4 days',
+      },
+    ],
+    recipeIdeas: [bbcGoodFoodCollection('salad-recipes', 'Salad recipes')],
+  },
+]

--- a/src/lib/preservation/data/legumes.ts
+++ b/src/lib/preservation/data/legumes.ts
@@ -1,11 +1,302 @@
 /**
  * Legumes — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  GARDEN_ORGANIC_STORING,
+  UMN_HARVEST_STORAGE,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: peas, runner-beans, broad-beans,
-// french-beans, climbing-french-beans, borlotti-beans, edamame, mangetout,
-// sugar-snap-peas, asparagus-peas, black-turtle-beans, fenugreek, ground-nut
-export const legumesPreservation: PreservationGuide[] = []
+export const legumesPreservation: PreservationGuide[] = [
+  {
+    plantId: 'peas',
+    summary:
+      'The sugars turn to starch within hours of picking — eat them the same day or get them straight into the freezer.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick, pod and eat the same day if you can — peas lose their sweetness faster than anything else on the plot. Unpodded they hold 3–4 days in the fridge.',
+        storageLife: '3–4 days in the pod, fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Pod, blanch for 90 seconds, cool in cold water, then open-freeze on a tray before bagging. Done within an hour of picking they beat anything from the shop.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('pea', 'Pea'),
+      bbcGoodFoodCollection('pea-recipes', 'Pea recipes'),
+    ],
+  },
+  {
+    plantId: 'runner-beans',
+    summary:
+      'The great Scottish glut crop — freeze the young ones and turn the stragglers into chutney.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in a loose bag in the salad drawer. Pick young and often — pods left to swell go stringy and slow the plant down.',
+        storageLife: '3–5 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Top, tail and de-string, slice diagonally, blanch for 2 minutes, cool and bag in meal-sized portions.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Runner bean chutney is the classic answer to the ones that got away — slice, salt, then simmer with vinegar, sugar, mustard and turmeric.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [BBC_GOOD_FOOD.chutneys],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('runner_bean', 'Runner bean'),
+      bbcGoodFoodCollection('runner-bean-recipes', 'Runner bean recipes'),
+    ],
+  },
+  {
+    plantId: 'broad-beans',
+    summary:
+      'Pod and freeze the main crop; let the last pods dry on the plant for winter stews.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick while the beans are the size of a thumbnail and eat within a couple of days — big floury beans want skinning after cooking.',
+        storageLife: '2–3 days in the pod, fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Pod, blanch for 2 minutes, cool and bag. The grey skins slip off easily once defrosted if you want bright green beans.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Leave the last pods to blacken and dry on the plant, then shell and store the beans in airtight jars. Soak overnight and boil until tender before eating.',
+        storageLife: '1 year+ in airtight jars',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('broad_beans', 'Broad bean'),
+      bbcGoodFoodCollection('broad-bean-recipes', 'Broad bean recipes'),
+    ],
+  },
+  {
+    plantId: 'french-beans',
+    summary: 'Quick to glut in a good week — blanch and freeze whatever you cannot eat fresh.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick pencil-thin and eat within a few days, keeping any extras unwashed in a bag in the fridge. Keep picking to keep the plants cropping.',
+        storageLife: '3–5 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Top and tail, blanch whole for 2 minutes, cool in cold water and freeze flat on a tray before bagging.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('french_beans', 'French bean')],
+  },
+  {
+    plantId: 'climbing-french-beans',
+    summary:
+      'Freeze the glut of green pods, and let a few plants run on for home-grown haricot beans.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick young and slim every couple of days and keep unwashed in the fridge.',
+        storageLife: '3–5 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Top and tail, blanch for 2 minutes, cool and bag in portions — climbers crop hard so the freezer earns its keep.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Leave late pods to dry on the vine until they rattle, then shell out the haricots into airtight jars. Dried beans must be soaked and boiled hard for at least 10 minutes before eating — never slow-cook them from raw.',
+        storageLife: '1 year+ in airtight jars',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('french_beans', 'French bean')],
+  },
+  {
+    plantId: 'borlotti-beans',
+    summary:
+      'Grown for drying — let the speckled pods rattle on the vine, then shell into jars for winter.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Shell the beans at the plump, mottled stage and simmer until tender for the best fresh borlotti — always cook them well, never eat raw.',
+        storageLife: 'use within a few days of shelling',
+      },
+      {
+        method: 'dry',
+        how: 'Leave the pods on the plant until papery and rattling; in a wet autumn pull whole plants and hang them somewhere airy to finish. Shell once fully dry.',
+        resources: [NCHFP.drying, GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store the shelled dried beans in airtight jars somewhere cool and dark. Soak overnight and boil hard for at least 10 minutes before eating — never slow-cook dried borlotti from raw.',
+        storageLife: '1 year+ in airtight jars',
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('borlotti_bean', 'Borlotti bean')],
+  },
+  {
+    plantId: 'edamame',
+    summary: 'Best steamed the day they are picked — blanch and freeze the pods for later.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick while the pods are plump and bright green and steam or boil them the same day — the flavour fades fast.',
+        storageLife: '1–2 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch whole pods for 2–3 minutes, cool in cold water and freeze in bags. Cook straight from frozen with a pinch of salt.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('soya_bean', 'Soya bean')],
+  },
+  {
+    plantId: 'mangetout',
+    summary: 'Pick flat and young, eat fresh — the freezer is a fallback for a heavy week.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick while the pods are flat, before the peas swell, and keep in a bag in the fridge. Crispest eaten within a day or two.',
+        storageLife: '2–3 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch for 1 minute, cool fast and open-freeze on a tray. They soften a little, so save frozen ones for stir-fries rather than salads.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('mangetout', 'Mangetout')],
+  },
+  {
+    plantId: 'sugar-snap-peas',
+    summary: 'Sweetest straight off the plant — blanch and freeze only what you cannot keep up with.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick when the pods are plump but still snap cleanly, and eat within a couple of days from the fridge.',
+        storageLife: '2–3 days in the fridge',
+      },
+      {
+        method: 'freeze',
+        how: 'Top, tail and de-string, blanch for 90 seconds, cool and freeze on a tray before bagging. Best used in cooked dishes after freezing.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('pea', 'Pea'),
+      bbcGoodFoodCollection('pea-recipes', 'Pea recipes'),
+    ],
+  },
+  {
+    plantId: 'asparagus-peas',
+    summary:
+      'A pick-daily novelty — the winged pods are only good tiny, so eat fresh and freeze small batches.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick the pods at 2–3cm — any bigger and they turn woody. Best steamed with butter the day they are picked.',
+        storageLife: '1–2 days in the fridge',
+      },
+      {
+        method: 'fridge',
+        how: 'Keep unwashed in a bag in the salad drawer and use quickly; they toughen in storage as well as on the plant.',
+        storageLife: '2–3 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch for 1 minute, cool and open-freeze. A fallback for a glut rather than a highlight — save frozen ones for stews.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'black-turtle-beans',
+    summary:
+      'A true storage crop — dry on the vine, jar up for the year, and always boil hard before eating.',
+    methods: [
+      {
+        method: 'dry',
+        how: 'Leave the pods to dry fully on the plant until they rattle; if autumn turns wet, pull whole plants and hang them under cover to finish. Shell once papery.',
+        resources: [NCHFP.drying, GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store the dried beans in airtight jars somewhere cool and dark. Soak overnight and boil hard for at least 10 minutes before eating — never slow-cook dried beans from raw.',
+        storageLife: '1 year+ in airtight jars',
+      },
+      {
+        method: 'freeze',
+        how: 'Cook a big pot properly (soaked, then boiled hard) and freeze in tubs with a little of the cooking liquid — home-made tinned beans.',
+        storageLife: '6 months frozen, cooked',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('black_beans', 'Black bean')],
+  },
+  {
+    plantId: 'fenugreek',
+    summary:
+      'Two crops in one — fresh methi leaves for the fridge, and seed pods dried for the spice jar.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Use the methi leaves fresh in curries and flatbreads; a bunch keeps a few days wrapped in damp paper in the fridge.',
+        storageLife: '3–4 days',
+      },
+      {
+        method: 'dry',
+        how: 'Dry bunches of leaves somewhere warm and airy for kasuri methi, and let seed pods dry fully on the plant before shelling the seeds into a jar for spice.',
+        storageLife: 'leaves 6–12 months; seeds 1 year+ in airtight jars',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('fenugreek', 'Fenugreek')],
+  },
+  {
+    plantId: 'ground-nut',
+    summary:
+      'Treat the tubers like small potatoes — lift in autumn, store cool and dark, and always cook before eating.',
+    methods: [
+      {
+        method: 'store-cool',
+        how: 'Lift the tubers in autumn once the tops die back and store somewhere cool, dark and frost-free in a paper sack or a box of dry compost. Always cook them thoroughly — never eat raw.',
+        storageLife: '2–4 months, cool and dark',
+        resources: [GARDEN_ORGANIC_STORING, UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'fridge',
+        how: 'Smaller amounts keep in a paper bag in the fridge — do not wash until you are ready to cook them.',
+        storageLife: '2–3 weeks',
+      },
+    ],
+  },
+]

--- a/src/lib/preservation/data/mushrooms.ts
+++ b/src/lib/preservation/data/mushrooms.ts
@@ -1,10 +1,147 @@
 /**
  * Mushrooms — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import { NCHFP, bbcFoodIngredient, bbcGoodFoodCollection } from '../resources'
 
-// TODO(preserving-data): author guides for: oyster-mushroom, shiitake,
-// lions-mane, king-oyster, button-mushroom
-export const mushroomsPreservation: PreservationGuide[] = []
+export const mushroomsPreservation: PreservationGuide[] = [
+  {
+    plantId: 'oyster-mushroom',
+    summary:
+      'Flushes come all at once — use fresh within days, then dry or cook-and-freeze the rest. Never home-can mushrooms.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep in a paper bag in the fridge, never a sealed plastic one — they sweat and slime. Use within a few days of picking.',
+        storageLife: '3–5 days in a paper bag',
+      },
+      {
+        method: 'dry',
+        how: 'Tear into strips and dry in a dehydrator or low oven until cracker-crisp, then store airtight. Rehydrate in warm water for soups and noodles — the soaking liquid is free stock.',
+        storageLife: '1 year+ airtight and dry',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Saute in butter or dry-fry until the moisture is gone, cool, and freeze in portions. Raw mushrooms freeze to mush; cooked ones hold up fine.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('oyster_mushroom', 'Oyster mushroom'),
+      bbcGoodFoodCollection('mushroom-recipes', 'Mushroom recipes'),
+    ],
+  },
+  {
+    plantId: 'shiitake',
+    summary:
+      'The one mushroom that improves with drying — the flavour deepens and the stock from soaked caps is a bonus.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep fresh caps a week in a paper bag in the fridge. Save the tough stems in the freezer for stock.',
+        storageLife: 'up to 1 week in a paper bag',
+      },
+      {
+        method: 'dry',
+        how: 'Slice or thread whole caps and dry in a dehydrator, low oven or airing cupboard until brittle, then store airtight. Dried shiitake tastes stronger than fresh — soak 20–30 minutes before cooking.',
+        storageLife: '1 year+ airtight and dry',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Saute sliced caps until dry in the pan, then cool and freeze in meal-sized bags. Freezing is the route for cooked surplus; drying beats it for flavour.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('shiitake_mushroom', 'Shiitake mushroom'),
+      bbcGoodFoodCollection('mushroom-recipes', 'Mushroom recipes'),
+    ],
+  },
+  {
+    plantId: 'lions-mane',
+    summary:
+      'Delicate and quick to spoil — eat fresh within days, freeze cooked slices, or dry the surplus for powder and broths.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep whole in a paper bag in the fridge and use within a few days — it browns and sours faster than most mushrooms.',
+        storageLife: '3–5 days in a paper bag',
+      },
+      {
+        method: 'freeze',
+        how: 'Slice into steaks and dry-fry or saute until golden and the moisture is gone, then cool and freeze flat. Cooked first it keeps its lovely crab-like texture; raw it turns to sponge.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Tear into chunks and dry low and slow until hard, then store airtight. Dried pieces are chewy rehydrated, so most folk blitz them to powder for broths and gravies.',
+        storageLife: '1 year+ airtight and dry',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [bbcGoodFoodCollection('mushroom-recipes', 'Mushroom recipes')],
+  },
+  {
+    plantId: 'king-oyster',
+    summary:
+      'The best keeper of the home-grown mushrooms — a week or more in the fridge, and thick slices dry and freeze well.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keeps longer than most mushrooms thanks to its dense flesh — a paper bag in the fridge buys you a week or more.',
+        storageLife: '7–10 days in a paper bag',
+      },
+      {
+        method: 'dry',
+        how: 'Slice lengthways into thick strips and dry until leathery-hard, then store airtight. Rehydrated slices keep a good meaty chew for stews and stir-fries.',
+        storageLife: '1 year+ airtight and dry',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'freeze',
+        how: 'Slice into coins or scored steaks, saute until browned, then cool and freeze in portions. Cooked first, the meaty texture survives the freezer.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('mushroom', 'Mushroom'),
+      bbcGoodFoodCollection('mushroom-recipes', 'Mushroom recipes'),
+    ],
+  },
+  {
+    plantId: 'button-mushroom',
+    summary:
+      'A steady cropper rather than a glut crop — fridge for the week, cook-and-freeze or dry anything beyond that.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep in a paper bag in the fridge and use within the week. Do not wash until you cook them — damp buttons slime fast.',
+        storageLife: '5–7 days in a paper bag',
+      },
+      {
+        method: 'freeze',
+        how: 'Saute sliced or halved buttons until the liquid cooks off, then cool and freeze in portions for sauces, stews and fry-ups. Freezing or drying only — mushrooms are a classic low-acid canning risk.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Slice 5mm thick and dry in a dehydrator or low oven until crisp, then store airtight in the dark. Blitz a jarful to mushroom powder for instant umami in gravies.',
+        storageLife: '1 year+ airtight and dry',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('mushroom', 'Mushroom'),
+      bbcGoodFoodCollection('mushroom-recipes', 'Mushroom recipes'),
+    ],
+  },
+]

--- a/src/lib/preservation/data/other.ts
+++ b/src/lib/preservation/data/other.ts
@@ -1,10 +1,185 @@
 /**
  * Specialty Vegetables — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  GARDEN_ORGANIC_STORING,
+  UMN_HARVEST_STORAGE,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: sweetcorn, asparagus,
-// globe-artichoke, rhubarb, celery, cardoon, mashua
-export const otherPreservation: PreservationGuide[] = []
+export const otherPreservation: PreservationGuide[] = [
+  {
+    plantId: 'sweetcorn',
+    summary:
+      'The clock starts the moment you pick — eat or freeze the same day, before the sugars turn to starch.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Pick when the silks are brown and a pierced kernel bleeds milky juice, then get it in the pot. Sweetcorn loses sweetness by the hour, so harvest just before you cook.',
+        storageLife: '1–2 days at most, and it is downhill all the way',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch whole cobs for 4–6 minutes or strip the kernels and blanch for 2, cool fast in iced water, and bag. Freezing is the safe route for corn — never home-can it without pressure canning.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('sweetcorn', 'Sweetcorn'),
+      bbcGoodFoodCollection('sweetcorn-recipes', 'Sweetcorn recipes'),
+    ],
+  },
+  {
+    plantId: 'asparagus',
+    summary:
+      'A short season best eaten spear-to-pan the same day; blanch and freeze the surplus rather than trying to store it.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Stand the spears upright in a jar with an inch of water, like a bunch of flowers, and keep in the fridge. Trim the bases first.',
+        storageLife: '3–4 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch spears 2–4 minutes depending on thickness, cool in iced water, and freeze flat on a tray before bagging. Frozen spears go soft, so plan them for soups, tarts and risotto rather than steaming whole.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'pickle',
+        how: 'Pack blanched spears upright in jars of hot spiced vinegar for a sharp spring pickle. Asparagus is a low-acid vegetable, so vinegar pickling or freezing only — never plain home canning.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('asparagus', 'Asparagus'),
+      bbcGoodFoodCollection('asparagus-recipes', 'Asparagus recipes'),
+    ],
+  },
+  {
+    plantId: 'globe-artichoke',
+    summary:
+      'Best cooked within days of cutting; a glut of buds becomes frozen hearts or a jar of marinated hearts in the fridge.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Keep unwashed buds in a bag in the salad drawer and cook within the week. A splash of water in the bag stops the bracts drying out.',
+        storageLife: 'about 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Trim down to the hearts, rub with lemon to stop browning, blanch for 5–7 minutes, then cool and freeze. Raw artichoke discolours and freezes badly.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'pickle',
+        how: 'Simmer trimmed hearts in vinegar and water, then jar in fresh spiced vinegar. Hearts kept under oil are fridge-only and short-life — never a shelf preserve.',
+        storageLife: 'pickled 6–12 months sealed; hearts in oil a few days in the fridge',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('globe_artichoke', 'Globe artichoke')],
+  },
+  {
+    plantId: 'rhubarb',
+    summary:
+      'The great Scottish glut crop — it freezes raw with no fuss and turns into crumbles, jam and cordial all year.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Wrap pulled stems in a damp cloth or bag in the salad drawer. Leaves off and on the compost — they are not edible.',
+        storageLife: '1–2 weeks',
+      },
+      {
+        method: 'freeze',
+        how: 'Chop raw into crumble-sized chunks and open-freeze on a tray before bagging — no blanching needed. Freeze in weighed batches so each bag is one crumble or one batch of jam.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'jam',
+        how: 'Rhubarb and ginger jam is the classic; rhubarb chutney handles the coarser late stems. Low in pectin, so pair with jam sugar or a high-pectin fruit.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [NCHFP.jams, BBC_GOOD_FOOD.chutneys],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('rhubarb', 'Rhubarb'),
+      bbcGoodFoodCollection('rhubarb-recipes', 'Rhubarb recipes'),
+    ],
+  },
+  {
+    plantId: 'celery',
+    summary:
+      'Keeps a fortnight in the fridge; after that it is soup-bag territory — frozen celery is for cooking, not crunching.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Wrap whole heads tightly in foil or a damp cloth in the salad drawer. Limp stalks revive in a jug of iced water.',
+        storageLife: 'about 2 weeks',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Chop and blanch for 1–2 minutes, or freeze raw straight into a soup bag with other stock vegetables. Frozen celery loses its crunch, so it is for soups, stews and stock only.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Dry the leaves and thin stalks in a low oven or dehydrator, then crumble with salt for homemade celery salt. Store airtight in the dark.',
+        storageLife: '6–12 months airtight',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('celery', 'Celery'),
+      bbcGoodFoodCollection('celery-recipes', 'Celery recipes'),
+    ],
+  },
+  {
+    plantId: 'cardoon',
+    summary:
+      'Blanched stems are a use-it-fresh crop — cook within the week, and freeze any cooked surplus for gratins.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Wrap the cut stems in a damp cloth in the salad drawer and use within a week. Always cook cardoon before eating — strip the strings and simmer until tender.',
+        storageLife: 'up to 1 week',
+      },
+      {
+        method: 'freeze',
+        how: 'Cut into short lengths, rub with lemon, blanch in acidulated water for 5 minutes, then cool and freeze. Ready straight from the freezer for gratins and stews.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'mashua',
+    summary:
+      'Treat the tubers like oca — lift after frost and store cool and dark; a few days of light sweetens the peppery bite.',
+    methods: [
+      {
+        method: 'store-cool',
+        how: 'Lift after the first frosts, let the tubers dry for a day, and store in paper bags or trays somewhere cool, dark and frost-free. A few days in daylight before cooking mellows the mustardy heat.',
+        storageLife: '2–3 months cool and dark',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'fridge',
+        how: 'Smaller batches keep in a paper bag in the salad drawer. Best roasted or boiled — raw mashua is fierce.',
+        storageLife: '2–3 weeks',
+      },
+    ],
+  },
+]

--- a/src/lib/preservation/data/root-vegetables.ts
+++ b/src/lib/preservation/data/root-vegetables.ts
@@ -1,12 +1,536 @@
 /**
  * Root Vegetables — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  GARDEN_ORGANIC_STORING,
+  UMN_HARVEST_STORAGE,
+  UMN_SAUERKRAUT,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: carrot, beetroot, parsnip, turnip,
-// swede, radish, jerusalem-artichoke, celeriac, salsify, hamburg-parsley,
-// florence-fennel, mooli, black-radish, scorzonera, horseradish,
-// chinese-artichoke, yacon, skirret, oca, ulluco
-export const rootVegetablesPreservation: PreservationGuide[] = []
+export const rootVegetablesPreservation: PreservationGuide[] = [
+  {
+    plantId: 'carrot',
+    summary:
+      'A box of damp sand in a cool shed keeps maincrop carrots crisp until spring — the classic keeper.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Twist off the tops (they pull moisture from the root) and keep unwashed in a bag in the salad drawer.',
+        storageLife: '2–4 weeks',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lift on a dry day, rub off loose soil and layer undamaged roots in boxes of damp sand somewhere cool and frost-free. Use any damaged ones first.',
+        storageLife: '4–5 months in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Cut into batons or slices, blanch for 2–3 minutes, cool and bag. Small whole carrots freeze well blanched for 5 minutes.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('carrot', 'Carrot'),
+      bbcGoodFoodCollection('carrot-cake-recipes', 'Carrot cake recipes'),
+    ],
+  },
+  {
+    plantId: 'beetroot',
+    summary:
+      'Stores for months in damp sand, and the glut makes the best pickle on the allotment.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Twist the tops off an inch above the root — cutting makes them bleed — and keep unwashed in the fridge.',
+        storageLife: '2–3 weeks',
+      },
+      {
+        method: 'store-cool',
+        how: 'Layer undamaged roots in boxes of damp sand in a cool, frost-free shed. Check monthly and use any that soften.',
+        storageLife: '3–5 months in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'pickle',
+        how: 'Boil until tender, slip the skins, slice and pack in spiced vinegar. The classic route for a glut.',
+        storageLife: '6–12 months in sealed jars',
+        resources: [NCHFP.pickling, BBC_GOOD_FOOD.pickles],
+      },
+      {
+        method: 'freeze',
+        how: 'Cook fully first — boil or roast, skin, cube and freeze in tubs. Raw beetroot goes rubbery in the freezer.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('beetroot', 'Beetroot'),
+      bbcGoodFoodCollection('beetroot-recipes', 'Beetroot recipes'),
+    ],
+  },
+  {
+    plantId: 'parsnip',
+    summary:
+      'The easiest keeper of all — leave them in the ground and let the frost do the sweetening.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave in the bed and dig as needed right through winter — frost converts starch to sugar and improves them. Mark the row before the tops die back.',
+        storageLife: 'in the ground until early spring',
+      },
+      {
+        method: 'store-cool',
+        how: 'If the plot is far away or the ground freezes solid, lift and pack in boxes of damp sand in a cool shed.',
+        storageLife: '3–4 months in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Cut into chunks, blanch for 2–3 minutes and freeze, or par-roast and freeze ready for the roasting tin.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('parsnip', 'Parsnip')],
+  },
+  {
+    plantId: 'turnip',
+    summary:
+      'Eat the small summer ones fresh; maincrop turnips store in sand like any other root.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Twist off the tops (cook those like spring greens) and keep the roots in a bag in the salad drawer.',
+        storageLife: '2–3 weeks',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lift maincrop turnips before hard frost, twist the tops off and store in boxes of damp sand somewhere cool.',
+        storageLife: '3–4 months in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Cube, blanch for 2 minutes and freeze — best kept for mash, soups and stews rather than serving whole.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('turnip', 'Turnip')],
+  },
+  {
+    plantId: 'swede',
+    summary:
+      'Hardy enough to sit in the ground until Burns Night — the lowest-effort winter storage there is.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave in the bed and lift as needed through winter — swedes shrug off Scottish frost better than almost anything.',
+        storageLife: 'in the ground until spring',
+      },
+      {
+        method: 'store-cool',
+        how: 'Or lift, twist off the tops and store in boxes of damp sand or net sacks somewhere cool and frost-free.',
+        storageLife: '4–6 months',
+        resources: [GARDEN_ORGANIC_STORING, UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Cook and mash your neeps, then freeze in portions — ready to reheat alongside the haggis.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('swede', 'Swede')],
+  },
+  {
+    plantId: 'radish',
+    summary:
+      'A sow-little-and-often crop — eat fresh within days, and quick-pickle any that get away.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Best pulled and eaten the same day while they still snap. Woody or pithy ones have been left too long.',
+        storageLife: 'a day or two at their best',
+      },
+      {
+        method: 'fridge',
+        how: 'Remove the leaves and keep the roots in a bag or a tub of water in the fridge to hold the crunch.',
+        storageLife: 'up to 10 days',
+      },
+      {
+        method: 'pickle',
+        how: 'Slice into rounds and pour over a hot sweet-and-sour vinegar — quick-pickled radish is ready next day and lifts any salad or sandwich.',
+        storageLife: '2–4 weeks in the fridge',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('radish', 'Radish'),
+      BBC_GOOD_FOOD.pickles,
+    ],
+  },
+  {
+    plantId: 'jerusalem-artichoke',
+    summary:
+      'Store them in the ground — the knobbly tubers shrivel fast once lifted, so dig only what you need.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave the tubers in the bed all winter and fork out a portion at a time. They are completely frost-hardy in the soil.',
+        storageLife: 'in the ground until spring regrowth',
+      },
+      {
+        method: 'store-cool',
+        how: 'If you must lift a batch, pack unwashed tubers in damp sand and use within a few weeks — they lose moisture much faster than carrots.',
+        storageLife: '2–4 weeks in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Cook into soup or a purée first and freeze in tubs. Raw tubers discolour and turn soft in the freezer.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('jerusalem_artichoke', 'Jerusalem artichoke')],
+  },
+  {
+    plantId: 'celeriac',
+    summary:
+      'An ugly root that keeps beautifully — sand-boxed celeriac gives celery flavour all winter.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Trim the leaf stalks and whiskery roots, then keep whole and unwashed in the salad drawer.',
+        storageLife: '3–4 weeks',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lift before hard frost, trim the tops to a stub and pack in boxes of damp sand in a cool shed.',
+        storageLife: '3–5 months in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Peel, cube and blanch for 2–3 minutes before bagging, or freeze it as ready-made mash or soup.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('celeriac', 'Celeriac')],
+  },
+  {
+    plantId: 'salsify',
+    summary:
+      'Hardy enough to overwinter in the bed — lift the oyster-flavoured roots as the kitchen needs them.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave in the ground over winter and dig as needed — the long brittle roots keep best undisturbed in the soil.',
+        storageLife: 'in the ground until spring',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lifted roots dry out quickly, so pack them straight into damp sand and use within a few weeks.',
+        storageLife: '2–4 weeks in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Peel (in a bowl of acidulated water to stop browning), blanch 2 minutes and freeze, or freeze as cooked purée for soup.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('salsify', 'Salsify')],
+  },
+  {
+    plantId: 'hamburg-parsley',
+    summary:
+      'Two crops in one — the parsnip-like roots store in ground or sand, and the tops freeze like parsley.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Fully hardy, so leave the roots in the bed and lift through winter as needed.',
+        storageLife: 'in the ground until early spring',
+      },
+      {
+        method: 'store-cool',
+        how: 'Or lift and pack in boxes of damp sand in a cool shed, the same as carrots and parsnips.',
+        storageLife: '3–4 months in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Chop the leaves and freeze in ice-cube trays with a little water, just like parsley. The roots freeze best cubed and blanched for soup and stock.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'florence-fennel',
+    summary:
+      'A poor keeper — eat the bulbs fresh and fast, and pickle or freeze any surplus for cooking.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Cut and eat as soon as the bulbs are fist-sized — they bolt and toughen quickly, so do not wait for bigger.',
+        storageLife: 'a few days at its best',
+      },
+      {
+        method: 'fridge',
+        how: 'Keep whole bulbs in the salad drawer with the fronds trimmed off (freeze the fronds as a herb).',
+        storageLife: 'about 10 days',
+      },
+      {
+        method: 'freeze',
+        how: 'Slice into wedges, blanch for 2–3 minutes and freeze — good braised or roasted later, though the raw crunch is lost.',
+        storageLife: '6–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'pickle',
+        how: 'Shave thinly and quick-pickle in sweet white-wine vinegar — keeps the aniseed freshness for salads and fish.',
+        storageLife: '2–4 weeks in the fridge',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('fennel', 'Fennel'),
+      bbcGoodFoodCollection('fennel-recipes', 'Fennel recipes'),
+    ],
+  },
+  {
+    plantId: 'mooli',
+    summary:
+      'Keeps a fortnight in the fridge, but the real destination for a glut is kimchi-style ferments and quick pickles.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Remove the leaves and keep the roots wrapped or bagged in the salad drawer.',
+        storageLife: 'about 2 weeks',
+      },
+      {
+        method: 'pickle',
+        how: 'Cube or slice and pour over a hot rice-vinegar brine with a little sugar and turmeric for danmuji-style pickles.',
+        storageLife: '1–2 months in the fridge',
+        resources: [NCHFP.pickling],
+      },
+      {
+        method: 'ferment',
+        how: 'Cube, salt at about 2 percent with garlic, ginger and chilli, and ferment at room temperature for a few days for kkakdugi (radish kimchi). Keep the tubers submerged in the brine.',
+        storageLife: 'several months in the fridge once fermented',
+        resources: [UMN_SAUERKRAUT, NCHFP.fermenting],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('daikon', 'Daikon (mooli)')],
+  },
+  {
+    plantId: 'black-radish',
+    summary:
+      'The winter radish that actually keeps — treat it like a storage root, not a salad crop.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Top the roots and keep them in a bag in the salad drawer — far longer-lived than summer radish.',
+        storageLife: '3 weeks or more',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lift before hard frost and pack in boxes of damp sand in a cool shed, the same as carrots.',
+        storageLife: '2–3 months in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'pickle',
+        how: 'Slice or grate and quick-pickle in cider vinegar to tame the heat — good with cold meats and cheese.',
+        storageLife: '1–2 months in the fridge',
+        resources: [NCHFP.pickling],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('radish', 'Radish')],
+  },
+  {
+    plantId: 'scorzonera',
+    summary:
+      'Black salsify overwinters happily in the bed — dig as needed and handle the brittle roots gently.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Fully hardy — leave in the ground all winter and lift a few roots at a time. Being perennial, any you miss simply grow on.',
+        storageLife: 'in the ground until spring',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lifted roots shrivel fast, so pack them straight into damp sand and use within a few weeks.',
+        storageLife: '2–4 weeks in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Scrub, blanch 2–3 minutes, then slip the black skins and freeze the pale roots in bags for later braising.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('salsify', 'Salsify')],
+  },
+  {
+    plantId: 'horseradish',
+    summary:
+      'Dig roots as needed and preserve the grated heat in vinegar — a little goes a very long way.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave the patch in the ground and dig sections of root through autumn and winter — it is effectively unkillable.',
+        storageLife: 'in the ground year-round',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lifted roots keep for months packed in damp sand in a cool shed, ready for grating.',
+        storageLife: '3–6 months in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'pickle',
+        how: 'Grate (outdoors, or by an open window — it is stronger than onions) and pack into small jars topped with white vinegar and a pinch of salt.',
+        storageLife: '3–6 months in the fridge',
+        resources: [NCHFP.pickling],
+      },
+      {
+        method: 'ferment',
+        how: 'Grated root fermented in a 2 percent salt brine for a week or two makes a mellower, livelier condiment than the vinegar version.',
+        storageLife: 'several months in the fridge',
+        resources: [NCHFP.fermenting],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('horseradish', 'Horseradish')],
+  },
+  {
+    plantId: 'chinese-artichoke',
+    summary:
+      'Crosnes barely store at all — keep them in the soil and lift small batches, pickling any surplus.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave the little spiral tubers in the ground and fork out a meal at a time through winter — they stay plump in the soil and shrivel within days out of it.',
+        storageLife: 'in the ground until spring',
+      },
+      {
+        method: 'fridge',
+        how: 'Rinse and keep a lifted batch in a sealed bag or a tub of barely damp sand in the fridge, and use quickly.',
+        storageLife: 'up to a week',
+      },
+      {
+        method: 'pickle',
+        how: 'The classic use for a surplus — brine briefly, then pack whole in spiced vinegar, as done in both France and Japan. No peeling needed, just a good scrub.',
+        storageLife: '2–3 months in the fridge',
+        resources: [NCHFP.pickling],
+      },
+    ],
+  },
+  {
+    plantId: 'yacon',
+    summary:
+      'Cure the big storage tubers in the sun to sweeten, then they keep for months somewhere cool and dark.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Lift after the tops are frosted, separate the big storage tubers from the growing crowns, and cure in sun or a bright windowsill for 1–2 weeks — the sweetness builds noticeably.',
+      },
+      {
+        method: 'store-cool',
+        how: 'Store the cured tubers unwashed in a box somewhere cool, dark and frost-free. They sweeten further in storage; check monthly for soft ones.',
+        storageLife: '3–5 months',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'fridge',
+        how: 'Once cut, wrap and keep in the fridge. Peeled slices are good in fruit salads and slaws — a squeeze of lemon stops browning.',
+        storageLife: '1–2 weeks once cut',
+      },
+    ],
+  },
+  {
+    plantId: 'skirret',
+    summary:
+      'The medieval sweet root — fully hardy, so the bed itself is the store cupboard.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Leave the root clusters in the ground all winter and lift as needed — flavour is best after frost. Replant a few offsets as you go for next year.',
+        storageLife: 'in the ground until spring',
+      },
+      {
+        method: 'store-cool',
+        how: 'Lifted clusters keep a few weeks packed in damp sand in a cool shed, the same as other thin roots.',
+        storageLife: '3–4 weeks in sand',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Scrub, blanch the thin roots for 2 minutes and freeze in bags — they roast well from frozen.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'oca',
+    summary:
+      'Sun-cure the tubers after lifting to mellow the lemony tang, then store like small potatoes.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Lift after the first frost kills the tops, then lay the tubers on a sunny windowsill for one to two weeks — light greening mellows the oxalate sharpness and sweetens them.',
+      },
+      {
+        method: 'store-cool',
+        how: 'After curing, store in paper bags or trays somewhere cool, dark and frost-free. Save a handful of sound tubers for replanting in spring.',
+        storageLife: '2–4 months',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Cook first — boil or roast, then freeze in portions. Raw tubers do not freeze well.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+  {
+    plantId: 'ulluco',
+    summary:
+      'The prettiest tuber on the plot but a short keeper — handle gently and eat within a few weeks.',
+    methods: [
+      {
+        method: 'store-cool',
+        how: 'Lift late (the tubers bulk up in autumn), handle the thin-skinned tubers gently and store unwashed in trays somewhere cool, dark and frost-free. Keep a few back for replanting.',
+        storageLife: '4–8 weeks',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'fridge',
+        how: 'A small batch keeps in a paper bag in the salad drawer — the waxy flesh stays firm boiled, steamed or sliced raw into salads.',
+        storageLife: '2–3 weeks',
+      },
+      {
+        method: 'freeze',
+        how: 'Cook into stews or soup and freeze the finished dish — the tubers themselves do not freeze well raw.',
+        storageLife: '8–10 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+  },
+]

--- a/src/lib/preservation/data/solanaceae.ts
+++ b/src/lib/preservation/data/solanaceae.ts
@@ -1,11 +1,253 @@
 /**
  * Solanaceae — Preserving guides
- * Authoring spec: docs/plans/food-preservation-plan.md
+ * Authoring spec: ./README.md
  */
 
 import { PreservationGuide } from '@/types/preservation'
+import {
+  NCHFP,
+  GARDEN_ORGANIC_STORING,
+  UMN_HARVEST_STORAGE,
+  BBC_GOOD_FOOD,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+} from '../resources'
 
-// TODO(preserving-data): author guides for: potato, early-potato,
-// second-early-potato, maincrop-potato, cherry-tomato, plum-tomato,
-// blight-resistant-tomato, tomatillo
-export const solanaceaePreservation: PreservationGuide[] = []
+export const solanaceaePreservation: PreservationGuide[] = [
+  {
+    plantId: 'potato',
+    summary:
+      'The all-purpose tattie — dry off well and store dark in paper sacks; never the fridge, which turns them sweet.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Cut the haulms and leave the tubers in the ground for 1–2 weeks to set the skins, then lift on a dry day and let them dry on the surface for a few hours before sacking.',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Store unwashed in paper or hessian sacks somewhere cool, dark and frost-free — never plastic and never the fridge. Check monthly and pull out anything soft or sprouting.',
+        storageLife: '2–6 months depending on type',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Potatoes only freeze cooked — blanch chips for 2–3 minutes, or freeze mash and par-roasted tatties in meal-sized portions.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('potato', 'Potato'),
+      bbcGoodFoodCollection('potato-recipes', 'Potato recipes'),
+    ],
+  },
+  {
+    plantId: 'early-potato',
+    summary:
+      'New tatties are for eating, not keeping — dig only what you need and get them to the pot the same day.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'The ground is their best store — leave the rest growing and lift as you go. Flavour is sweetest within hours of digging.',
+        storageLife: 'a few days after lifting',
+      },
+      {
+        method: 'fridge',
+        how: 'If you dug too many, keep them unwashed in a paper bag in the fridge. This is the one exception to the no-fridge rule for tatties, and it buys days, not weeks.',
+        storageLife: 'up to a week',
+      },
+      {
+        method: 'freeze',
+        how: 'Parboil small whole tubers for 2–3 minutes, cool and freeze — fine later for crushing and frying, though never quite the same as fresh-dug.',
+        storageLife: '8–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('new_potatoes', 'New potatoes'),
+      bbcGoodFoodCollection('new-potato-recipes', 'New potato recipes'),
+    ],
+  },
+  {
+    plantId: 'second-early-potato',
+    summary:
+      'The in-betweener — bigger yields than first earlies but still a short keeper; think weeks, not months.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Lift as needed through July and August and eat within a fortnight — they are at their best straight from the ground.',
+        storageLife: 'about 2 weeks',
+      },
+      {
+        method: 'store-cool',
+        how: 'Any surplus keeps a few weeks unwashed in a paper sack somewhere cool and dark, but plan meals around them — the skins are too thin for proper winter storage.',
+        storageLife: '4–6 weeks',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'freeze',
+        how: 'Blanch chips or cook and mash before freezing — a good home for any that will not get eaten in time.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('new_potatoes', 'New potatoes'),
+      bbcGoodFoodCollection('potato-recipes', 'Potato recipes'),
+    ],
+  },
+  {
+    plantId: 'maincrop-potato',
+    summary:
+      'The keeper of the four — cure the skins hard and a good sack of maincrops feeds you until spring.',
+    methods: [
+      {
+        method: 'cure',
+        how: 'Cut the haulms about 2 weeks before lifting so the skins set, lift on a dry day, and leave the tubers on the surface for a few hours to dry. Thick set skins are what make them keep.',
+        resources: [GARDEN_ORGANIC_STORING],
+      },
+      {
+        method: 'store-cool',
+        how: 'Sack up unwashed in paper or hessian and store cool, dark and frost-free — 5–10°C in a shed or garage is ideal, and the fridge is too cold. Check monthly and remove anything soft, green or sprouting.',
+        storageLife: '4–6 months',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Blanched chips, mash and roasties all freeze well — the right use for forked or damaged tubers that would rot in the sack.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('potato', 'Potato'),
+      bbcGoodFoodCollection('potato-recipes', 'Potato recipes'),
+    ],
+  },
+  {
+    plantId: 'cherry-tomato',
+    summary:
+      'A proper glut in any good year — eat from the vine, then freeze whole or oven-dry the rest.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Ripen and keep on the worktop, not the fridge — cold dulls the flavour. Eat within the week.',
+        storageLife: 'about 1 week at room temperature',
+      },
+      {
+        method: 'fridge',
+        how: 'Fully ripe fruit holds a few extra days in the salad drawer. Bring back to room temperature before eating to recover the flavour.',
+        storageLife: 'a few extra days',
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze whole on a tray, then bag. The skins slip off under a warm tap and they drop straight into winter sauces and stews.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Halve, salt lightly and semi-dry in the oven at 100°C for 3–4 hours. Semi-dried tomatoes are not shelf-stable — keep them in the freezer, not in oil in the cupboard.',
+        storageLife: '6 months frozen once semi-dried',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('cherry_tomatoes', 'Cherry tomatoes'),
+      bbcGoodFoodCollection('cherry-tomato-recipes', 'Cherry tomato recipes'),
+    ],
+  },
+  {
+    plantId: 'plum-tomato',
+    summary:
+      'The sauce tomato — cook the glut into passata for the freezer, and turn the green stragglers into chutney.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Ripen on the worktop and use within the week. Green fruit ripens slowly indoors next to a banana.',
+        storageLife: 'about 1 week at room temperature',
+      },
+      {
+        method: 'freeze',
+        how: 'Cook down into passata and freeze in tubs, or freeze whole on trays for later. Home-canned tomatoes need added acid to be safe, so the freezer is the simpler route for passata.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing, NCHFP.canning],
+      },
+      {
+        method: 'dry',
+        how: 'Halve lengthways, scoop the seeds and slow-dry at 100°C — the dense flesh of plum varieties dries best of all. Store fully dried in jars, or semi-dried in the freezer.',
+        storageLife: '6–12 months dried',
+        resources: [NCHFP.drying],
+      },
+      {
+        method: 'jam',
+        how: 'Green tomato chutney is the classic end-of-season answer for fruit that will not ripen — chop, then simmer with onions, vinegar, sugar and spice.',
+        storageLife: '1 year+ in sealed jars',
+        resources: [BBC_GOOD_FOOD.chutneys],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('tomato', 'Tomato'),
+      bbcGoodFoodCollection('tomato-recipes', 'Tomato recipes'),
+    ],
+  },
+  {
+    plantId: 'blight-resistant-tomato',
+    summary:
+      'Bred to keep cropping through a damp Scottish autumn — so expect a bigger, later glut to freeze, dry and sauce.',
+    methods: [
+      {
+        method: 'fresh',
+        how: 'Keep ripe fruit on the worktop and eat within the week. Anything still green at the end of the season ripens indoors, or goes in the chutney pan.',
+        storageLife: 'about 1 week at room temperature',
+      },
+      {
+        method: 'fridge',
+        how: 'Fully ripe fruit holds a few extra days in the fridge — bring it back to room temperature before eating.',
+        storageLife: 'a few extra days',
+      },
+      {
+        method: 'freeze',
+        how: 'Freeze whole on trays or cook down into sauce and passata for tubs. Skip home canning unless you know the added-acid rules — freezing is the safe, easy route.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+      {
+        method: 'dry',
+        how: 'Halve and semi-dry in a low oven at 100°C for 3–4 hours, then store in the freezer — intensely flavoured and ready for winter pastas.',
+        storageLife: '6 months frozen once semi-dried',
+        resources: [NCHFP.drying],
+      },
+    ],
+    recipeIdeas: [
+      bbcFoodIngredient('tomato', 'Tomato'),
+      bbcGoodFoodCollection('tomato-recipes', 'Tomato recipes'),
+    ],
+  },
+  {
+    plantId: 'tomatillo',
+    summary:
+      'Keeps for weeks in its papery husk — and the surest route to a Scottish salsa verde is the freezer.',
+    methods: [
+      {
+        method: 'fridge',
+        how: 'Leave the husks on and keep loose in the fridge — they hold far longer than a tomato. Husk and rinse the sticky coating off just before use.',
+        storageLife: '2–3 weeks',
+      },
+      {
+        method: 'store-cool',
+        how: 'Husks on and spread in a single layer somewhere cool and airy, they keep a few weeks out of the fridge too. Check for any turning soft under the husk.',
+        storageLife: '2–3 weeks',
+        resources: [UMN_HARVEST_STORAGE],
+      },
+      {
+        method: 'freeze',
+        how: 'Husk, rinse and freeze whole on a tray before bagging — or roast and blitz into salsa verde first and freeze that in tubs.',
+        storageLife: '10–12 months frozen',
+        resources: [NCHFP.freezing],
+      },
+    ],
+    recipeIdeas: [bbcFoodIngredient('tomatillo', 'Tomatillo')],
+  },
+]


### PR DESCRIPTION
## Summary

Runs all 10 preservation-guide authoring sessions from `src/lib/preservation/data/README.md` as one parallel batch, adding **150 guides** across the 13 remaining category data files and bringing coverage to **157/157 crops** (cucurbits was the pre-existing exemplar): leafy-greens 21, root-vegetables 20, herbs 20, other/mushrooms/edible-extras 19, berries 15, brassicas 13, legumes 13, alliums 11, fruit-trees 10, solanaceae 8.

With coverage complete:

- **`PENDING_GUIDES` deleted** from `preservation-coverage.test.ts` — the coverage test now unconditionally asserts every crop with a preserve storage method (freeze/jam/pickle/ferment/dry) has a guide; the non-vacuous floor rises from `> 0` to `> 100`, and the two list-housekeeping tests go with the list.
- **Authoring README updated** — the session table is replaced with a coverage note; the spec, link rules and verified resource library stay as the reference for future crops.
- **Nav decision reconsidered** (per the integration session's revisit note): **Preserving stays in the More menu.** Coverage no longer blocks promotion, but usage evidence still does; primary nav is already at five slots, Seeds also lives in More, and Today's glut nudges already surface preserving contextually in harvest windows. Promoting later is a one-line move in `Navigation.tsx`.
- CLAUDE.md and `docs/plans/current-plan.md` updated.

Authoring notes: every new BBC Food / BBC Good Food URL was curl-verified 200 during authoring; 404 slug candidates were dropped rather than guessed (several BBC hubs are plural despite the singular slug rule: `damsons`, `greengages`, `mulberries`, `medlars`, `cherry_tomatoes`, `new_potatoes`, `brussels_sprouts`). NCHFP/RHS shared constants were used as pre-verified (those domains block fetches from the CI container). Food-safety guardrails applied throughout: no home-canning of low-acid vegetables anywhere, garlic/herb-oil botulism warnings, soak-and-boil warnings on dried haricot-family beans, elderberry cooked-only, pumpkin purée freeze-only.

## Related issue

None — follow-up to #448/#450 (Preserving foundation + integration).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes — full unit suite (1135 passed), type-check, lint, and `tests/preserving.spec.ts` (chromium) all green
- [x] I have updated documentation if needed — CLAUDE.md, data README, current-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtJJ53nrPFsuvfa7H9md7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtJJ53nrPFsuvfa7H9md7s)_