### PR TITLE
Root-vegetables preserving polish: beetroot pickle safety wording, fill recipe-link gaps

### DIFF
--- a/src/lib/preservation/data/root-vegetables.ts
+++ b/src/lib/preservation/data/root-vegetables.ts
@@ -14,6 +14,10 @@ import {
   bbcGoodFoodCollection,
 } from '../resources'
 
+/** Shared fallback collections for roots without a BBC Food hub of their own */
+const ROOT_VEG_RECIPES = bbcGoodFoodCollection('root-vegetable-recipes', 'Root vegetable recipes')
+const RADISH_RECIPES = bbcGoodFoodCollection('radish-recipes', 'Radish recipes')
+
 export const rootVegetablesPreservation: PreservationGuide[] = [
   {
     plantId: 'carrot',
@@ -61,8 +65,8 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
       },
       {
         method: 'pickle',
-        how: 'Boil until tender, slip the skins, slice and pack in spiced vinegar. The classic route for a glut.',
-        storageLife: '6–12 months in sealed jars',
+        how: 'Boil until tender, slip the skins, slice and pack in spiced vinegar. Keep the jars in the fridge, or water-bath process them (see NCHFP) if you want them shelf-stable.',
+        storageLife: '3–4 months in the fridge; 1 year+ if water-bath processed',
         resources: [NCHFP.pickling, BBC_GOOD_FOOD.pickles],
       },
       {
@@ -75,6 +79,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('beetroot', 'Beetroot'),
       bbcGoodFoodCollection('beetroot-recipes', 'Beetroot recipes'),
+      BBC_GOOD_FOOD.chutneys,
     ],
   },
   {
@@ -100,7 +105,10 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('parsnip', 'Parsnip')],
+    recipeIdeas: [
+      bbcFoodIngredient('parsnip', 'Parsnip'),
+      bbcGoodFoodCollection('parsnip-recipes', 'Parsnip recipes'),
+    ],
   },
   {
     plantId: 'turnip',
@@ -125,7 +133,10 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('turnip', 'Turnip')],
+    recipeIdeas: [
+      bbcFoodIngredient('turnip', 'Turnip'),
+      bbcGoodFoodCollection('turnip-recipes', 'Turnip recipes'),
+    ],
   },
   {
     plantId: 'swede',
@@ -150,7 +161,10 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('swede', 'Swede')],
+    recipeIdeas: [
+      bbcFoodIngredient('swede', 'Swede'),
+      bbcGoodFoodCollection('swede-recipes', 'Swede recipes'),
+    ],
   },
   {
     plantId: 'radish',
@@ -176,6 +190,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     ],
     recipeIdeas: [
       bbcFoodIngredient('radish', 'Radish'),
+      RADISH_RECIPES,
       BBC_GOOD_FOOD.pickles,
     ],
   },
@@ -202,7 +217,10 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('jerusalem_artichoke', 'Jerusalem artichoke')],
+    recipeIdeas: [
+      bbcFoodIngredient('jerusalem_artichoke', 'Jerusalem artichoke'),
+      bbcGoodFoodCollection('jerusalem-artichoke-recipes', 'Jerusalem artichoke recipes'),
+    ],
   },
   {
     plantId: 'celeriac',
@@ -227,7 +245,10 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('celeriac', 'Celeriac')],
+    recipeIdeas: [
+      bbcFoodIngredient('celeriac', 'Celeriac'),
+      bbcGoodFoodCollection('celeriac-recipes', 'Celeriac recipes'),
+    ],
   },
   {
     plantId: 'salsify',
@@ -252,7 +273,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('salsify', 'Salsify')],
+    recipeIdeas: [bbcFoodIngredient('salsify', 'Salsify'), ROOT_VEG_RECIPES],
   },
   {
     plantId: 'hamburg-parsley',
@@ -277,6 +298,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
+    recipeIdeas: [ROOT_VEG_RECIPES],
   },
   {
     plantId: 'florence-fennel',
@@ -334,7 +356,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [UMN_SAUERKRAUT, NCHFP.fermenting],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('daikon', 'Daikon (mooli)')],
+    recipeIdeas: [bbcFoodIngredient('daikon', 'Daikon (mooli)'), RADISH_RECIPES],
   },
   {
     plantId: 'black-radish',
@@ -359,7 +381,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.pickling],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('radish', 'Radish')],
+    recipeIdeas: [bbcFoodIngredient('radish', 'Radish'), RADISH_RECIPES],
   },
   {
     plantId: 'scorzonera',
@@ -384,7 +406,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('salsify', 'Salsify')],
+    recipeIdeas: [bbcFoodIngredient('salsify', 'Salsify'), ROOT_VEG_RECIPES],
   },
   {
     plantId: 'horseradish',
@@ -439,6 +461,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.pickling],
       },
     ],
+    recipeIdeas: [ROOT_VEG_RECIPES],
   },
   {
     plantId: 'yacon',
@@ -461,6 +484,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         storageLife: '1–2 weeks once cut',
       },
     ],
+    recipeIdeas: [ROOT_VEG_RECIPES],
   },
   {
     plantId: 'skirret',
@@ -485,6 +509,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
+    recipeIdeas: [ROOT_VEG_RECIPES],
   },
   {
     plantId: 'oca',
@@ -508,6 +533,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
+    recipeIdeas: [ROOT_VEG_RECIPES],
   },
   {
     plantId: 'ulluco',
@@ -532,5 +558,6 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
+    recipeIdeas: [ROOT_VEG_RECIPES],
   },
 ]


### PR DESCRIPTION
## Summary

This PR started as authoring session 2 of 10 (root-vegetables preserving guides), but the batch PR #452 merged first and authored all 20 of this session's crops (plus everything else), superseding the original content. Rather than clobber that equal-or-better authoring, this branch was rebuilt as a slim delta on top of main carrying the value that survived a full review of both versions:

- **Beetroot pickle safety fix** (applies to the #452 wording): the guide claimed "6–12 months in sealed jars" for an unprocessed cold-fill vinegar pickle. Per the NCHFP guidance linked in that very method, unprocessed jars must be refrigerated; only water-bath-processed jars are shelf-stable. The how-to now says fridge-or-process, and the storage life reflects both routes.
- **Recipe-link gap fill**: six crops had no `recipeIdeas` at all (hamburg-parsley, chinese-artichoke, yacon, skirret, oca, ulluco) — they now get the curl-verified BBC Good Food `root-vegetable-recipes` collection, hoisted to a shared module constant (with `radish-recipes`) per the `resources.ts` one-fix-point convention. Verified collection links were added where main had only the BBC Food ingredient hub: parsnip, turnip, swede, radish, jerusalem-artichoke, celeriac, mooli, black-radish, salsify, scorzonera, plus `BBC_GOOD_FOOD.chutneys` for beetroot.

Review notes (from the review of both authorings):
- gemini-code-assist's comment on the superseded version's yacon wording ("sunlight converts the starches") is addressed by adoption of main's wording, which correctly avoids the starch claim (yacon stores inulin/FOS, not starch).
- Follow-up worth considering separately: several guides advertise methods absent from the crop's `Vegetable.storage.methods` (e.g. freeze for carrot). `task-generator.ts` gates Today-dashboard glut nudges on `storage.methods`, so those nudges won't fire for methods only mentioned in guides. Back-filling `storage.methods` (or adding a consistency test) would close the gap — left out here because it changes app behaviour.

## URL verification

All slugs added by this delta were curl-verified with `curl -s -o /dev/null -w "%{http_code}" -A "Mozilla/5.0" "<url>"`:

```
bbcgoodfood.com/recipes/collection/root-vegetable-recipes -> 200
bbcgoodfood.com/recipes/collection/radish-recipes -> 200
bbcgoodfood.com/recipes/collection/parsnip-recipes -> 200
bbcgoodfood.com/recipes/collection/turnip-recipes -> 200
bbcgoodfood.com/recipes/collection/swede-recipes -> 200
bbcgoodfood.com/recipes/collection/jerusalem-artichoke-recipes -> 200
bbcgoodfood.com/recipes/collection/celeriac-recipes -> 200
```

(`BBC_GOOD_FOOD.chutneys` is an existing verified shared constant.)

## Testing

- `npx vitest run src/__tests__/lib/preservation-data.test.ts src/__tests__/lib/preservation-coverage.test.ts` — 9 passed
- `npm run lint` — clean
- `npm run type-check` — clean
- `CI=1 npx playwright test` against a production build — 133 passed, 8 skipped, 1 flaky-passed-on-retry (`allotment.spec.ts` infrastructure naming, unrelated to this data-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7i7VEhJ6A7EGA98Mdetab