### PR TITLE
Add classic-dish recipe ideas to preserving guides

### DIFF
--- a/src/lib/preservation/data/README.md
+++ b/src/lib/preservation/data/README.md
@@ -24,9 +24,16 @@ For each crop, add one `PreservationGuide`:
    - `resources`: 0–2 links per method, **preferring the shared constants** in
      `../resources` (NCHFP per-method pages, Garden Organic storing, UMN
      harvest/storage, RHS fruit storing, PSU Let's Preserve).
-4. **`recipeIdeas`** — 1–3 links for eating the glut (cakes, bakes, soups,
-   cordials): BBC Food ingredient hubs first, then BBC Good Food collections,
-   River Cottage for preserves-heavy crops.
+4. **`recipeIdeas`** — 1–4 links for eating the glut. Lead with the BBC Food
+   ingredient hub or a BBC Good Food collection, then add one or two *classic
+   dishes* — everyday or heritage — that people actually make from a harvest
+   (lettuce soup, colcannon, borscht, cranachan, gooseberry fool, stovies,
+   stuffed marrow, rhubarb crumble…). Helpers in `../resources`:
+   `bbcFoodDish` (per-dish hub pages like `cranachan`), `bbcFoodRecipe`
+   (single BBC Food recipes, slug includes numeric id), `bbcGoodFoodRecipe`
+   (single non-premium BBC Good Food recipes), `greatBritishChefsRecipe`
+   (free, ad-supported — used where the BBC has no page for a classic, e.g.
+   clapshot, cock-a-leekie). A few strong classics beat a padded list.
 
 ## Link rules (important)
 
@@ -104,8 +111,11 @@ All in `src/lib/preservation/resources.ts`. For reference:
 | UMN preserving | https://extension.umn.edu/food-safety/preserving-and-preparing | All methods landing page |
 | UMN harvest/storage | https://extension.umn.edu/planting-and-growing-guides/harvesting-and-storing-home-garden-vegetables | 30+ crops, storage conditions |
 | UMN sauerkraut | https://extension.umn.edu/preserving-and-preparing/how-make-your-own-sauerkraut | Best free fermentation primer |
-| BBC Food hubs | https://www.bbc.co.uk/food/<ingredient> | Per-ingredient recipes, no ads |
+| BBC Food hubs | https://www.bbc.co.uk/food/<ingredient-or-dish> | Per-ingredient and per-dish recipe pages, no ads |
+| BBC Food recipes | https://www.bbc.co.uk/food/recipes/<slug_id> | Single recipes; slug includes numeric id, never guess |
 | BBC Good Food | https://www.bbcgoodfood.com/recipes/collection/<slug> | Verified slugs only; recipes checked non-premium |
+| BBC Good Food recipes | https://www.bbcgoodfood.com/recipes/<slug> | Single recipes; verify 200 and "isPremium":false |
+| Great British Chefs | https://www.greatbritishchefs.com/recipes/<slug> | Free, ad-supported; for classics the BBC lacks |
 | River Cottage | https://www.rivercottage.net/recipes | Free, strong preserves coverage |
 | Wikibooks Cookbook | https://en.wikibooks.org/wiki/Cookbook:Table_of_Contents | CC technique reference |
 

--- a/src/lib/preservation/data/alliums.ts
+++ b/src/lib/preservation/data/alliums.ts
@@ -12,6 +12,8 @@ import {
   BBC_GOOD_FOOD,
   bbcFoodIngredient,
   bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
+  greatBritishChefsRecipe,
 } from '../resources'
 
 export const alliumsPreservation: PreservationGuide[] = [
@@ -47,6 +49,7 @@ export const alliumsPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('onion', 'Onion'),
       bbcGoodFoodCollection('onion-recipes', 'Onion recipes'),
+      bbcGoodFoodRecipe('french-onion-soup', 'French onion soup'),
     ],
   },
   {
@@ -102,7 +105,8 @@ export const alliumsPreservation: PreservationGuide[] = [
     ],
     recipeIdeas: [
       bbcFoodIngredient('leek', 'Leek'),
-      bbcGoodFoodCollection('leek-recipes', 'Leek recipes'),
+      greatBritishChefsRecipe('cock-a-leekie-soup-recipe', 'Cock-a-leekie soup'),
+      bbcGoodFoodRecipe('leek-potato-soup', 'Leek & potato soup'),
     ],
   },
   {

--- a/src/lib/preservation/data/berries.ts
+++ b/src/lib/preservation/data/berries.ts
@@ -4,7 +4,14 @@
  */
 
 import { PreservationGuide } from '@/types/preservation'
-import { NCHFP, BBC_GOOD_FOOD, bbcFoodIngredient, bbcGoodFoodCollection } from '../resources'
+import {
+  NCHFP,
+  BBC_GOOD_FOOD,
+  bbcFoodDish,
+  bbcFoodIngredient,
+  bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
+} from '../resources'
 
 export const berriesPreservation: PreservationGuide[] = [
   {
@@ -33,6 +40,7 @@ export const berriesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('strawberry', 'Strawberry'),
       bbcGoodFoodCollection('strawberries-recipes', 'Strawberry recipes'),
+      bbcFoodDish('eton_mess', 'Eton mess'),
     ],
   },
   {
@@ -61,6 +69,7 @@ export const berriesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('raspberry', 'Raspberry'),
       bbcGoodFoodCollection('raspberry-recipes', 'Raspberry recipes'),
+      bbcFoodDish('cranachan', 'Cranachan'),
     ],
   },
   {
@@ -115,7 +124,10 @@ export const berriesPreservation: PreservationGuide[] = [
         storageLife: '4–7 days in the fridge',
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('redcurrant', 'Redcurrant')],
+    recipeIdeas: [
+      bbcFoodIngredient('redcurrant', 'Redcurrant'),
+      bbcFoodDish('summer_pudding', 'Summer pudding'),
+    ],
   },
   {
     plantId: 'gooseberry',
@@ -143,6 +155,7 @@ export const berriesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('gooseberry', 'Gooseberry'),
       bbcGoodFoodCollection('gooseberry-recipes', 'Gooseberry recipes'),
+      bbcGoodFoodRecipe('gooseberry-fool', 'Gooseberry fool'),
     ],
   },
   {
@@ -198,7 +211,7 @@ export const berriesPreservation: PreservationGuide[] = [
     ],
     recipeIdeas: [
       bbcFoodIngredient('blackberry', 'Blackberry'),
-      bbcGoodFoodCollection('blackberry-recipes', 'Blackberry recipes'),
+      bbcGoodFoodRecipe('apple-blackberry-crumble', 'Apple & blackberry crumble'),
       bbcGoodFoodCollection('flavoured-gin-recipes', 'Flavoured gin recipes'),
     ],
   },

--- a/src/lib/preservation/data/brassicas.ts
+++ b/src/lib/preservation/data/brassicas.ts
@@ -10,8 +10,10 @@ import {
   UMN_HARVEST_STORAGE,
   UMN_SAUERKRAUT,
   BBC_GOOD_FOOD,
+  bbcFoodDish,
   bbcFoodIngredient,
   bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
 } from '../resources'
 
 export const brassicasPreservation: PreservationGuide[] = [
@@ -35,6 +37,7 @@ export const brassicasPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('broccoli', 'Broccoli'),
       bbcGoodFoodCollection('broccoli-recipes', 'Broccoli recipes'),
+      bbcGoodFoodRecipe('broccoli-stilton-soup', 'Broccoli & stilton soup'),
     ],
   },
   {
@@ -62,7 +65,8 @@ export const brassicasPreservation: PreservationGuide[] = [
     ],
     recipeIdeas: [
       bbcFoodIngredient('cabbage', 'Cabbage'),
-      bbcGoodFoodCollection('cabbage-recipes', 'Cabbage recipes'),
+      bbcGoodFoodRecipe('bubble-squeak', 'Bubble & squeak'),
+      bbcFoodDish('coleslaw', 'Coleslaw'),
     ],
   },
   {
@@ -90,7 +94,8 @@ export const brassicasPreservation: PreservationGuide[] = [
     ],
     recipeIdeas: [
       bbcFoodIngredient('cauliflower', 'Cauliflower'),
-      bbcGoodFoodCollection('cauliflower-recipes', 'Cauliflower recipes'),
+      bbcFoodDish('cauliflower_cheese', 'Cauliflower cheese'),
+      bbcFoodDish('piccalilli', 'Piccalilli'),
     ],
   },
   {
@@ -116,7 +121,10 @@ export const brassicasPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('brussels_sprouts', 'Brussels sprouts')],
+    recipeIdeas: [
+      bbcFoodIngredient('brussels_sprouts', 'Brussels sprouts'),
+      bbcGoodFoodRecipe('bubble-squeak', 'Bubble & squeak'),
+    ],
   },
   {
     plantId: 'kohlrabi',
@@ -144,6 +152,7 @@ export const brassicasPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('kohlrabi', 'Kohlrabi'),
       bbcGoodFoodCollection('kohlrabi-recipes', 'Kohlrabi recipes'),
+      bbcFoodDish('coleslaw', 'Coleslaw'),
     ],
   },
   {
@@ -170,7 +179,10 @@ export const brassicasPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('savoy_cabbage', 'Savoy cabbage')],
+    recipeIdeas: [
+      bbcFoodIngredient('savoy_cabbage', 'Savoy cabbage'),
+      bbcGoodFoodRecipe('rumbledethumps', 'Rumbledethumps'),
+    ],
   },
   {
     plantId: 'red-cabbage',
@@ -201,7 +213,10 @@ export const brassicasPreservation: PreservationGuide[] = [
         resources: [UMN_SAUERKRAUT],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('red_cabbage', 'Red cabbage')],
+    recipeIdeas: [
+      bbcFoodIngredient('red_cabbage', 'Red cabbage'),
+      bbcGoodFoodRecipe('braised-red-cabbage', 'Braised red cabbage'),
+    ],
   },
   {
     plantId: 'chinese-broccoli',

--- a/src/lib/preservation/data/cucurbits.ts
+++ b/src/lib/preservation/data/cucurbits.ts
@@ -13,8 +13,11 @@ import {
   GARDEN_ORGANIC_STORING,
   UMN_HARVEST_STORAGE,
   BBC_GOOD_FOOD,
+  bbcFoodDish,
   bbcFoodIngredient,
+  bbcFoodRecipe,
   bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
 } from '../resources'
 
 export const cucurbitsPreservation: PreservationGuide[] = [
@@ -49,7 +52,8 @@ export const cucurbitsPreservation: PreservationGuide[] = [
     ],
     recipeIdeas: [
       bbcFoodIngredient('courgette', 'Courgette'),
-      bbcGoodFoodCollection('courgette-cake-recipes', 'Courgette cake recipes'),
+      bbcFoodDish('ratatouille', 'Ratatouille'),
+      bbcFoodRecipe('stuffed_marrow_43279', 'Stuffed marrow'),
       BBC_GOOD_FOOD.glutCakes,
     ],
   },
@@ -102,6 +106,7 @@ export const cucurbitsPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('pumpkin', 'Pumpkin'),
       bbcGoodFoodCollection('pumpkin-recipes', 'Pumpkin recipes'),
+      bbcGoodFoodRecipe('pumpkin-soup', 'Pumpkin soup'),
     ],
   },
   {

--- a/src/lib/preservation/data/herbs.ts
+++ b/src/lib/preservation/data/herbs.ts
@@ -7,8 +7,11 @@ import { PreservationGuide } from '@/types/preservation'
 import {
   NCHFP,
   BBC_GOOD_FOOD,
+  bbcFoodDish,
   bbcFoodIngredient,
+  bbcFoodRecipe,
   bbcGoodFoodCollection,
+  greatBritishChefsRecipe,
 } from '../resources'
 
 export const herbsPreservation: PreservationGuide[] = [
@@ -88,6 +91,7 @@ export const herbsPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('mint', 'Mint'),
       bbcGoodFoodCollection('mint-recipes', 'Mint recipes'),
+      bbcFoodDish('mint_sauce', 'Mint sauce'),
     ],
   },
   {
@@ -176,7 +180,10 @@ export const herbsPreservation: PreservationGuide[] = [
         resources: [NCHFP.drying],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('lovage', 'Lovage')],
+    recipeIdeas: [
+      bbcFoodIngredient('lovage', 'Lovage'),
+      bbcFoodRecipe('lettuceandlovagesoup_14299', 'Lettuce and lovage soup'),
+    ],
   },
   {
     plantId: 'sorrel',
@@ -194,7 +201,10 @@ export const herbsPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('sorrel', 'Sorrel')],
+    recipeIdeas: [
+      bbcFoodIngredient('sorrel', 'Sorrel'),
+      greatBritishChefsRecipe('sorrel-soup-recipe', 'Sorrel soup (green borscht)'),
+    ],
   },
   {
     plantId: 'oregano',

--- a/src/lib/preservation/data/leafy-greens.ts
+++ b/src/lib/preservation/data/leafy-greens.ts
@@ -9,7 +9,10 @@ import {
   UMN_SAUERKRAUT,
   UMN_HARVEST_STORAGE,
   bbcFoodIngredient,
+  bbcFoodRecipe,
   bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
+  greatBritishChefsRecipe,
 } from '../resources'
 
 export const leafyGreensPreservation: PreservationGuide[] = [
@@ -32,6 +35,7 @@ export const leafyGreensPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('lettuce', 'Lettuce'),
       bbcGoodFoodCollection('lettuce-recipes', 'Lettuce recipes'),
+      greatBritishChefsRecipe('lettuce-soup-recipe', 'Lettuce soup'),
     ],
   },
   {
@@ -57,6 +61,7 @@ export const leafyGreensPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('spinach', 'Spinach'),
       bbcGoodFoodCollection('spinach-recipes', 'Spinach recipes'),
+      bbcGoodFoodRecipe('eggs-florentine', 'Eggs Florentine'),
     ],
   },
   {
@@ -101,6 +106,7 @@ export const leafyGreensPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('kale', 'Kale'),
       bbcGoodFoodCollection('kale-recipes', 'Kale recipes'),
+      bbcGoodFoodRecipe('colcannon', 'Colcannon'),
     ],
   },
   {
@@ -304,7 +310,10 @@ export const leafyGreensPreservation: PreservationGuide[] = [
         resources: [NCHFP.freezing],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('watercress', 'Watercress')],
+    recipeIdeas: [
+      bbcFoodIngredient('watercress', 'Watercress'),
+      bbcFoodRecipe('watercresssoup_93505', 'Watercress soup'),
+    ],
   },
   {
     plantId: 'salad-burnet',

--- a/src/lib/preservation/data/legumes.ts
+++ b/src/lib/preservation/data/legumes.ts
@@ -11,6 +11,7 @@ import {
   BBC_GOOD_FOOD,
   bbcFoodIngredient,
   bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
 } from '../resources'
 
 export const legumesPreservation: PreservationGuide[] = [
@@ -34,6 +35,7 @@ export const legumesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('pea', 'Pea'),
       bbcGoodFoodCollection('pea-recipes', 'Pea recipes'),
+      bbcGoodFoodRecipe('pea-ham-soup', 'Pea & ham soup'),
     ],
   },
   {

--- a/src/lib/preservation/data/other.ts
+++ b/src/lib/preservation/data/other.ts
@@ -9,8 +9,10 @@ import {
   GARDEN_ORGANIC_STORING,
   UMN_HARVEST_STORAGE,
   BBC_GOOD_FOOD,
+  bbcFoodDish,
   bbcFoodIngredient,
   bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
 } from '../resources'
 
 export const otherPreservation: PreservationGuide[] = [
@@ -34,6 +36,7 @@ export const otherPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('sweetcorn', 'Sweetcorn'),
       bbcGoodFoodCollection('sweetcorn-recipes', 'Sweetcorn recipes'),
+      bbcGoodFoodRecipe('sweetcorn-fritters', 'Sweetcorn fritters'),
     ],
   },
   {
@@ -115,6 +118,7 @@ export const otherPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('rhubarb', 'Rhubarb'),
       bbcGoodFoodCollection('rhubarb-recipes', 'Rhubarb recipes'),
+      bbcFoodDish('rhubarb_crumble', 'Rhubarb crumble'),
     ],
   },
   {

--- a/src/lib/preservation/data/root-vegetables.ts
+++ b/src/lib/preservation/data/root-vegetables.ts
@@ -10,8 +10,12 @@ import {
   UMN_HARVEST_STORAGE,
   UMN_SAUERKRAUT,
   BBC_GOOD_FOOD,
+  bbcFoodDish,
   bbcFoodIngredient,
+  bbcFoodRecipe,
   bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
+  greatBritishChefsRecipe,
 } from '../resources'
 
 /** Shared fallback collections for roots without a BBC Food hub of their own */
@@ -45,6 +49,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('carrot', 'Carrot'),
       bbcGoodFoodCollection('carrot-cake-recipes', 'Carrot cake recipes'),
+      bbcGoodFoodRecipe('carrot-coriander-soup', 'Carrot & coriander soup'),
     ],
   },
   {
@@ -79,7 +84,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('beetroot', 'Beetroot'),
       bbcGoodFoodCollection('beetroot-recipes', 'Beetroot recipes'),
-      BBC_GOOD_FOOD.chutneys,
+      bbcFoodRecipe('borschbeetrootsoup_12298', 'Borsch (beetroot soup)'),
     ],
   },
   {
@@ -108,6 +113,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('parsnip', 'Parsnip'),
       bbcGoodFoodCollection('parsnip-recipes', 'Parsnip recipes'),
+      bbcGoodFoodRecipe('spiced-parsnip-soup', 'Spiced parsnip soup'),
     ],
   },
   {
@@ -136,6 +142,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('turnip', 'Turnip'),
       bbcGoodFoodCollection('turnip-recipes', 'Turnip recipes'),
+      greatBritishChefsRecipe('clapshot-recipe', 'Clapshot'),
     ],
   },
   {
@@ -164,6 +171,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('swede', 'Swede'),
       bbcGoodFoodCollection('swede-recipes', 'Swede recipes'),
+      bbcGoodFoodRecipe('neeps-tatties', 'Neeps & tatties'),
     ],
   },
   {
@@ -220,6 +228,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('jerusalem_artichoke', 'Jerusalem artichoke'),
       bbcGoodFoodCollection('jerusalem-artichoke-recipes', 'Jerusalem artichoke recipes'),
+      greatBritishChefsRecipe('jerusalem-artichoke-soup-recipe', 'Jerusalem artichoke (Palestine) soup'),
     ],
   },
   {
@@ -248,6 +257,7 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('celeriac', 'Celeriac'),
       bbcGoodFoodCollection('celeriac-recipes', 'Celeriac recipes'),
+      bbcGoodFoodRecipe('celeriac-remoulade', 'Celeriac remoulade'),
     ],
   },
   {
@@ -437,7 +447,10 @@ export const rootVegetablesPreservation: PreservationGuide[] = [
         resources: [NCHFP.fermenting],
       },
     ],
-    recipeIdeas: [bbcFoodIngredient('horseradish', 'Horseradish')],
+    recipeIdeas: [
+      bbcFoodIngredient('horseradish', 'Horseradish'),
+      bbcFoodDish('horseradish_sauce', 'Horseradish sauce'),
+    ],
   },
   {
     plantId: 'chinese-artichoke',

--- a/src/lib/preservation/data/solanaceae.ts
+++ b/src/lib/preservation/data/solanaceae.ts
@@ -9,8 +9,10 @@ import {
   GARDEN_ORGANIC_STORING,
   UMN_HARVEST_STORAGE,
   BBC_GOOD_FOOD,
+  bbcFoodDish,
   bbcFoodIngredient,
   bbcGoodFoodCollection,
+  bbcGoodFoodRecipe,
 } from '../resources'
 
 export const solanaceaePreservation: PreservationGuide[] = [
@@ -39,7 +41,8 @@ export const solanaceaePreservation: PreservationGuide[] = [
     ],
     recipeIdeas: [
       bbcFoodIngredient('potato', 'Potato'),
-      bbcGoodFoodCollection('potato-recipes', 'Potato recipes'),
+      bbcGoodFoodRecipe('scottish-stovies', 'Stovies'),
+      bbcFoodDish('champ', 'Champ'),
     ],
   },
   {
@@ -123,6 +126,7 @@ export const solanaceaePreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('potato', 'Potato'),
       bbcGoodFoodCollection('potato-recipes', 'Potato recipes'),
+      bbcGoodFoodRecipe('scottish-stovies', 'Stovies'),
     ],
   },
   {
@@ -156,6 +160,7 @@ export const solanaceaePreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('cherry_tomatoes', 'Cherry tomatoes'),
       bbcGoodFoodCollection('cherry-tomato-recipes', 'Cherry tomato recipes'),
+      bbcGoodFoodRecipe('gazpacho', 'Gazpacho'),
     ],
   },
   {
@@ -190,6 +195,7 @@ export const solanaceaePreservation: PreservationGuide[] = [
     recipeIdeas: [
       bbcFoodIngredient('tomato', 'Tomato'),
       bbcGoodFoodCollection('tomato-recipes', 'Tomato recipes'),
+      bbcFoodDish('tomato_soup', 'Tomato soup'),
     ],
   },
   {

--- a/src/lib/preservation/resources.ts
+++ b/src/lib/preservation/resources.ts
@@ -105,11 +105,7 @@ export function bbcFoodIngredient(slug: string, label: string): PreservationReso
  * mint_sauce, horseradish_sauce. Spot-check any new slug returns 200.
  */
 export function bbcFoodDish(slug: string, label: string): PreservationResource {
-  return {
-    title: `${label} recipes`,
-    url: `https://www.bbc.co.uk/food/${slug}`,
-    source: 'BBC Food',
-  }
+  return bbcFoodIngredient(slug, label)
 }
 
 /**

--- a/src/lib/preservation/resources.ts
+++ b/src/lib/preservation/resources.ts
@@ -98,6 +98,60 @@ export function bbcFoodIngredient(slug: string, label: string): PreservationReso
 }
 
 /**
+ * BBC Food dish hub, e.g. bbcFoodDish('cranachan', 'Cranachan') — a per-dish
+ * collection page in the same /food/<slug> namespace as ingredient hubs.
+ * Verified working: cranachan, rhubarb_crumble, eton_mess, summer_pudding,
+ * cauliflower_cheese, coleslaw, piccalilli, ratatouille, tomato_soup, champ,
+ * mint_sauce, horseradish_sauce. Spot-check any new slug returns 200.
+ */
+export function bbcFoodDish(slug: string, label: string): PreservationResource {
+  return {
+    title: `${label} recipes`,
+    url: `https://www.bbc.co.uk/food/${slug}`,
+    source: 'BBC Food',
+  }
+}
+
+/**
+ * BBC Food single recipe page, e.g.
+ * bbcFoodRecipe('stuffed_marrow_43279', 'Stuffed marrow'). The slug includes
+ * the numeric id, so only use URLs verified to return 200 — never guess.
+ */
+export function bbcFoodRecipe(slug: string, title: string): PreservationResource {
+  return {
+    title,
+    url: `https://www.bbc.co.uk/food/recipes/${slug}`,
+    source: 'BBC Food',
+  }
+}
+
+/**
+ * BBC Good Food single recipe page, e.g.
+ * bbcGoodFoodRecipe('colcannon', 'Colcannon'). Only use slugs verified to
+ * return 200 AND checked non-premium ("isPremium":false in the page data).
+ */
+export function bbcGoodFoodRecipe(slug: string, title: string): PreservationResource {
+  return {
+    title,
+    url: `https://www.bbcgoodfood.com/recipes/${slug}`,
+    source: 'BBC Good Food',
+  }
+}
+
+/**
+ * Great British Chefs recipe page (free to read, ad-supported, no sign-up
+ * wall), e.g. greatBritishChefsRecipe('clapshot-recipe', 'Clapshot').
+ * Verify the slug returns 200 before adding.
+ */
+export function greatBritishChefsRecipe(slug: string, title: string): PreservationResource {
+  return {
+    title,
+    url: `https://www.greatbritishchefs.com/recipes/${slug}`,
+    source: 'Great British Chefs',
+  }
+}
+
+/**
  * BBC Good Food collection, e.g. bbcGoodFoodCollection('jam-recipes', 'Jam recipes').
  * Only use slugs verified to return 200 — there is no generic 'chutney-recipes'
  * or 'glut-recipes' collection.


### PR DESCRIPTION
## Summary

Enriches `recipeIdeas` across the preserving guides with *classic ways to cook and eat* each crop — everyday and heritage dishes made from a harvest or glut — rather than only preserving-the-glut links. ~30 crops updated, common Scottish allotment crops first.

Highlights: lettuce soup (soupe de laitue), colcannon for kale, bubble & squeak, rumbledethumps for savoy, borscht for beetroot, clapshot for turnip, neeps & tatties for swede, cranachan for raspberries, gooseberry fool, summer pudding for redcurrants, stovies and champ for potatoes, cock-a-leekie and leek & potato soup for leeks, stuffed marrow and ratatouille for courgette, rhubarb crumble, Eton mess, pea & ham soup, Jerusalem artichoke (Palestine) soup, celeriac remoulade, sorrel soup (green borscht), lettuce & lovage soup, watercress soup, cauliflower cheese + piccalilli, French onion soup, gazpacho, tomato soup, pumpkin soup, sweetcorn fritters, eggs Florentine, mint sauce, horseradish sauce.

Supporting changes:
- New helpers in `src/lib/preservation/resources.ts`: `bbcFoodDish` (per-dish hub pages), `bbcFoodRecipe` (single BBC Food recipes), `bbcGoodFoodRecipe` (single non-premium BBC Good Food recipes), `greatBritishChefsRecipe` (used only where the BBC has no page for a classic: lettuce soup, clapshot, cock-a-leekie, sorrel soup, Jerusalem artichoke soup).
- Updated the authoring spec (`data/README.md`) to cover classic dishes and the new link sources.
- A few generic collection links were swapped for stronger classics to keep lists at 3–4 entries (e.g. beetroot's chutney collection → borscht; chutney remains linked in the pickle method).

**Link verification:** every new URL was curl-verified `200` (with `og:title`/`<title>` checked to confirm the right dish), and each BBC Good Food recipe page was checked for `"isPremium":false`. Great British Chefs is a new source: free to read, ad-supported, no sign-up wall (verified via plain curl).

**Flagged rather than forced in:**
- **Nettle soup** — a verified free recipe exists (`bbcgoodfood.com/recipes/nettle-soup`), but there is no nettle crop in the vegetable database to attach it to. If foraged crops ever get added, it's ready.
- **Pease pudding** — a true heritage classic, but it's made from dried split peas and the peas guide has no dry method, so it had no honest home.

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes (`npm run test:unit` — 1130 passed, `npm run lint`, `npm run type-check` all clean)
- [x] I have updated documentation if needed (authoring spec in `data/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xz6kxGCYKkFsLsvmYUwdKV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xz6kxGCYKkFsLsvmYUwdKV)_