### PR TITLE
Season Observer Phase 2a: Open-Meteo Archive weather foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ Sign in or create an account to enable cloud sync for your garden data across mu
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
+## 🌦️ Weather Data Attribution
+
+Forecasts, frost dates, and historical season weather are provided by
+[Open-Meteo.com](https://open-meteo.com/), licensed under
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). No API key is
+required and coordinates are only ever sent to Open-Meteo to fetch weather
+for your plot.
+
 ## 📜 License & Usage Policy
 
 This project is **open source and free for personal, educational, and community use**.

--- a/docs/plans/season-observer.md
+++ b/docs/plans/season-observer.md
@@ -76,11 +76,20 @@ No photo storage exists. Local-first in a PWA means IndexedDB blobs
 importer (filter by ~100m of plot coords, group by date, human-confirm) is a
 self-contained follow-up. Optional local vision captioning stays human-confirmed.
 
-### Weather backfill (Phase 2a)
-Add an **Archive API** client (`archive-api.open-meteo.com`) for one-call
-full-season backfill incl. soil moisture + ET0, plus a **10-year daily
-baseline**, cached in localStorage/IndexedDB (not SQLite/parquet — that would be
-the forbidden second stack). Reuse `frost-dates.ts` for the frost metric.
+### Weather backfill (Phase 2a) — **shipped**
+Archive API client (`src/lib/weather/open-meteo-archive.ts`): one call fetches
+a whole season of daily weather (temps, rain, radiation, ET0, sunshine,
+daylight, weather code) plus hourly soil temp/moisture aggregated to daily
+(`soil-daily.ts`), cached in localStorage keyed by rounded coords + year —
+completed seasons forever, the current season with a 24h TTL. 10-year monthly
+normals in `weather-baseline.ts` (`getBaseline`), pure `computeBaseline` over
+fetched seasons. Everything comes from the Archive API (ERA5): the Historical
+Forecast API was rejected for the current season because its soil layers
+(0/6/18cm, 0-1cm moisture) don't match ERA5's 0-7/7-28cm, which would break
+comparability with the baseline; the ~5-day lag doesn't matter for a
+retrospective report. Coordinates stay in local cache keys only (rounded
+~1 km), never logged, absent from exported types. Reuse `frost-dates.ts` for
+the frost metric.
 
 ### Derived metrics + rules engine (Phase 2b)
 Deterministic code over logs + weather: GDD accumulation, soil temp at sowing,

--- a/src/__tests__/lib/weather/open-meteo-archive.test.ts
+++ b/src/__tests__/lib/weather/open-meteo-archive.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  fetchSeasonWeather,
+  getCachedSeason,
+  _resetSeasonCacheForTests,
+} from '@/lib/weather/open-meteo-archive'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
+  }
+})()
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+const COORDS = { latitude: 55.95, longitude: -3.18 }
+const CURRENT_YEAR = new Date().getFullYear()
+const PAST_YEAR = CURRENT_YEAR - 1
+
+function archiveResponse(dates: string[], withHourly = false) {
+  const n = dates.length
+  const body: Record<string, unknown> = {
+    daily: {
+      time: dates,
+      temperature_2m_max: Array(n).fill(15.0),
+      temperature_2m_min: Array(n).fill(8.1),
+      temperature_2m_mean: Array(n).fill(11.5),
+      precipitation_sum: Array(n).fill(1.2),
+      shortwave_radiation_sum: Array(n).fill(20.48),
+      et0_fao_evapotranspiration: Array(n).fill(3.16),
+      sunshine_duration: Array(n).fill(36000), // 10 hours in seconds
+      daylight_duration: Array(n).fill(61200), // 17 hours in seconds
+      weather_code: Array(n).fill(61),
+    },
+  }
+  if (withHourly) {
+    body.hourly = {
+      time: dates.flatMap((d) =>
+        Array.from({ length: 24 }, (_, h) => `${d}T${String(h).padStart(2, '0')}:00`)
+      ),
+      soil_temperature_0_to_7cm: Array(n * 24).fill(12.4),
+      soil_temperature_7_to_28cm: Array(n * 24).fill(13.1),
+      soil_moisture_0_to_7cm: Array(n * 24).fill(0.164),
+    }
+  }
+  return new Response(JSON.stringify(body), { status: 200 })
+}
+
+describe('fetchSeasonWeather', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    _resetSeasonCacheForTests()
+    vi.clearAllMocks()
+    vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('parses daily records including unit conversion and soil aggregation', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      archiveResponse([`${PAST_YEAR}-06-01`, `${PAST_YEAR}-06-02`], true)
+    )
+
+    const season = await fetchSeasonWeather(COORDS, PAST_YEAR)
+    expect(season).not.toBeNull()
+    expect(season!.year).toBe(PAST_YEAR)
+    expect(season!.complete).toBe(true)
+    expect(season!.days).toHaveLength(2)
+    expect(season!.days[0]).toMatchObject({
+      date: `${PAST_YEAR}-06-01`,
+      tempMaxC: 15,
+      tempMinC: 8.1,
+      tempMeanC: 11.5,
+      precipitationMm: 1.2,
+      shortwaveRadiationMJm2: 20.48,
+      et0Mm: 3.16,
+      sunshineHours: 10,
+      daylightHours: 17,
+      weatherCode: 61,
+      soilTempMean0to7C: 12.4,
+      soilTempMean7to28C: 13.1,
+      soilMoistureMean0to7: 0.164,
+    })
+  })
+
+  it('requests the full calendar year for a completed past season', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(archiveResponse([`${PAST_YEAR}-01-01`]))
+
+    await fetchSeasonWeather(COORDS, PAST_YEAR)
+    const url = vi.mocked(globalThis.fetch).mock.calls[0][0] as string
+    expect(url).toContain('archive-api.open-meteo.com/v1/archive')
+    expect(url).toContain(`start_date=${PAST_YEAR}-01-01`)
+    expect(url).toContain(`end_date=${PAST_YEAR}-12-31`)
+    expect(url).toContain('temperature_2m_mean')
+    expect(url).toContain('soil_moisture_0_to_7cm')
+  })
+
+  it('marks the current in-progress season as incomplete', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(archiveResponse([`${CURRENT_YEAR}-01-01`]))
+
+    const season = await fetchSeasonWeather(COORDS, CURRENT_YEAR)
+    expect(season!.complete).toBe(false)
+    const url = vi.mocked(globalThis.fetch).mock.calls[0][0] as string
+    expect(url).not.toContain(`end_date=${CURRENT_YEAR}-12-31`)
+  })
+
+  it('returns null for a future year without touching the network', async () => {
+    const season = await fetchSeasonWeather(COORDS, CURRENT_YEAR + 1)
+    expect(season).toBeNull()
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('serves a cached season without a second fetch', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(archiveResponse([`${PAST_YEAR}-06-01`]))
+
+    await fetchSeasonWeather(COORDS, PAST_YEAR)
+    const second = await fetchSeasonWeather(COORDS, PAST_YEAR)
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(second).not.toBeNull()
+  })
+
+  it('misses the cache for a different year or coordinates', async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(() =>
+      Promise.resolve(archiveResponse([`${PAST_YEAR}-06-01`]))
+    )
+
+    await fetchSeasonWeather(COORDS, PAST_YEAR)
+    await fetchSeasonWeather(COORDS, PAST_YEAR - 1)
+    await fetchSeasonWeather({ latitude: 57.15, longitude: -2.09 }, PAST_YEAR)
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns null when the API responds with an error status', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response('error', { status: 500 }))
+
+    expect(await fetchSeasonWeather(COORDS, PAST_YEAR)).toBeNull()
+  })
+
+  it('returns null when fetch throws and nothing is cached', async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValueOnce(new Error('network down'))
+
+    expect(await fetchSeasonWeather(COORDS, PAST_YEAR)).toBeNull()
+    expect(getCachedSeason(COORDS, PAST_YEAR)).toBeNull()
+  })
+
+  it('returns null when the response has no usable daily data', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ daily: { time: [] } }), { status: 200 })
+    )
+
+    expect(await fetchSeasonWeather(COORDS, PAST_YEAR)).toBeNull()
+  })
+
+  it('trims trailing days the archive padded with nulls', async () => {
+    const body = {
+      daily: {
+        time: [`${PAST_YEAR}-06-01`, `${PAST_YEAR}-06-02`, `${PAST_YEAR}-06-03`],
+        temperature_2m_max: [15, null, null],
+        temperature_2m_min: [8, null, null],
+        temperature_2m_mean: [11, null, null],
+        precipitation_sum: [0.4, null, null],
+      },
+    }
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(body), { status: 200 })
+    )
+
+    const season = await fetchSeasonWeather(COORDS, PAST_YEAR)
+    expect(season!.days).toHaveLength(1)
+    expect(season!.days[0].date).toBe(`${PAST_YEAR}-06-01`)
+  })
+})
+
+describe('getCachedSeason', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    _resetSeasonCacheForTests()
+    vi.clearAllMocks()
+    vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the cached season without any fetch', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(archiveResponse([`${PAST_YEAR}-06-01`]))
+    await fetchSeasonWeather(COORDS, PAST_YEAR)
+    vi.mocked(globalThis.fetch).mockClear()
+
+    const cached = getCachedSeason(COORDS, PAST_YEAR)
+    expect(cached).not.toBeNull()
+    expect(cached!.year).toBe(PAST_YEAR)
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns null when nothing is cached', () => {
+    expect(getCachedSeason(COORDS, PAST_YEAR)).toBeNull()
+  })
+
+  it('survives a memory-cache reset via localStorage', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(archiveResponse([`${PAST_YEAR}-06-01`]))
+    await fetchSeasonWeather(COORDS, PAST_YEAR)
+
+    _resetSeasonCacheForTests() // simulate a new session; localStorage persists
+    expect(getCachedSeason(COORDS, PAST_YEAR)).not.toBeNull()
+  })
+})

--- a/src/__tests__/lib/weather/open-meteo-archive.test.ts
+++ b/src/__tests__/lib/weather/open-meteo-archive.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   fetchSeasonWeather,
   getCachedSeason,
+  isValidPlotCoordinates,
   _resetSeasonCacheForTests,
+  type PlotCoordinates,
 } from '@/lib/weather/open-meteo-archive'
 
 const localStorageMock = (() => {
@@ -55,6 +57,25 @@ function archiveResponse(dates: string[], withHourly = false) {
   }
   return new Response(JSON.stringify(body), { status: 200 })
 }
+
+describe('isValidPlotCoordinates', () => {
+  it('accepts real-world coordinates', () => {
+    expect(isValidPlotCoordinates({ latitude: 55.95, longitude: -3.18 })).toBe(true)
+    expect(isValidPlotCoordinates({ latitude: -90, longitude: 180 })).toBe(true)
+  })
+
+  it('rejects missing, non-numeric, non-finite, or out-of-range values', () => {
+    expect(isValidPlotCoordinates(null)).toBe(false)
+    expect(isValidPlotCoordinates(undefined)).toBe(false)
+    expect(isValidPlotCoordinates({ latitude: NaN, longitude: 0 })).toBe(false)
+    expect(isValidPlotCoordinates({ latitude: 0, longitude: -Infinity })).toBe(false)
+    expect(isValidPlotCoordinates({ latitude: 90.1, longitude: 0 })).toBe(false)
+    expect(isValidPlotCoordinates({ latitude: 0, longitude: 180.1 })).toBe(false)
+    expect(
+      isValidPlotCoordinates({ latitude: '55.95', longitude: -3.18 } as unknown as PlotCoordinates)
+    ).toBe(false)
+  })
+})
 
 describe('fetchSeasonWeather', () => {
   beforeEach(() => {
@@ -120,6 +141,50 @@ describe('fetchSeasonWeather', () => {
     const season = await fetchSeasonWeather(COORDS, CURRENT_YEAR + 1)
     expect(season).toBeNull()
     expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns null for missing or invalid coordinates without touching the network', async () => {
+    const invalid = [
+      undefined,
+      { latitude: NaN, longitude: -3.18 },
+      { latitude: 55.95, longitude: Infinity },
+      { latitude: 91, longitude: -3.18 },
+      { latitude: 55.95, longitude: -181 },
+      { latitude: '55.95', longitude: -3.18 },
+    ]
+    for (const coords of invalid) {
+      expect(await fetchSeasonWeather(coords as unknown as PlotCoordinates, PAST_YEAR)).toBeNull()
+    }
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('stores the season under a versioned, coordinate-rounded key', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(archiveResponse([`${PAST_YEAR}-06-01`]))
+
+    await fetchSeasonWeather({ latitude: 55.9533, longitude: -3.1883 }, PAST_YEAR)
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      `bwp-season-weather-v1-55.95_-3.19_${PAST_YEAR}`,
+      expect.any(String)
+    )
+  })
+
+  it('refetches the current in-progress season once its 24h TTL expires', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(globalThis.fetch).mockImplementation(() =>
+        Promise.resolve(archiveResponse([`${CURRENT_YEAR}-01-01`]))
+      )
+
+      await fetchSeasonWeather(COORDS, CURRENT_YEAR)
+      await fetchSeasonWeather(COORDS, CURRENT_YEAR)
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1) // within TTL: cached
+
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000)
+      await fetchSeasonWeather(COORDS, CURRENT_YEAR)
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2) // stale: refetched
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('serves a cached season without a second fetch', async () => {
@@ -210,6 +275,12 @@ describe('getCachedSeason', () => {
 
   it('returns null when nothing is cached', () => {
     expect(getCachedSeason(COORDS, PAST_YEAR)).toBeNull()
+  })
+
+  it('returns null for invalid coordinates', () => {
+    expect(
+      getCachedSeason({ latitude: NaN, longitude: -3.18 }, PAST_YEAR)
+    ).toBeNull()
   })
 
   it('survives a memory-cache reset via localStorage', async () => {

--- a/src/__tests__/lib/weather/soil-daily.test.ts
+++ b/src/__tests__/lib/weather/soil-daily.test.ts
@@ -87,4 +87,20 @@ describe('aggregateSoilDaily', () => {
   it('returns an empty map for an empty series', () => {
     expect(aggregateSoilDaily({ time: [] }).size).toBe(0)
   })
+
+  it('skips malformed non-string timestamp entries', () => {
+    const time = hourlyTimes('2025-06-01', 24)
+    // Corrupt two entries — the runtime payload could contain anything.
+    ;(time as unknown[])[3] = null
+    ;(time as unknown[])[7] = 42
+    const series: HourlySoilSeries = {
+      time,
+      soil_temperature_0_to_7cm: Array(24).fill(10),
+    }
+
+    const result = aggregateSoilDaily(series)
+    expect(result.size).toBe(1)
+    // 22 valid stamps remain — still enough for a mean.
+    expect(result.get('2025-06-01')!.soilTempMean0to7C).toBe(10)
+  })
 })

--- a/src/__tests__/lib/weather/soil-daily.test.ts
+++ b/src/__tests__/lib/weather/soil-daily.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { aggregateSoilDaily, type HourlySoilSeries } from '@/lib/weather/soil-daily'
+
+function hourlyTimes(date: string, hours: number): string[] {
+  return Array.from({ length: hours }, (_, h) => `${date}T${String(h).padStart(2, '0')}:00`)
+}
+
+describe('aggregateSoilDaily', () => {
+  it('computes daily means for a full day of readings', () => {
+    const series: HourlySoilSeries = {
+      time: hourlyTimes('2025-06-01', 24),
+      soil_temperature_0_to_7cm: Array.from({ length: 24 }, (_, h) => 10 + (h % 2)), // alternating 10/11
+      soil_temperature_7_to_28cm: Array(24).fill(13),
+      soil_moisture_0_to_7cm: Array(24).fill(0.1614),
+    }
+
+    const result = aggregateSoilDaily(series)
+    const day = result.get('2025-06-01')
+    expect(day).toBeDefined()
+    expect(day!.soilTempMean0to7C).toBe(10.5)
+    expect(day!.soilTempMean7to28C).toBe(13)
+    // Moisture keeps three decimals
+    expect(day!.soilMoistureMean0to7).toBe(0.161)
+  })
+
+  it('groups readings by date across multiple days', () => {
+    const series: HourlySoilSeries = {
+      time: [...hourlyTimes('2025-06-01', 24), ...hourlyTimes('2025-06-02', 24)],
+      soil_temperature_0_to_7cm: [...Array(24).fill(10), ...Array(24).fill(14)],
+    }
+
+    const result = aggregateSoilDaily(series)
+    expect(result.size).toBe(2)
+    expect(result.get('2025-06-01')!.soilTempMean0to7C).toBe(10)
+    expect(result.get('2025-06-02')!.soilTempMean0to7C).toBe(14)
+  })
+
+  it('returns null for a partial day with too few readings', () => {
+    // Only 6 hourly readings (e.g. the ragged edge near "now")
+    const series: HourlySoilSeries = {
+      time: hourlyTimes('2025-06-01', 6),
+      soil_temperature_0_to_7cm: Array(6).fill(12),
+    }
+
+    const result = aggregateSoilDaily(series)
+    expect(result.get('2025-06-01')!.soilTempMean0to7C).toBeNull()
+  })
+
+  it('skips null readings but still averages when enough remain', () => {
+    const temps: (number | null)[] = Array(24).fill(10)
+    // 8 nulls scattered through the day -> 16 valid readings, still >= minimum
+    for (let i = 0; i < 8; i++) temps[i * 3] = null
+    const series: HourlySoilSeries = {
+      time: hourlyTimes('2025-06-01', 24),
+      soil_temperature_0_to_7cm: temps,
+    }
+
+    const result = aggregateSoilDaily(series)
+    expect(result.get('2025-06-01')!.soilTempMean0to7C).toBe(10)
+  })
+
+  it('returns null when nulls leave too few valid readings', () => {
+    const temps: (number | null)[] = Array(24).fill(null)
+    // Only 11 valid readings — one below the minimum of 12
+    for (let i = 0; i < 11; i++) temps[i] = 9
+    const series: HourlySoilSeries = {
+      time: hourlyTimes('2025-06-01', 24),
+      soil_temperature_0_to_7cm: temps,
+    }
+
+    const result = aggregateSoilDaily(series)
+    expect(result.get('2025-06-01')!.soilTempMean0to7C).toBeNull()
+  })
+
+  it('returns null for metrics whose series is missing entirely', () => {
+    const series: HourlySoilSeries = {
+      time: hourlyTimes('2025-06-01', 24),
+      soil_temperature_0_to_7cm: Array(24).fill(11),
+    }
+
+    const day = aggregateSoilDaily(series).get('2025-06-01')!
+    expect(day.soilTempMean0to7C).toBe(11)
+    expect(day.soilTempMean7to28C).toBeNull()
+    expect(day.soilMoistureMean0to7).toBeNull()
+  })
+
+  it('returns an empty map for an empty series', () => {
+    expect(aggregateSoilDaily({ time: [] }).size).toBe(0)
+  })
+})

--- a/src/__tests__/lib/weather/weather-baseline.test.ts
+++ b/src/__tests__/lib/weather/weather-baseline.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  computeBaseline,
+  getBaseline,
+  BASELINE_WINDOW_YEARS,
+  _resetBaselineCacheForTests,
+} from '@/lib/weather/weather-baseline'
+import {
+  _resetSeasonCacheForTests,
+  type SeasonDailyRecord,
+  type SeasonWeather,
+} from '@/lib/weather/open-meteo-archive'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
+  }
+})()
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate()
+}
+
+function makeDay(date: string, overrides: Partial<SeasonDailyRecord> = {}): SeasonDailyRecord {
+  return {
+    date,
+    tempMaxC: 15,
+    tempMinC: 5,
+    tempMeanC: 10,
+    precipitationMm: 2,
+    shortwaveRadiationMJm2: 15,
+    et0Mm: 2.5,
+    sunshineHours: 5,
+    daylightHours: 14,
+    weatherCode: 3,
+    soilTempMean0to7C: 11,
+    soilTempMean7to28C: 12,
+    soilMoistureMean0to7: 0.16,
+    ...overrides,
+  }
+}
+
+interface SeasonOptions {
+  /** Added to every day's tempMeanC (base value is the month number). */
+  tempOffset?: number
+  /** Months (1-12) to omit entirely — a data gap. */
+  skipMonths?: number[]
+  /** Limit a month to its first N days: { month, days }. */
+  partialMonth?: { month: number; days: number }
+}
+
+function makeSeason(year: number, options: SeasonOptions = {}): SeasonWeather {
+  const days: SeasonDailyRecord[] = []
+  for (let month = 1; month <= 12; month++) {
+    if (options.skipMonths?.includes(month)) continue
+    let total = daysInMonth(year, month)
+    if (options.partialMonth?.month === month) total = options.partialMonth.days
+    for (let day = 1; day <= total; day++) {
+      const date = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+      days.push(makeDay(date, { tempMeanC: month + (options.tempOffset ?? 0) }))
+    }
+  }
+  return { year, days, complete: true, fetchedAt: new Date().toISOString() }
+}
+
+describe('computeBaseline', () => {
+  it('returns null for an empty seasons list', () => {
+    expect(computeBaseline([])).toBeNull()
+  })
+
+  it('computes monthly normals across full years', () => {
+    const seasons = [makeSeason(2020), makeSeason(2021, { tempOffset: 2 })]
+    const baseline = computeBaseline(seasons)!
+
+    expect(baseline.startYear).toBe(2020)
+    expect(baseline.endYear).toBe(2021)
+    expect(baseline.yearsUsed).toEqual([2020, 2021])
+    expect(baseline.months).toHaveLength(12)
+
+    const june = baseline.months[5]
+    expect(june.month).toBe(6)
+    // Daily means are 6 and 8 -> normal 7
+    expect(june.meanTempC).toBe(7)
+    // 30 June days x 2mm each year
+    expect(june.totalRainfallMm).toBe(60)
+    // 30 June days x 5h each year
+    expect(june.sunshineHours).toBe(150)
+    expect(june.yearsUsed).toBe(2)
+  })
+
+  it('excludes a year with a missing month from that month only', () => {
+    const seasons = [makeSeason(2020), makeSeason(2021, { tempOffset: 2, skipMonths: [6] })]
+    const baseline = computeBaseline(seasons)!
+
+    const june = baseline.months[5]
+    expect(june.meanTempC).toBe(6) // only 2020 contributes
+    expect(june.yearsUsed).toBe(1)
+
+    const july = baseline.months[6]
+    expect(july.meanTempC).toBe(8) // (7 + 9) / 2 — both years
+    expect(july.yearsUsed).toBe(2)
+  })
+
+  it('excludes a month with too few days from means and totals', () => {
+    // 10 June days: below the 20-day mean minimum and the 90% total coverage
+    const seasons = [
+      makeSeason(2020),
+      makeSeason(2021, { tempOffset: 2, partialMonth: { month: 6, days: 10 } }),
+    ]
+    const baseline = computeBaseline(seasons)!
+
+    const june = baseline.months[5]
+    expect(june.meanTempC).toBe(6)
+    expect(june.totalRainfallMm).toBe(60)
+    expect(june.yearsUsed).toBe(1)
+  })
+
+  it('keeps a mean but drops a total when only totals lack coverage', () => {
+    // 25 of 30 June days have rain data (83% < 90%), but 25 valid temps >= 20
+    const season = makeSeason(2020)
+    for (const day of season.days) {
+      if (day.date.startsWith('2020-06-') && Number(day.date.slice(8)) > 25) {
+        day.precipitationMm = null
+        day.sunshineHours = null
+      }
+    }
+    const baseline = computeBaseline([season])!
+
+    const june = baseline.months[5]
+    expect(june.meanTempC).toBe(6)
+    expect(june.totalRainfallMm).toBeNull()
+    expect(june.sunshineHours).toBeNull()
+  })
+
+  it('reports null normals for months no year covered', () => {
+    const seasons = [makeSeason(2020, { skipMonths: [1] })]
+    const baseline = computeBaseline(seasons)!
+
+    const january = baseline.months[0]
+    expect(january.meanTempC).toBeNull()
+    expect(january.totalRainfallMm).toBeNull()
+    expect(january.sunshineHours).toBeNull()
+    expect(january.yearsUsed).toBe(0)
+  })
+})
+
+describe('getBaseline', () => {
+  const COORDS = { latitude: 55.95, longitude: -3.18 }
+
+  function datesForYear(year: number): string[] {
+    const dates: string[] = []
+    const d = new Date(Date.UTC(year, 0, 1))
+    while (d.getUTCFullYear() === year) {
+      dates.push(d.toISOString().slice(0, 10))
+      d.setUTCDate(d.getUTCDate() + 1)
+    }
+    return dates
+  }
+
+  function fullYearResponse(url: string): Response {
+    const year = Number(new URL(url).searchParams.get('start_date')!.slice(0, 4))
+    const dates = datesForYear(year)
+    const n = dates.length
+    return new Response(
+      JSON.stringify({
+        daily: {
+          time: dates,
+          temperature_2m_max: Array(n).fill(15),
+          temperature_2m_min: Array(n).fill(5),
+          temperature_2m_mean: Array(n).fill(11.5),
+          precipitation_sum: Array(n).fill(1.2),
+          sunshine_duration: Array(n).fill(36000), // 10 hours
+        },
+      }),
+      { status: 200 }
+    )
+  }
+
+  beforeEach(() => {
+    localStorageMock.clear()
+    _resetBaselineCacheForTests()
+    _resetSeasonCacheForTests()
+    vi.clearAllMocks()
+    vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches the missing window years, computes normals, and caches', async () => {
+    vi.mocked(globalThis.fetch).mockImplementation((input) =>
+      Promise.resolve(fullYearResponse(String(input)))
+    )
+
+    const baseline = await getBaseline(COORDS)
+    expect(baseline).not.toBeNull()
+    expect(globalThis.fetch).toHaveBeenCalledTimes(BASELINE_WINDOW_YEARS)
+
+    const endYear = new Date().getFullYear() - 1
+    expect(baseline!.endYear).toBe(endYear)
+    expect(baseline!.startYear).toBe(endYear - BASELINE_WINDOW_YEARS + 1)
+    expect(baseline!.yearsUsed).toHaveLength(BASELINE_WINDOW_YEARS)
+
+    const june = baseline!.months[5]
+    expect(june.meanTempC).toBe(11.5)
+    expect(june.totalRainfallMm).toBe(36) // 30 days x 1.2mm
+    expect(june.sunshineHours).toBe(300) // 30 days x 10h
+
+    // Second call is served from the baseline cache — zero further fetches.
+    vi.mocked(globalThis.fetch).mockClear()
+    const again = await getBaseline(COORDS)
+    expect(again).not.toBeNull()
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the archive is unreachable and nothing is cached', async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error('network down'))
+
+    expect(await getBaseline(COORDS)).toBeNull()
+  })
+
+  it('publishes a baseline when enough years succeed despite some failures', async () => {
+    let call = 0
+    vi.mocked(globalThis.fetch).mockImplementation((input) => {
+      call++
+      // Fail 4 of the 10 years; 6 remain, above the 5-year minimum.
+      if (call <= 4) return Promise.reject(new Error('archive outage'))
+      return Promise.resolve(fullYearResponse(String(input)))
+    })
+
+    const baseline = await getBaseline(COORDS)
+    expect(baseline).not.toBeNull()
+    expect(baseline!.yearsUsed).toHaveLength(BASELINE_WINDOW_YEARS - 4)
+  })
+
+  it('returns null when too few years are available for a trustworthy average', async () => {
+    let call = 0
+    vi.mocked(globalThis.fetch).mockImplementation((input) => {
+      call++
+      // Only 4 years succeed — below the 5-year minimum.
+      if (call > 4) return Promise.reject(new Error('archive outage'))
+      return Promise.resolve(fullYearResponse(String(input)))
+    })
+
+    expect(await getBaseline(COORDS)).toBeNull()
+  })
+})

--- a/src/__tests__/lib/weather/weather-baseline.test.ts
+++ b/src/__tests__/lib/weather/weather-baseline.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/weather/weather-baseline'
 import {
   _resetSeasonCacheForTests,
+  type PlotCoordinates,
   type SeasonDailyRecord,
   type SeasonWeather,
 } from '@/lib/weather/open-meteo-archive'
@@ -256,5 +257,67 @@ describe('getBaseline', () => {
     })
 
     expect(await getBaseline(COORDS)).toBeNull()
+  })
+
+  it('returns null for missing or invalid coordinates without fetching', async () => {
+    expect(await getBaseline({ latitude: NaN, longitude: -3.18 })).toBeNull()
+    expect(await getBaseline({ latitude: 55.95, longitude: 181 })).toBeNull()
+    expect(await getBaseline(undefined as unknown as PlotCoordinates)).toBeNull()
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('caches under a versioned key that encodes the window years', async () => {
+    vi.mocked(globalThis.fetch).mockImplementation((input) =>
+      Promise.resolve(fullYearResponse(String(input)))
+    )
+
+    await getBaseline(COORDS)
+    const endYear = new Date().getFullYear() - 1
+    const startYear = endYear - BASELINE_WINDOW_YEARS + 1
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      `bwp-weather-baseline-v1-55.95_-3.18_${startYear}-${endYear}`,
+      expect.any(String)
+    )
+  })
+
+  it('retries the missing years after an incomplete baseline expires', async () => {
+    vi.useFakeTimers()
+    try {
+      const endYear = new Date().getFullYear() - 1
+      const startYear = endYear - BASELINE_WINDOW_YEARS + 1
+      let outage = true
+      vi.mocked(globalThis.fetch).mockImplementation((input) => {
+        const url = String(input)
+        const year = Number(new URL(url).searchParams.get('start_date')!.slice(0, 4))
+        // The four oldest years are down during the first pass.
+        if (outage && year < startYear + 4) return Promise.reject(new Error('archive outage'))
+        return Promise.resolve(fullYearResponse(url))
+      })
+
+      const first = await getBaseline(COORDS)
+      expect(first!.yearsUsed).toHaveLength(BASELINE_WINDOW_YEARS - 4)
+      expect(globalThis.fetch).toHaveBeenCalledTimes(BASELINE_WINDOW_YEARS)
+
+      // Within the TTL the incomplete baseline is served from cache.
+      vi.mocked(globalThis.fetch).mockClear()
+      await getBaseline(COORDS)
+      expect(globalThis.fetch).not.toHaveBeenCalled()
+
+      // After the TTL it recomputes: only the 4 missing years are refetched
+      // (the 6 archived seasons are immutable) and the window completes.
+      outage = false
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000)
+      const third = await getBaseline(COORDS)
+      expect(globalThis.fetch).toHaveBeenCalledTimes(4)
+      expect(third!.yearsUsed).toHaveLength(BASELINE_WINDOW_YEARS)
+
+      // A full-window baseline is immutable — no refetch after another day.
+      vi.mocked(globalThis.fetch).mockClear()
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000)
+      expect(await getBaseline(COORDS)).not.toBeNull()
+      expect(globalThis.fetch).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/components/dashboard/WeatherStrip.tsx
+++ b/src/components/dashboard/WeatherStrip.tsx
@@ -44,37 +44,52 @@ export default function WeatherStrip({ forecast }: WeatherStripProps) {
   if (forecast.length === 0) return null
 
   return (
-    <div
-      className="grid grid-cols-3 gap-2 -mt-4"
-      role="region"
-      aria-label="Three day weather forecast"
-    >
-      {forecast.map((day, index) => {
-        const { Icon, label } = getWeatherIcon(day.weatherCode)
-        return (
-          <div
-            key={day.date}
-            className="zen-card px-3 py-3 flex flex-col items-center text-center"
-          >
-            <div className="text-xs font-medium text-zen-stone-500 mb-1">
-              {tileLabel(day.date, index)}
-            </div>
-            <Icon
-              className="w-7 h-7 text-zen-water-600 mb-1"
-              aria-label={label}
-            />
-            <div className="text-sm text-zen-ink-900 flex items-center justify-center">
-              {Math.round(day.tempMaxC)}° <span className="text-zen-stone-400">/ {Math.round(day.tempMinC)}°</span>
-              <FrostIndicator tempMinC={day.tempMinC} />
-            </div>
-            {day.precipitationMm > 0 && (
-              <div className="text-xs text-zen-water-600 mt-0.5">
-                {day.precipitationMm.toFixed(1)}mm
+    <div className="-mt-4">
+      <div
+        className="grid grid-cols-3 gap-2"
+        role="region"
+        aria-label="Three day weather forecast"
+      >
+        {forecast.map((day, index) => {
+          const { Icon, label } = getWeatherIcon(day.weatherCode)
+          return (
+            <div
+              key={day.date}
+              className="zen-card px-3 py-3 flex flex-col items-center text-center"
+            >
+              <div className="text-xs font-medium text-zen-stone-500 mb-1">
+                {tileLabel(day.date, index)}
               </div>
-            )}
-          </div>
-        )
-      })}
+              <Icon
+                className="w-7 h-7 text-zen-water-600 mb-1"
+                aria-label={label}
+              />
+              <div className="text-sm text-zen-ink-900 flex items-center justify-center">
+                {Math.round(day.tempMaxC)}° <span className="text-zen-stone-400">/ {Math.round(day.tempMinC)}°</span>
+                <FrostIndicator tempMinC={day.tempMinC} />
+              </div>
+              {day.precipitationMm > 0 && (
+                <div className="text-xs text-zen-water-600 mt-0.5">
+                  {day.precipitationMm.toFixed(1)}mm
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+      {/* Open-Meteo data is CC BY 4.0 — attribution with a link is required. */}
+      <p className="mt-1 text-right text-[10px] text-zen-stone-400">
+        Weather data by{' '}
+        <a
+          href="https://open-meteo.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-zen-stone-500"
+        >
+          Open-Meteo.com
+        </a>{' '}
+        (CC BY 4.0)
+      </p>
     </div>
   )
 }

--- a/src/lib/weather/open-meteo-archive.ts
+++ b/src/lib/weather/open-meteo-archive.ts
@@ -1,0 +1,323 @@
+/**
+ * Open-Meteo Historical Weather (Archive) Service
+ *
+ * Season-at-once historical weather for the Season Observer: one API call
+ * fetches a whole calendar year of daily weather plus hourly soil series
+ * (aggregated to daily here — see soil-daily.ts), parsed into typed daily
+ * records and cached locally. A future rules engine consumes these records
+ * to compare a season against the plot's 10-year baseline (weather-baseline.ts).
+ *
+ * Endpoint decision: everything comes from the Archive API (ERA5/ERA5-Land,
+ * https://archive-api.open-meteo.com/v1/archive). The Historical Forecast API
+ * was considered for the current in-progress season (it has ~no lag), but it
+ * publishes soil variables at different depth layers (0cm/6cm point depths,
+ * 0-1cm/1-3cm/... moisture layers) than ERA5's 0-7cm/7-28cm, so mixing the
+ * two would make current-season soil metrics incomparable with the multi-year
+ * baseline. The Archive API's ~5-day lag is irrelevant for a retrospective
+ * season report, so a single consistent source wins. All variable names below
+ * were verified against the live API (2026-07).
+ *
+ * Caching: completed past seasons are immutable and cached forever; the
+ * current in-progress season is cached with a 24h TTL and refetched whole
+ * (still just one call) when stale. Aggregating hourly soil data to daily
+ * before caching keeps a season at roughly 40 KB of JSON, so ten years fit
+ * comfortably in localStorage — matching the storage the existing weather
+ * code uses — with an in-memory fallback when quota is exhausted.
+ *
+ * Privacy: coordinates are home-adjacent. They appear only in local cache
+ * keys (rounded to ~1 km like the existing weather cache), are never logged,
+ * and are absent from every exported type, so cached or derived weather data
+ * can be shared without leaking the plot location.
+ *
+ * Open-Meteo is free for non-commercial use, needs no API key, supports CORS
+ * (called directly from the browser), and requires CC BY 4.0 attribution —
+ * shown where weather data surfaces (WeatherStrip) and in the README.
+ */
+
+import { logger } from '@/lib/logger'
+import { aggregateSoilDaily } from './soil-daily'
+
+const ENDPOINT = 'https://archive-api.open-meteo.com/v1/archive'
+const CACHE_PREFIX = 'bwp-season-weather-'
+// Archive queries scan a year of ERA5 data and are slower than the forecast
+// API; allow the same headroom as the climate endpoint in frost-dates.ts.
+const FETCH_TIMEOUT_MS = 15000
+// The current season grows a new tail every day (minus the ~5-day archive
+// lag); refetch at most once a day. Completed seasons never expire.
+const CURRENT_SEASON_TTL_MS = 24 * 60 * 60 * 1000
+
+const DAILY_VARIABLES = [
+  'temperature_2m_max',
+  'temperature_2m_min',
+  'temperature_2m_mean',
+  'precipitation_sum',
+  'shortwave_radiation_sum',
+  'et0_fao_evapotranspiration',
+  'sunshine_duration',
+  'daylight_duration',
+  'weather_code',
+].join(',')
+
+const HOURLY_VARIABLES = [
+  'soil_temperature_0_to_7cm',
+  'soil_temperature_7_to_28cm',
+  'soil_moisture_0_to_7cm',
+].join(',')
+
+/** Geographic coordinates, matching the shape of AllotmentMeta.coordinates. */
+export interface PlotCoordinates {
+  latitude: number
+  longitude: number
+}
+
+/** One day of historical weather. Null means the archive had no value. */
+export interface SeasonDailyRecord {
+  /** ISO date (YYYY-MM-DD). */
+  date: string
+  /** Daily max air temperature at 2m in °C. */
+  tempMaxC: number | null
+  /** Daily min air temperature at 2m in °C. */
+  tempMinC: number | null
+  /** Daily mean air temperature at 2m in °C. */
+  tempMeanC: number | null
+  /** Total daily precipitation in mm. */
+  precipitationMm: number | null
+  /** Daily shortwave solar radiation sum in MJ/m². */
+  shortwaveRadiationMJm2: number | null
+  /** Daily FAO reference evapotranspiration (ET₀) in mm. */
+  et0Mm: number | null
+  /** Sunshine duration in hours. */
+  sunshineHours: number | null
+  /** Daylight duration in hours. */
+  daylightHours: number | null
+  /** Most severe WMO weather code of the day. */
+  weatherCode: number | null
+  /** Mean soil temperature at 0–7cm in °C (aggregated from hourly). */
+  soilTempMean0to7C: number | null
+  /** Mean soil temperature at 7–28cm in °C (aggregated from hourly). */
+  soilTempMean7to28C: number | null
+  /** Mean volumetric soil moisture at 0–7cm in m³/m³ (aggregated from hourly). */
+  soilMoistureMean0to7: number | null
+}
+
+/** A season (calendar year) of daily weather for one plot. */
+export interface SeasonWeather {
+  /** Calendar year the records cover. */
+  year: number
+  /** Daily records in date order, trailing no-data days trimmed. */
+  days: SeasonDailyRecord[]
+  /** True for a completed past year — the data is immutable. */
+  complete: boolean
+  /** ISO timestamp when this season was fetched. */
+  fetchedAt: string
+}
+
+interface ArchiveResponse {
+  daily?: {
+    time?: string[]
+    temperature_2m_max?: (number | null)[]
+    temperature_2m_min?: (number | null)[]
+    temperature_2m_mean?: (number | null)[]
+    precipitation_sum?: (number | null)[]
+    shortwave_radiation_sum?: (number | null)[]
+    et0_fao_evapotranspiration?: (number | null)[]
+    sunshine_duration?: (number | null)[]
+    daylight_duration?: (number | null)[]
+    weather_code?: (number | null)[]
+  }
+  hourly?: {
+    time?: string[]
+    soil_temperature_0_to_7cm?: (number | null)[]
+    soil_temperature_7_to_28cm?: (number | null)[]
+    soil_moisture_0_to_7cm?: (number | null)[]
+  }
+}
+
+interface CachedSeason {
+  season: SeasonWeather
+  /** Epoch ms after which the entry is stale, or null for immutable seasons. */
+  expiresAt: number | null
+}
+
+const memoryCache = new Map<string, CachedSeason>()
+
+function cacheKey(coords: PlotCoordinates, year: number): string {
+  // Round to 2 decimals (~1 km) so tiny coordinate jitter still hits the
+  // cache — and so the exact plot location never leaves the device.
+  const lat = coords.latitude.toFixed(2)
+  const lng = coords.longitude.toFixed(2)
+  return `${CACHE_PREFIX}${lat}_${lng}_${year}`
+}
+
+function readCache(key: string): SeasonWeather | null {
+  let entry = memoryCache.get(key) ?? null
+  if (!entry && typeof localStorage !== 'undefined') {
+    try {
+      const raw = localStorage.getItem(key)
+      if (raw) {
+        entry = JSON.parse(raw) as CachedSeason
+        memoryCache.set(key, entry)
+      }
+    } catch {
+      return null
+    }
+  }
+  if (!entry) return null
+  if (entry.expiresAt !== null && entry.expiresAt < Date.now()) {
+    memoryCache.delete(key)
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      // Removal is best-effort; a stale entry is re-written on next fetch.
+    }
+    return null
+  }
+  return entry.season
+}
+
+function writeCache(key: string, season: SeasonWeather): void {
+  const entry: CachedSeason = {
+    season,
+    expiresAt: season.complete ? null : Date.now() + CURRENT_SEASON_TTL_MS,
+  }
+  memoryCache.set(key, entry)
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(key, JSON.stringify(entry))
+  } catch {
+    // Quota errors are non-fatal — the memory cache still serves this session.
+  }
+}
+
+/** Internal helper: only used by tests to clear caches between runs. */
+export function _resetSeasonCacheForTests(): void {
+  memoryCache.clear()
+}
+
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals
+  return Math.round(value * factor) / factor
+}
+
+function numberOrNull(
+  series: (number | null)[] | undefined,
+  index: number,
+  decimals: number,
+  scale = 1
+): number | null {
+  const v = series?.[index]
+  if (typeof v !== 'number' || Number.isNaN(v)) return null
+  return round(v * scale, decimals)
+}
+
+/** Local ISO date (YYYY-MM-DD) — matches Open-Meteo's timezone=auto days. */
+function todayIsoLocal(): string {
+  return new Date().toLocaleDateString('en-CA')
+}
+
+function buildDays(data: ArchiveResponse): SeasonDailyRecord[] | null {
+  const time = data.daily?.time
+  if (!Array.isArray(time) || time.length === 0) return null
+  const daily = data.daily!
+  const hourly = data.hourly
+  const hourlyTime = hourly?.time
+  const soilByDate =
+    hourly && Array.isArray(hourlyTime) && hourlyTime.length > 0
+      ? aggregateSoilDaily({ ...hourly, time: hourlyTime })
+      : undefined
+
+  const days: SeasonDailyRecord[] = time.map((date, i) => {
+    const soil = soilByDate?.get(date)
+    return {
+      date,
+      tempMaxC: numberOrNull(daily.temperature_2m_max, i, 1),
+      tempMinC: numberOrNull(daily.temperature_2m_min, i, 1),
+      tempMeanC: numberOrNull(daily.temperature_2m_mean, i, 1),
+      precipitationMm: numberOrNull(daily.precipitation_sum, i, 2),
+      shortwaveRadiationMJm2: numberOrNull(daily.shortwave_radiation_sum, i, 2),
+      et0Mm: numberOrNull(daily.et0_fao_evapotranspiration, i, 2),
+      // Open-Meteo returns durations in seconds; hours are the useful unit.
+      sunshineHours: numberOrNull(daily.sunshine_duration, i, 2, 1 / 3600),
+      daylightHours: numberOrNull(daily.daylight_duration, i, 2, 1 / 3600),
+      weatherCode: numberOrNull(daily.weather_code, i, 0),
+      soilTempMean0to7C: soil?.soilTempMean0to7C ?? null,
+      soilTempMean7to28C: soil?.soilTempMean7to28C ?? null,
+      soilMoistureMean0to7: soil?.soilMoistureMean0to7 ?? null,
+    }
+  })
+
+  // The archive lags ~5 days behind real time and pads the gap with nulls;
+  // trim trailing days that carry no temperature or precipitation data.
+  let end = days.length
+  while (end > 0) {
+    const d = days[end - 1]
+    if (d.tempMeanC !== null || d.tempMaxC !== null || d.precipitationMm !== null) break
+    end--
+  }
+  return end > 0 ? days.slice(0, end) : null
+}
+
+/**
+ * Return the cached season for the given plot and year, or null when absent
+ * or stale. Never touches the network.
+ */
+export function getCachedSeason(coords: PlotCoordinates, year: number): SeasonWeather | null {
+  return readCache(cacheKey(coords, year))
+}
+
+/**
+ * Fetch a whole season (calendar year) of daily weather for the plot.
+ * Cache-first: a completed past season is fetched at most once, ever; the
+ * current in-progress season is refetched after 24h. Returns null when the
+ * year is in the future, when offline, or when the API fails and nothing is
+ * cached — callers should degrade gracefully.
+ */
+export async function fetchSeasonWeather(
+  coords: PlotCoordinates,
+  year: number
+): Promise<SeasonWeather | null> {
+  const today = todayIsoLocal()
+  const currentYear = Number(today.slice(0, 4))
+  if (year > currentYear) return null
+
+  const key = cacheKey(coords, year)
+  const cached = readCache(key)
+  if (cached) return cached
+
+  const complete = year < currentYear
+  const endDate = complete ? `${year}-12-31` : today
+  const url =
+    `${ENDPOINT}?latitude=${coords.latitude}&longitude=${coords.longitude}` +
+    `&start_date=${year}-01-01&end_date=${endDate}` +
+    `&daily=${DAILY_VARIABLES}&hourly=${HOURLY_VARIABLES}&timezone=auto`
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    if (!response.ok) {
+      logger.warn('season-archive: API request failed', { status: response.status, year })
+      return null
+    }
+    const data = (await response.json()) as ArchiveResponse
+    const days = buildDays(data)
+    if (!days) {
+      logger.warn('season-archive: response had no usable daily data', { year })
+      return null
+    }
+    const season: SeasonWeather = {
+      year,
+      days,
+      complete,
+      fetchedAt: new Date().toISOString(),
+    }
+    writeCache(key, season)
+    return season
+  } catch (error) {
+    logger.warn('season-archive: fetch error', { error: String(error), year })
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/src/lib/weather/open-meteo-archive.ts
+++ b/src/lib/weather/open-meteo-archive.ts
@@ -35,10 +35,14 @@
  */
 
 import { logger } from '@/lib/logger'
+import { todayLocalISO } from '@/lib/log-date'
 import { aggregateSoilDaily } from './soil-daily'
 
 const ENDPOINT = 'https://archive-api.open-meteo.com/v1/archive'
-const CACHE_PREFIX = 'bwp-season-weather-'
+// The "v1" segment versions the cached payload shape — bump it if
+// SeasonDailyRecord ever changes, so forever-cached immutable seasons
+// can't be served in an incompatible shape.
+const CACHE_PREFIX = 'bwp-season-weather-v1-'
 // Archive queries scan a year of ERA5 data and are slower than the forecast
 // API; allow the same headroom as the climate endpoint in frost-dates.ts.
 const FETCH_TIMEOUT_MS = 15000
@@ -68,6 +72,26 @@ const HOURLY_VARIABLES = [
 export interface PlotCoordinates {
   latitude: number
   longitude: number
+}
+
+/**
+ * Runtime guard for plot coordinates. AllotmentMeta.coordinates is user data
+ * (geolocation or manual entry, possibly from an imported/migrated document),
+ * so despite the strict types every entry point re-checks the values before
+ * building cache keys or request URLs.
+ */
+export function isValidPlotCoordinates(
+  coords: PlotCoordinates | null | undefined
+): coords is PlotCoordinates {
+  return (
+    coords != null &&
+    typeof coords.latitude === 'number' &&
+    typeof coords.longitude === 'number' &&
+    Number.isFinite(coords.latitude) &&
+    Number.isFinite(coords.longitude) &&
+    Math.abs(coords.latitude) <= 90 &&
+    Math.abs(coords.longitude) <= 180
+  )
 }
 
 /** One day of historical weather. Null means the archive had no value. */
@@ -172,7 +196,8 @@ function readCache(key: string): SeasonWeather | null {
     }
     return null
   }
-  return entry.season
+  // ?? null guards a corrupt entry (e.g. hand-edited storage) parsing fine.
+  return entry.season ?? null
 }
 
 function writeCache(key: string, season: SeasonWeather): void {
@@ -208,11 +233,6 @@ function numberOrNull(
   const v = series?.[index]
   if (typeof v !== 'number' || Number.isNaN(v)) return null
   return round(v * scale, decimals)
-}
-
-/** Local ISO date (YYYY-MM-DD) — matches Open-Meteo's timezone=auto days. */
-function todayIsoLocal(): string {
-  return new Date().toLocaleDateString('en-CA')
 }
 
 function buildDays(data: ArchiveResponse): SeasonDailyRecord[] | null {
@@ -262,21 +282,24 @@ function buildDays(data: ArchiveResponse): SeasonDailyRecord[] | null {
  * or stale. Never touches the network.
  */
 export function getCachedSeason(coords: PlotCoordinates, year: number): SeasonWeather | null {
+  if (!isValidPlotCoordinates(coords)) return null
   return readCache(cacheKey(coords, year))
 }
 
 /**
  * Fetch a whole season (calendar year) of daily weather for the plot.
  * Cache-first: a completed past season is fetched at most once, ever; the
- * current in-progress season is refetched after 24h. Returns null when the
- * year is in the future, when offline, or when the API fails and nothing is
- * cached — callers should degrade gracefully.
+ * current in-progress season is refetched after 24h. Returns null when
+ * coordinates are missing/invalid, when the year is in the future, when
+ * offline, or when the API fails and nothing is cached — callers should
+ * degrade gracefully.
  */
 export async function fetchSeasonWeather(
   coords: PlotCoordinates,
   year: number
 ): Promise<SeasonWeather | null> {
-  const today = todayIsoLocal()
+  if (!isValidPlotCoordinates(coords)) return null
+  const today = todayLocalISO()
   const currentYear = Number(today.slice(0, 4))
   if (year > currentYear) return null
 

--- a/src/lib/weather/soil-daily.ts
+++ b/src/lib/weather/soil-daily.ts
@@ -69,7 +69,10 @@ function meanAt(
 export function aggregateSoilDaily(hourly: HourlySoilSeries): Map<string, DailySoilAggregates> {
   const indexesByDate = new Map<string, number[]>()
   for (let i = 0; i < hourly.time.length; i++) {
-    const date = hourly.time[i].slice(0, 10)
+    const stamp = hourly.time[i]
+    // The series comes from an untyped API payload — skip malformed entries.
+    if (typeof stamp !== 'string') continue
+    const date = stamp.slice(0, 10)
     if (date.length !== 10) continue
     const indexes = indexesByDate.get(date)
     if (indexes) {

--- a/src/lib/weather/soil-daily.ts
+++ b/src/lib/weather/soil-daily.ts
@@ -1,0 +1,91 @@
+/**
+ * Hourly → daily aggregation for Open-Meteo soil variables.
+ *
+ * The Archive API only publishes soil temperature and soil moisture as
+ * hourly series, so the season-archive client aggregates them to one
+ * value per day before caching. Pure functions, no I/O — unit tested
+ * directly with fixture series.
+ */
+
+/** Hourly soil series as returned by the Open-Meteo Archive API. */
+export interface HourlySoilSeries {
+  /** ISO timestamps, e.g. "2025-06-01T13:00". */
+  time: string[]
+  soil_temperature_0_to_7cm?: (number | null)[]
+  soil_temperature_7_to_28cm?: (number | null)[]
+  soil_moisture_0_to_7cm?: (number | null)[]
+}
+
+/** Daily aggregates derived from the hourly soil series. */
+export interface DailySoilAggregates {
+  /** Mean soil temperature at 0–7cm in °C, or null when coverage is too thin. */
+  soilTempMean0to7C: number | null
+  /** Mean soil temperature at 7–28cm in °C, or null when coverage is too thin. */
+  soilTempMean7to28C: number | null
+  /** Mean volumetric soil moisture at 0–7cm in m³/m³, or null when coverage is too thin. */
+  soilMoistureMean0to7: number | null
+}
+
+/**
+ * Minimum valid hourly readings required before a daily mean is trusted.
+ * A half-day of data still gives a usable mean; fewer readings (e.g. the
+ * archive's ragged trailing edge near "now") yield null instead of a
+ * value skewed toward one part of the day.
+ */
+const MIN_HOURLY_READINGS = 12
+
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals
+  return Math.round(value * factor) / factor
+}
+
+/**
+ * Mean of the values at the given indexes, skipping null/NaN entries.
+ * Returns null when fewer than MIN_HOURLY_READINGS valid readings exist.
+ */
+function meanAt(
+  series: (number | null)[] | undefined,
+  indexes: number[],
+  decimals: number
+): number | null {
+  if (!series) return null
+  let sum = 0
+  let count = 0
+  for (const i of indexes) {
+    const v = series[i]
+    if (typeof v !== 'number' || Number.isNaN(v)) continue
+    sum += v
+    count++
+  }
+  if (count < MIN_HOURLY_READINGS) return null
+  return round(sum / count, decimals)
+}
+
+/**
+ * Aggregate hourly soil series into per-day means keyed by ISO date
+ * (YYYY-MM-DD). Days with too few valid readings get null for the
+ * affected metric rather than a misleading partial mean.
+ */
+export function aggregateSoilDaily(hourly: HourlySoilSeries): Map<string, DailySoilAggregates> {
+  const indexesByDate = new Map<string, number[]>()
+  for (let i = 0; i < hourly.time.length; i++) {
+    const date = hourly.time[i].slice(0, 10)
+    if (date.length !== 10) continue
+    const indexes = indexesByDate.get(date)
+    if (indexes) {
+      indexes.push(i)
+    } else {
+      indexesByDate.set(date, [i])
+    }
+  }
+
+  const result = new Map<string, DailySoilAggregates>()
+  for (const [date, indexes] of indexesByDate) {
+    result.set(date, {
+      soilTempMean0to7C: meanAt(hourly.soil_temperature_0_to_7cm, indexes, 1),
+      soilTempMean7to28C: meanAt(hourly.soil_temperature_7_to_28cm, indexes, 1),
+      soilMoistureMean0to7: meanAt(hourly.soil_moisture_0_to_7cm, indexes, 3),
+    })
+  }
+  return result
+}

--- a/src/lib/weather/weather-baseline.ts
+++ b/src/lib/weather/weather-baseline.ts
@@ -13,13 +13,22 @@
 import { logger } from '@/lib/logger'
 import {
   fetchSeasonWeather,
+  isValidPlotCoordinates,
   type PlotCoordinates,
   type SeasonWeather,
 } from './open-meteo-archive'
 
-const CACHE_PREFIX = 'bwp-weather-baseline-'
+// The "v1" segment versions the cached payload shape — bump it if
+// WeatherBaseline ever changes so an old cached shape can't be served.
+const CACHE_PREFIX = 'bwp-weather-baseline-v1-'
 /** How many completed years the baseline window spans. */
 export const BASELINE_WINDOW_YEARS = 10
+/**
+ * How long a baseline computed from an incomplete window (some years failed
+ * to fetch) stays valid. Recomputing after a day picks up the missing years
+ * opportunistically; a full-window baseline is immutable for its endYear.
+ */
+const INCOMPLETE_BASELINE_TTL_MS = 24 * 60 * 60 * 1000
 /**
  * Minimum years of usable data before a baseline is published. A "10-year
  * average" built on fewer than half the window would mislead more than help.
@@ -152,36 +161,62 @@ export function computeBaseline(seasons: SeasonWeather[]): WeatherBaseline | nul
   }
 }
 
-const memoryCache = new Map<string, WeatherBaseline>()
+interface CachedBaseline {
+  baseline: WeatherBaseline
+  /** Epoch ms after which the entry is stale, or null for full-window baselines. */
+  expiresAt: number | null
+}
 
-function cacheKey(coords: PlotCoordinates, endYear: number): string {
+const memoryCache = new Map<string, CachedBaseline>()
+
+function cacheKey(coords: PlotCoordinates, startYear: number, endYear: number): string {
   // Rounded to ~1 km like the season cache; the exact plot location stays
-  // out of storage keys and is never part of the baseline payload.
+  // out of storage keys and is never part of the baseline payload. Both
+  // window years are in the key so a future BASELINE_WINDOW_YEARS change
+  // can't serve a baseline computed over a different window.
   const lat = coords.latitude.toFixed(2)
   const lng = coords.longitude.toFixed(2)
-  return `${CACHE_PREFIX}${lat}_${lng}_${endYear}`
+  return `${CACHE_PREFIX}${lat}_${lng}_${startYear}-${endYear}`
 }
 
 function readCache(key: string): WeatherBaseline | null {
-  const inMemory = memoryCache.get(key)
-  if (inMemory) return inMemory
-  if (typeof localStorage === 'undefined') return null
-  try {
-    const raw = localStorage.getItem(key)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as WeatherBaseline
-    memoryCache.set(key, parsed)
-    return parsed
-  } catch {
+  let entry = memoryCache.get(key) ?? null
+  if (!entry && typeof localStorage !== 'undefined') {
+    try {
+      const raw = localStorage.getItem(key)
+      if (!raw) return null
+      entry = JSON.parse(raw) as CachedBaseline
+      memoryCache.set(key, entry)
+    } catch {
+      return null
+    }
+  }
+  if (!entry) return null
+  if (entry.expiresAt !== null && entry.expiresAt < Date.now()) {
+    memoryCache.delete(key)
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      // Removal is best-effort; a stale entry is overwritten on recompute.
+    }
     return null
   }
+  // ?? null guards a corrupt entry (e.g. hand-edited storage) parsing fine.
+  return entry.baseline ?? null
 }
 
 function writeCache(key: string, baseline: WeatherBaseline): void {
-  memoryCache.set(key, baseline)
+  // A baseline missing some window years (failed fetches) expires after a
+  // day so the missing years are retried; a full window is immutable.
+  const isComplete = baseline.yearsUsed.length >= BASELINE_WINDOW_YEARS
+  const entry: CachedBaseline = {
+    baseline,
+    expiresAt: isComplete ? null : Date.now() + INCOMPLETE_BASELINE_TTL_MS,
+  }
+  memoryCache.set(key, entry)
   if (typeof localStorage === 'undefined') return
   try {
-    localStorage.setItem(key, JSON.stringify(baseline))
+    localStorage.setItem(key, JSON.stringify(entry))
   } catch {
     // Quota errors are non-fatal — the memory cache still serves this session.
   }
@@ -197,25 +232,29 @@ export function _resetBaselineCacheForTests(): void {
  * seasons on first call. Missing years are fetched through the season cache,
  * so a fully-cached plot computes offline. Years that fail to fetch are
  * skipped; the baseline is published when at least MIN_BASELINE_YEARS
- * contributed, otherwise null — callers should degrade gracefully.
+ * contributed, otherwise null — callers should degrade gracefully. A
+ * baseline built from an incomplete window is cached for a day and then
+ * recomputed so the missing years get retried.
  *
  * The window is the BASELINE_WINDOW_YEARS completed years before the current
  * one, so the cached baseline rolls forward automatically at new year.
  */
 export async function getBaseline(coords: PlotCoordinates): Promise<WeatherBaseline | null> {
+  if (!isValidPlotCoordinates(coords)) return null
   const endYear = new Date().getFullYear() - 1
   const startYear = endYear - BASELINE_WINDOW_YEARS + 1
 
-  const key = cacheKey(coords, endYear)
+  const key = cacheKey(coords, startYear, endYear)
   const cached = readCache(key)
   if (cached) return cached
 
-  const seasons: SeasonWeather[] = []
-  for (let year = startYear; year <= endYear; year++) {
-    // fetchSeasonWeather is cache-first, so already-archived years cost nothing.
-    const season = await fetchSeasonWeather(coords, year)
-    if (season) seasons.push(season)
-  }
+  // Fetch the window years concurrently — this is a one-time backfill of
+  // BASELINE_WINDOW_YEARS calls (cache-first, so already-archived years cost
+  // nothing), well within Open-Meteo's free-tier rate limits, and the slow
+  // archive endpoint makes sequential fetching needlessly take ~10x longer.
+  const years = Array.from({ length: BASELINE_WINDOW_YEARS }, (_, i) => startYear + i)
+  const fetched = await Promise.all(years.map((year) => fetchSeasonWeather(coords, year)))
+  const seasons = fetched.filter((s): s is SeasonWeather => s !== null)
 
   if (seasons.length < MIN_BASELINE_YEARS) {
     logger.warn('weather-baseline: not enough archived years to compute a baseline', {

--- a/src/lib/weather/weather-baseline.ts
+++ b/src/lib/weather/weather-baseline.ts
@@ -1,0 +1,232 @@
+/**
+ * 10-year weather baseline (monthly normals) for the plot.
+ *
+ * Computes per-month normals — mean temperature, total rainfall, sunshine
+ * hours — from ~10 years of archived season data, so later code can say
+ * "June was 1.4°C below your 10-year average". The computation is a pure
+ * function over already-fetched SeasonWeather data; getBaseline() fetches
+ * missing years through the season-archive cache and caches the computed
+ * baseline locally, keyed by (rounded) coordinates like every other weather
+ * cache. Coordinates never appear inside the baseline itself.
+ */
+
+import { logger } from '@/lib/logger'
+import {
+  fetchSeasonWeather,
+  type PlotCoordinates,
+  type SeasonWeather,
+} from './open-meteo-archive'
+
+const CACHE_PREFIX = 'bwp-weather-baseline-'
+/** How many completed years the baseline window spans. */
+export const BASELINE_WINDOW_YEARS = 10
+/**
+ * Minimum years of usable data before a baseline is published. A "10-year
+ * average" built on fewer than half the window would mislead more than help.
+ */
+const MIN_BASELINE_YEARS = 5
+/** Minimum valid days before a month's mean is included for a year. */
+const MIN_DAYS_FOR_MEAN = 20
+/**
+ * Minimum fraction of the month's days with data before a monthly *total*
+ * (rainfall, sunshine) is included — missing days silently shrink a total,
+ * so totals need near-complete coverage.
+ */
+const MIN_COVERAGE_FOR_TOTAL = 0.9
+
+/** Normals for one calendar month, averaged across the baseline years. */
+export interface MonthlyNormal {
+  /** Calendar month, 1–12. */
+  month: number
+  /** Mean daily-mean temperature in °C, or null when no year had coverage. */
+  meanTempC: number | null
+  /** Mean monthly rainfall total in mm, or null when no year had coverage. */
+  totalRainfallMm: number | null
+  /** Mean monthly sunshine total in hours, or null when no year had coverage. */
+  sunshineHours: number | null
+  /** How many baseline years contributed to this month (max of the three metrics). */
+  yearsUsed: number
+}
+
+/** Per-month climate normals for the plot over a multi-year window. */
+export interface WeatherBaseline {
+  /** First year of the window (inclusive). */
+  startYear: number
+  /** Last year of the window (inclusive). */
+  endYear: number
+  /** Years that actually contributed data. */
+  yearsUsed: number[]
+  /** One entry per calendar month, index 0 = January. */
+  months: MonthlyNormal[]
+  /** ISO timestamp when the baseline was computed. */
+  computedAt: string
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate()
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null
+  const sum = values.reduce((a, b) => a + b, 0)
+  return Math.round((sum / values.length) * 10) / 10
+}
+
+interface MonthAccumulator {
+  meanTemps: number[]
+  rainTotals: number[]
+  sunshineTotals: number[]
+}
+
+/**
+ * Compute per-month normals from already-fetched seasons. Pure function.
+ *
+ * Gap handling: for each (year, month) a metric only contributes when
+ * coverage is sufficient — means need MIN_DAYS_FOR_MEAN valid days, totals
+ * need MIN_COVERAGE_FOR_TOTAL of the month's days — so a year with a hole
+ * (archive outage, mid-year start) degrades that month's sample instead of
+ * skewing the normal. Returns null when the seasons list is empty.
+ */
+export function computeBaseline(seasons: SeasonWeather[]): WeatherBaseline | null {
+  if (seasons.length === 0) return null
+
+  const accumulators: MonthAccumulator[] = Array.from({ length: 12 }, () => ({
+    meanTemps: [],
+    rainTotals: [],
+    sunshineTotals: [],
+  }))
+  const yearsUsed = new Set<number>()
+
+  for (const season of seasons) {
+    for (let month = 1; month <= 12; month++) {
+      const prefix = `${season.year}-${String(month).padStart(2, '0')}-`
+      const days = season.days.filter((d) => d.date.startsWith(prefix))
+      if (days.length === 0) continue
+
+      const acc = accumulators[month - 1]
+      const totalDays = daysInMonth(season.year, month)
+      let contributed = false
+
+      const temps = days
+        .map((d) => d.tempMeanC)
+        .filter((t): t is number => t !== null)
+      if (temps.length >= MIN_DAYS_FOR_MEAN) {
+        acc.meanTemps.push(temps.reduce((a, b) => a + b, 0) / temps.length)
+        contributed = true
+      }
+
+      const rain = days
+        .map((d) => d.precipitationMm)
+        .filter((r): r is number => r !== null)
+      if (rain.length >= totalDays * MIN_COVERAGE_FOR_TOTAL) {
+        acc.rainTotals.push(rain.reduce((a, b) => a + b, 0))
+        contributed = true
+      }
+
+      const sunshine = days
+        .map((d) => d.sunshineHours)
+        .filter((s): s is number => s !== null)
+      if (sunshine.length >= totalDays * MIN_COVERAGE_FOR_TOTAL) {
+        acc.sunshineTotals.push(sunshine.reduce((a, b) => a + b, 0))
+        contributed = true
+      }
+
+      if (contributed) yearsUsed.add(season.year)
+    }
+  }
+
+  const years = [...yearsUsed].sort((a, b) => a - b)
+  const seasonYears = seasons.map((s) => s.year)
+  return {
+    startYear: Math.min(...seasonYears),
+    endYear: Math.max(...seasonYears),
+    yearsUsed: years,
+    months: accumulators.map((acc, i) => ({
+      month: i + 1,
+      meanTempC: mean(acc.meanTemps),
+      totalRainfallMm: mean(acc.rainTotals),
+      sunshineHours: mean(acc.sunshineTotals),
+      yearsUsed: Math.max(acc.meanTemps.length, acc.rainTotals.length, acc.sunshineTotals.length),
+    })),
+    computedAt: new Date().toISOString(),
+  }
+}
+
+const memoryCache = new Map<string, WeatherBaseline>()
+
+function cacheKey(coords: PlotCoordinates, endYear: number): string {
+  // Rounded to ~1 km like the season cache; the exact plot location stays
+  // out of storage keys and is never part of the baseline payload.
+  const lat = coords.latitude.toFixed(2)
+  const lng = coords.longitude.toFixed(2)
+  return `${CACHE_PREFIX}${lat}_${lng}_${endYear}`
+}
+
+function readCache(key: string): WeatherBaseline | null {
+  const inMemory = memoryCache.get(key)
+  if (inMemory) return inMemory
+  if (typeof localStorage === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as WeatherBaseline
+    memoryCache.set(key, parsed)
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeCache(key: string, baseline: WeatherBaseline): void {
+  memoryCache.set(key, baseline)
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(key, JSON.stringify(baseline))
+  } catch {
+    // Quota errors are non-fatal — the memory cache still serves this session.
+  }
+}
+
+/** Internal helper: only used by tests to clear caches between runs. */
+export function _resetBaselineCacheForTests(): void {
+  memoryCache.clear()
+}
+
+/**
+ * Get the plot's 10-year baseline, computing (and caching) it from archived
+ * seasons on first call. Missing years are fetched through the season cache,
+ * so a fully-cached plot computes offline. Years that fail to fetch are
+ * skipped; the baseline is published when at least MIN_BASELINE_YEARS
+ * contributed, otherwise null — callers should degrade gracefully.
+ *
+ * The window is the BASELINE_WINDOW_YEARS completed years before the current
+ * one, so the cached baseline rolls forward automatically at new year.
+ */
+export async function getBaseline(coords: PlotCoordinates): Promise<WeatherBaseline | null> {
+  const endYear = new Date().getFullYear() - 1
+  const startYear = endYear - BASELINE_WINDOW_YEARS + 1
+
+  const key = cacheKey(coords, endYear)
+  const cached = readCache(key)
+  if (cached) return cached
+
+  const seasons: SeasonWeather[] = []
+  for (let year = startYear; year <= endYear; year++) {
+    // fetchSeasonWeather is cache-first, so already-archived years cost nothing.
+    const season = await fetchSeasonWeather(coords, year)
+    if (season) seasons.push(season)
+  }
+
+  if (seasons.length < MIN_BASELINE_YEARS) {
+    logger.warn('weather-baseline: not enough archived years to compute a baseline', {
+      yearsAvailable: seasons.length,
+      yearsNeeded: MIN_BASELINE_YEARS,
+    })
+    return null
+  }
+
+  const baseline = computeBaseline(seasons)
+  if (!baseline) return null
+  writeCache(key, baseline)
+  return baseline
+}


### PR DESCRIPTION
## Summary

The backfillable historical-weather data layer for the Season Observer (Phase 2, workstream B) — the foundation a future rules engine / end-of-season report will consume. Data layer + baseline only; no rules engine, findings, or report.

**New modules (all following the existing weather-lib conventions — fetch timeout, graceful `null` on failure, coordinate-keyed localStorage cache with in-memory fallback):**

- `src/lib/weather/open-meteo-archive.ts` — season-at-once client for the Historical Weather (Archive) API (`archive-api.open-meteo.com/v1/archive`, ERA5). One call per season fetches nine daily variables (`temperature_2m_max/min/mean`, `precipitation_sum`, `shortwave_radiation_sum`, `et0_fao_evapotranspiration`, `sunshine_duration`, `daylight_duration`, `weather_code`) plus the hourly-only soil series (`soil_temperature_0_to_7cm`, `soil_temperature_7_to_28cm`, `soil_moisture_0_to_7cm`) — all names verified against the live API. Public API: `fetchSeasonWeather(coords, year)`, `getCachedSeason(coords, year)`, exported `SeasonWeather` / `SeasonDailyRecord` types.
- `src/lib/weather/soil-daily.ts` — pure hourly→daily soil aggregation (min 12 valid readings per day; nulls skipped).
- `src/lib/weather/weather-baseline.ts` — 10-year monthly normals (mean temp, rainfall total, sunshine hours): pure `computeBaseline()` over fetched seasons with per-metric coverage thresholds (gap years degrade the sample instead of skewing it), and `getBaseline(coords)` which fetches missing years through the season cache, requires ≥5 usable years, and caches the result.

**Key decisions (documented in the module docstring):**

- **Archive API only** (ERA5) for both the baseline and the current season. The Historical Forecast API was evaluated for the in-progress season but publishes soil variables at incompatible depth layers (0/6/18cm point depths; 0–1cm/1–3cm/… moisture) vs ERA5's 0–7cm/7–28cm, which would make current-season soil metrics incomparable with the baseline. The archive's ~5-day lag is irrelevant for a retrospective season report.
- **Caching:** completed past seasons are immutable → cached forever; the current season carries a 24h TTL and is refetched whole (still one call). Hourly soil data is aggregated to daily *before* caching, so a season is ~40 KB — ten years fit comfortably in localStorage (the storage the existing weather code already uses; no second storage stack, nothing in the Yjs doc).
- **Privacy:** coordinates appear only in local cache keys (rounded to ~1 km like the existing weather cache), are never logged, and are absent from every exported type.
- **Attribution:** Open-Meteo CC BY 4.0 attribution added to `WeatherStrip` (where weather data surfaces) and the README — there was none before.

No new dependencies; Open-Meteo remains the only outbound call.

## Related issue

Part of the Season Observer plan (`docs/plans/season-observer.md`, Phase 2a — now marked shipped). Follows #467.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes (`npm run type-check`, `npm run lint`, `npm run test:unit` — 1184 passed, incl. 24 new mocked-fetch tests for soil aggregation, baseline computation with gap years, cache hit/miss, and failure paths — and `npm run build` all green)
- [x] I have updated documentation if needed (README attribution section, `docs/plans/season-observer.md` Phase 2a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6RGfSq4UvpKrZhbDTnxpd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6RGfSq4UvpKrZhbDTnxpd)_