### PR TITLE
Season Observer Phase 2A: camera-roll EXIF importer

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,23 @@
 # Current Plan
 
-Last updated: 2026-07-12 (Season Observer Phase 1 shipped — log capture + agronomy reference)
+Last updated: 2026-07-13 (Season Observer camera-roll EXIF importer shipped)
+
+## Season Observer — camera-roll photo import (shipped)
+
+Closes the last open Phase-1 acceptance criterion (retroactive season
+reconstruction from phone photos). `/log/import` reads EXIF
+(`DateTimeOriginal` + GPS) client-side with a small pure parser
+(`src/lib/photo-import/exif.ts` — no new dependency), keeps photos within
+~100m of `meta.coordinates` (haversine geofence, gracefully skipped when the
+plot has no coordinates), groups them by calendar date, and presents draft
+observations the user assigns to a bed and confirms — never auto-committed.
+Confirmed photos land as blobs in a separate plain IndexedDB store
+(`src/services/photo-store.ts`, `bwp-photos`) with the care-log observation
+referencing them via the existing `CareLogEntry.photoId` (v23). Photo
+bytes/EXIF/GPS never enter AllotmentData, so cloud sync, JSON export, share,
+and GDPR export stay free of photo location data. Vision captioning is
+deliberately deferred; `DraftObservation.suggestedCaption` + `DraftAnnotator`
+in `src/lib/photo-import/pipeline.ts` are the seam.
 
 ## Season Observer — Phase 1 (shipped)
 

--- a/docs/plans/season-observer.md
+++ b/docs/plans/season-observer.md
@@ -65,16 +65,43 @@ precedent).
 **Phase 1 acceptance status**
 - [x] Logging an observation/harvest is a 2-tap path (bed + event), rest optional.
 - [x] Works with no signal; syncs later (inherent to Yjs/IndexedDB).
-- [ ] Camera-roll importer (≥30 draft observations) — **deferred** (needs photo store).
+- [x] Camera-roll importer (≥30 draft observations) — **shipped** (see below).
 - [x] No new external service dependencies.
 
-## Deferred roadmap (with the reframing decisions)
+## Camera-roll EXIF importer (shipped)
 
-### Photos + camera-roll EXIF import
-No photo storage exists. Local-first in a PWA means IndexedDB blobs
-(`photo` records referenced by `CareLogEntry.photoId`, already wired). The EXIF
-importer (filter by ~100m of plot coords, group by date, human-confirm) is a
-self-contained follow-up. Optional local vision captioning stays human-confirmed.
+Reconstructs a season retroactively from the phone photo library. All
+client-side and local-only:
+
+- `src/lib/photo-import/exif.ts` — small pure JPEG/EXIF parser
+  (DateTimeOriginal + GPS DMS→decimal), no new dependency; tested against
+  synthesised EXIF byte fixtures, both endians. HEIC is out of scope
+  (surfaced to the user as "no readable date").
+- `src/lib/photo-import/geofence.ts` — haversine distance + ~100m plot
+  geofence over `meta.coordinates`; skipped with clear messaging when the
+  plot has no coordinates.
+- `src/lib/photo-import/pipeline.ts` — pure parse → geofence → group-by-date
+  → draft pipeline. Drafts are never auto-committed; unconfirmed drafts are
+  discarded. `DraftObservation.suggestedCaption` + the `DraftAnnotator`
+  interface are the deliberate seam for future local vision captioning
+  (unused in v1).
+- `src/services/photo-store.ts` — separate plain-IndexedDB blob store
+  (`bwp-photos`). Blobs stay out of the Yjs doc; only `CareLogEntry.photoId`
+  (already in v23) lives in the CRDT, so export/share/GDPR/cloud-sync
+  payloads never carry photo EXIF or GPS.
+- `/log/import` (`src/app/log/import/page.tsx`) — review UI linked from
+  Quick Log: pick photos → per-date draft groups with thumbnails →
+  include/exclude per photo, optional note, assign a bed → confirm writes
+  the blob then the observation care-log entry through the existing
+  `addCareLog` write path. Groups outside the active season are blocked
+  from import (same misfiling guard as /log).
+
+Acceptance test: `src/__tests__/lib/photo-import/pipeline.test.ts` runs 38
+synthesised photos end-to-end (real EXIF byte parsing) and asserts 30 drafts
+in 10 correctly-ordered date groups with camera-roll noise excluded for the
+right reasons.
+
+## Deferred roadmap (with the reframing decisions)
 
 ### Weather backfill (Phase 2a)
 Add an **Archive API** client (`archive-api.open-meteo.com`) for one-call

--- a/src/__tests__/lib/photo-import/exif-fixture.ts
+++ b/src/__tests__/lib/photo-import/exif-fixture.ts
@@ -1,0 +1,182 @@
+/**
+ * Synthesised JPEG/EXIF byte fixtures for the photo-import tests.
+ *
+ * Builds a minimal but structurally valid JPEG containing an APP1 Exif
+ * segment (TIFF header, IFD0 with Exif/GPS sub-IFD pointers,
+ * DateTimeOriginal, GPS DMS rationals) so the parser is exercised against
+ * real byte layouts — no real photos, no binary files in the repo.
+ */
+
+export interface ExifFixtureOptions {
+  /** EXIF-format timestamp, e.g. "2026:04:12 09:30:00". */
+  dateTimeOriginal?: string
+  /** Decimal degrees; sign selects the N/S / E/W ref. */
+  latitude?: number
+  longitude?: number
+  /** TIFF byte order. Defaults to little-endian ("II"). */
+  littleEndian?: boolean
+}
+
+const RATIONAL_DEN = 1_000_000
+
+/** Decimal degrees -> [deg, min, sec] as [num, den] rational pairs. */
+function toDmsRationals(decimal: number): Array<[number, number]> {
+  const abs = Math.abs(decimal)
+  const deg = Math.floor(abs)
+  const minFloat = (abs - deg) * 60
+  const min = Math.floor(minFloat)
+  const sec = (minFloat - min) * 60
+  return [
+    [deg, 1],
+    [min, 1],
+    [Math.round(sec * RATIONAL_DEN), RATIONAL_DEN],
+  ]
+}
+
+/** Build the TIFF block (starts with the byte-order mark). */
+function buildTiff(options: ExifFixtureOptions): Uint8Array {
+  const little = options.littleEndian ?? true
+  const hasDate = options.dateTimeOriginal !== undefined
+  const hasGps = options.latitude !== undefined && options.longitude !== undefined
+
+  const ifd0EntryCount = (hasDate ? 1 : 0) + (hasGps ? 1 : 0)
+  const HEADER = 8
+  const ifd0Start = HEADER
+  const ifd0Size = 2 + ifd0EntryCount * 12 + 4
+  const exifIfdStart = ifd0Start + ifd0Size
+  const exifIfdSize = hasDate ? 2 + 1 * 12 + 4 : 0
+  const dtDataStart = exifIfdStart + exifIfdSize
+  const dtDataSize = hasDate ? 20 : 0
+  const gpsIfdStart = dtDataStart + dtDataSize
+  const gpsIfdSize = hasGps ? 2 + 4 * 12 + 4 : 0
+  const latDataStart = gpsIfdStart + gpsIfdSize
+  const lonDataStart = latDataStart + (hasGps ? 24 : 0)
+  const total = lonDataStart + (hasGps ? 24 : 0)
+
+  const bytes = new Uint8Array(total)
+  const view = new DataView(bytes.buffer)
+  const u16 = (at: number, v: number) => view.setUint16(at, v, little)
+  const u32 = (at: number, v: number) => view.setUint32(at, v, little)
+  const ascii = (at: number, s: string) => {
+    for (let i = 0; i < s.length; i++) bytes[at + i] = s.charCodeAt(i)
+  }
+
+  // TIFF header
+  ascii(0, little ? 'II' : 'MM')
+  u16(2, 0x002a)
+  u32(4, ifd0Start)
+
+  // IFD0
+  u16(ifd0Start, ifd0EntryCount)
+  let entryAt = ifd0Start + 2
+  if (hasDate) {
+    u16(entryAt, 0x8769) // ExifIFDPointer
+    u16(entryAt + 2, 4) // LONG
+    u32(entryAt + 4, 1)
+    u32(entryAt + 8, exifIfdStart)
+    entryAt += 12
+  }
+  if (hasGps) {
+    u16(entryAt, 0x8825) // GPSIFDPointer
+    u16(entryAt + 2, 4)
+    u32(entryAt + 4, 1)
+    u32(entryAt + 8, gpsIfdStart)
+    entryAt += 12
+  }
+  u32(entryAt, 0) // next IFD
+
+  // Exif IFD: one entry, DateTimeOriginal (ASCII, 20 bytes incl. NUL)
+  if (hasDate) {
+    u16(exifIfdStart, 1)
+    const at = exifIfdStart + 2
+    u16(at, 0x9003)
+    u16(at + 2, 2) // ASCII
+    u32(at + 4, 20)
+    u32(at + 8, dtDataStart)
+    u32(at + 12, 0) // next IFD
+    ascii(dtDataStart, options.dateTimeOriginal!.slice(0, 19))
+    bytes[dtDataStart + 19] = 0
+  }
+
+  // GPS IFD: LatRef, Lat, LonRef, Lon
+  if (hasGps) {
+    const latRef = options.latitude! < 0 ? 'S' : 'N'
+    const lonRef = options.longitude! < 0 ? 'W' : 'E'
+    u16(gpsIfdStart, 4)
+    let at = gpsIfdStart + 2
+
+    // 0x0001 GPSLatitudeRef — ASCII count 2, inline value
+    u16(at, 0x0001)
+    u16(at + 2, 2)
+    u32(at + 4, 2)
+    ascii(at + 8, latRef)
+    bytes[at + 9] = 0
+    at += 12
+
+    // 0x0002 GPSLatitude — 3 RATIONALs at latDataStart
+    u16(at, 0x0002)
+    u16(at + 2, 5)
+    u32(at + 4, 3)
+    u32(at + 8, latDataStart)
+    at += 12
+
+    // 0x0003 GPSLongitudeRef
+    u16(at, 0x0003)
+    u16(at + 2, 2)
+    u32(at + 4, 2)
+    ascii(at + 8, lonRef)
+    bytes[at + 9] = 0
+    at += 12
+
+    // 0x0004 GPSLongitude
+    u16(at, 0x0004)
+    u16(at + 2, 5)
+    u32(at + 4, 3)
+    u32(at + 8, lonDataStart)
+    at += 12
+
+    u32(at, 0) // next IFD
+
+    const writeRationals = (start: number, rats: Array<[number, number]>) => {
+      rats.forEach(([num, den], i) => {
+        u32(start + i * 8, num)
+        u32(start + i * 8 + 4, den)
+      })
+    }
+    writeRationals(latDataStart, toDmsRationals(options.latitude!))
+    writeRationals(lonDataStart, toDmsRationals(options.longitude!))
+  }
+
+  return bytes
+}
+
+/** Wrap a TIFF block in SOI + APP1("Exif\0\0") + EOI. */
+export function buildJpegWithExif(options: ExifFixtureOptions = {}): ArrayBuffer {
+  const tiff = buildTiff(options)
+  const app1PayloadLen = 2 + 6 + tiff.length // length field itself + "Exif\0\0" + tiff
+  const total = 2 + 2 + app1PayloadLen + 2 // SOI + APP1 marker + payload + EOI
+  const bytes = new Uint8Array(total)
+  const view = new DataView(bytes.buffer)
+
+  let at = 0
+  view.setUint16(at, 0xffd8) // SOI
+  at += 2
+  view.setUint16(at, 0xffe1) // APP1 marker
+  at += 2
+  view.setUint16(at, app1PayloadLen) // segment length (big-endian, always)
+  at += 2
+  for (const c of 'Exif') bytes[at++] = c.charCodeAt(0)
+  bytes[at++] = 0
+  bytes[at++] = 0
+  bytes.set(tiff, at)
+  at += tiff.length
+  view.setUint16(at, 0xffd9) // EOI
+
+  return bytes.buffer
+}
+
+/** A JPEG with no APP1/EXIF segment at all. */
+export function buildJpegWithoutExif(): ArrayBuffer {
+  const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xd9])
+  return bytes.buffer
+}

--- a/src/__tests__/lib/photo-import/exif.test.ts
+++ b/src/__tests__/lib/photo-import/exif.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { parseExif, exifDateToIso } from '@/lib/photo-import/exif'
+import { buildJpegWithExif, buildJpegWithoutExif } from './exif-fixture'
+
+// Real-world-ish plot coordinates (Edinburgh allotment).
+const LAT = 55.9533
+const LON = -3.1883
+
+describe('exifDateToIso', () => {
+  it('converts EXIF timestamps to naive ISO', () => {
+    expect(exifDateToIso('2026:04:12 09:30:00')).toBe('2026-04-12T09:30:00')
+  })
+
+  it('rejects malformed values', () => {
+    expect(exifDateToIso('')).toBeUndefined()
+    expect(exifDateToIso('not a date')).toBeUndefined()
+    expect(exifDateToIso('2026-04-12 09:30:00')).toBeUndefined() // wrong separator
+    expect(exifDateToIso('2026:13:12 09:30:00')).toBeUndefined() // month 13
+    expect(exifDateToIso('2026:04:12 25:30:00')).toBeUndefined() // hour 25
+  })
+})
+
+describe('parseExif', () => {
+  it('reads DateTimeOriginal and GPS from a little-endian EXIF block', () => {
+    const buffer = buildJpegWithExif({
+      dateTimeOriginal: '2026:04:12 09:30:00',
+      latitude: LAT,
+      longitude: LON,
+      littleEndian: true,
+    })
+    const result = parseExif(buffer)
+    expect(result.takenAt).toBe('2026-04-12T09:30:00')
+    expect(result.latitude).toBeCloseTo(LAT, 5)
+    expect(result.longitude).toBeCloseTo(LON, 5)
+  })
+
+  it('reads big-endian ("MM") EXIF blocks too', () => {
+    const buffer = buildJpegWithExif({
+      dateTimeOriginal: '2026:07:01 18:05:59',
+      latitude: LAT,
+      longitude: LON,
+      littleEndian: false,
+    })
+    const result = parseExif(buffer)
+    expect(result.takenAt).toBe('2026-07-01T18:05:59')
+    expect(result.latitude).toBeCloseTo(LAT, 5)
+    expect(result.longitude).toBeCloseTo(LON, 5)
+  })
+
+  it('applies hemisphere refs: south and west are negative, north and east positive', () => {
+    const southWest = parseExif(
+      buildJpegWithExif({ latitude: -33.8688, longitude: -70.6693 })
+    )
+    expect(southWest.latitude).toBeCloseTo(-33.8688, 5)
+    expect(southWest.longitude).toBeCloseTo(-70.6693, 5)
+
+    const northEast = parseExif(
+      buildJpegWithExif({ latitude: 55.9533, longitude: 12.5683 })
+    )
+    expect(northEast.latitude).toBeCloseTo(55.9533, 5)
+    expect(northEast.longitude).toBeCloseTo(12.5683, 5)
+  })
+
+  it('returns date without GPS when GPS is absent', () => {
+    const result = parseExif(buildJpegWithExif({ dateTimeOriginal: '2026:01:15 11:00:00' }))
+    expect(result.takenAt).toBe('2026-01-15T11:00:00')
+    expect(result.latitude).toBeUndefined()
+    expect(result.longitude).toBeUndefined()
+  })
+
+  it('returns GPS without date when DateTimeOriginal is absent', () => {
+    const result = parseExif(buildJpegWithExif({ latitude: LAT, longitude: LON }))
+    expect(result.takenAt).toBeUndefined()
+    expect(result.latitude).toBeCloseTo(LAT, 5)
+  })
+
+  it('returns empty for a JPEG with no EXIF segment', () => {
+    expect(parseExif(buildJpegWithoutExif())).toEqual({})
+  })
+
+  it('returns empty for non-JPEG data', () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0])
+    expect(parseExif(png.buffer)).toEqual({})
+    expect(parseExif(new ArrayBuffer(0))).toEqual({})
+  })
+
+  it('survives truncated EXIF data without throwing', () => {
+    const full = new Uint8Array(
+      buildJpegWithExif({ dateTimeOriginal: '2026:04:12 09:30:00', latitude: LAT, longitude: LON })
+    )
+    // Chop the buffer at various points — parser must never throw.
+    for (const len of [3, 8, 20, 40, full.length - 10]) {
+      const truncated = full.slice(0, len)
+      expect(() => parseExif(truncated.buffer)).not.toThrow()
+    }
+  })
+
+  it('ignores a malformed EXIF date but still reads GPS', () => {
+    const result = parseExif(
+      buildJpegWithExif({ dateTimeOriginal: 'garbage garbage abc', latitude: LAT, longitude: LON })
+    )
+    expect(result.takenAt).toBeUndefined()
+    expect(result.latitude).toBeCloseTo(LAT, 5)
+  })
+})

--- a/src/__tests__/lib/photo-import/exif.test.ts
+++ b/src/__tests__/lib/photo-import/exif.test.ts
@@ -18,6 +18,14 @@ describe('exifDateToIso', () => {
     expect(exifDateToIso('2026:13:12 09:30:00')).toBeUndefined() // month 13
     expect(exifDateToIso('2026:04:12 25:30:00')).toBeUndefined() // hour 25
   })
+
+  it('rejects impossible calendar dates instead of letting them roll over', () => {
+    expect(exifDateToIso('2026:02:31 10:00:00')).toBeUndefined() // Feb 31 (would roll to Mar 3)
+    expect(exifDateToIso('2026:04:31 10:00:00')).toBeUndefined() // April has 30 days
+    expect(exifDateToIso('2026:02:29 10:00:00')).toBeUndefined() // 2026 is not a leap year
+    expect(exifDateToIso('2026:06:00 10:00:00')).toBeUndefined() // day 0
+    expect(exifDateToIso('2024:02:29 10:00:00')).toBe('2024-02-29T10:00:00') // real leap day
+  })
 })
 
 describe('parseExif', () => {

--- a/src/__tests__/lib/photo-import/geofence.test.ts
+++ b/src/__tests__/lib/photo-import/geofence.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  haversineDistanceMeters,
+  isWithinGeofence,
+  DEFAULT_GEOFENCE_RADIUS_METERS,
+} from '@/lib/photo-import/geofence'
+
+const PLOT = { latitude: 55.9533, longitude: -3.1883 } // Edinburgh
+
+/**
+ * A point exactly `meters` due north of `origin`. For a pure latitude
+ * offset the haversine distance is exactly R * dLat, so this constructs
+ * boundary cases without circular reasoning about longitude scaling.
+ */
+const EARTH_RADIUS_METERS = 6371008.8
+function metersNorth(origin: typeof PLOT, meters: number) {
+  const dLatDeg = (meters / EARTH_RADIUS_METERS) * (180 / Math.PI)
+  return { latitude: origin.latitude + dLatDeg, longitude: origin.longitude }
+}
+
+describe('haversineDistanceMeters', () => {
+  it('is zero for identical points', () => {
+    expect(haversineDistanceMeters(PLOT, PLOT)).toBe(0)
+  })
+
+  it('is symmetric', () => {
+    const other = { latitude: 55.96, longitude: -3.2 }
+    expect(haversineDistanceMeters(PLOT, other)).toBeCloseTo(
+      haversineDistanceMeters(other, PLOT),
+      9
+    )
+  })
+
+  it('matches the known scale of one degree of latitude (~111.2km)', () => {
+    const oneDegNorth = { latitude: PLOT.latitude + 1, longitude: PLOT.longitude }
+    const distance = haversineDistanceMeters(PLOT, oneDegNorth)
+    expect(distance).toBeGreaterThan(111_000)
+    expect(distance).toBeLessThan(111_400)
+  })
+
+  it('measures Edinburgh to Glasgow at roughly 67km', () => {
+    const glasgow = { latitude: 55.8642, longitude: -4.2518 }
+    const distance = haversineDistanceMeters(PLOT, glasgow)
+    expect(distance).toBeGreaterThan(60_000)
+    expect(distance).toBeLessThan(75_000)
+  })
+
+  it('handles points across the antimeridian without blowing up', () => {
+    const a = { latitude: 0, longitude: 179.9995 }
+    const b = { latitude: 0, longitude: -179.9995 }
+    // 0.001 deg of longitude at the equator ≈ 111.2m, not ~40,000km.
+    expect(haversineDistanceMeters(a, b)).toBeLessThan(200)
+  })
+})
+
+describe('isWithinGeofence (100m default)', () => {
+  it('accepts a photo 99m from the plot', () => {
+    expect(isWithinGeofence(metersNorth(PLOT, 99), PLOT)).toBe(true)
+  })
+
+  it('rejects a photo 101m from the plot', () => {
+    expect(isWithinGeofence(metersNorth(PLOT, 101), PLOT)).toBe(false)
+  })
+
+  it('is boundary-inclusive at exactly 100m', () => {
+    const boundary = metersNorth(PLOT, DEFAULT_GEOFENCE_RADIUS_METERS)
+    expect(haversineDistanceMeters(boundary, PLOT)).toBeCloseTo(100, 6)
+    expect(isWithinGeofence(boundary, PLOT)).toBe(true)
+  })
+
+  it('accepts the plot itself', () => {
+    expect(isWithinGeofence(PLOT, PLOT)).toBe(true)
+  })
+
+  it('honours a custom radius', () => {
+    const at250 = metersNorth(PLOT, 250)
+    expect(isWithinGeofence(at250, PLOT, 300)).toBe(true)
+    expect(isWithinGeofence(at250, PLOT, 200)).toBe(false)
+  })
+})

--- a/src/__tests__/lib/photo-import/pipeline.test.ts
+++ b/src/__tests__/lib/photo-import/pipeline.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest'
+import { parseExif } from '@/lib/photo-import/exif'
+import {
+  buildDraftObservations,
+  type PhotoMetaRecord,
+} from '@/lib/photo-import/pipeline'
+import { buildJpegWithExif } from './exif-fixture'
+
+const PLOT = { latitude: 55.9533, longitude: -3.1883 }
+const EARTH_RADIUS_METERS = 6371008.8
+
+/** Latitude offset in degrees for a due-north distance in metres. */
+function latOffset(meters: number): number {
+  return (meters / EARTH_RADIUS_METERS) * (180 / Math.PI)
+}
+
+let seq = 0
+function record(overrides: Partial<PhotoMetaRecord> = {}): PhotoMetaRecord {
+  seq++
+  return {
+    id: `photo-${seq}`,
+    fileName: `IMG_${String(seq).padStart(4, '0')}.jpg`,
+    takenAt: '2026-04-12T09:30:00',
+    latitude: PLOT.latitude,
+    longitude: PLOT.longitude,
+    ...overrides,
+  }
+}
+
+describe('buildDraftObservations — date grouping', () => {
+  it('groups drafts by calendar date, oldest date first, time-ordered within a day', () => {
+    const records = [
+      record({ takenAt: '2026-05-02T17:00:00' }),
+      record({ takenAt: '2026-05-01T09:00:00' }),
+      record({ takenAt: '2026-05-02T08:00:00' }),
+      record({ takenAt: '2026-05-01T12:30:00' }),
+    ]
+    const result = buildDraftObservations(records, { plotCoordinates: PLOT })
+
+    expect(result.groups.map(g => g.date)).toEqual(['2026-05-01', '2026-05-02'])
+    expect(result.groups[0].drafts.map(d => d.takenAt)).toEqual([
+      '2026-05-01T09:00:00',
+      '2026-05-01T12:30:00',
+    ])
+    expect(result.groups[1].drafts.map(d => d.takenAt)).toEqual([
+      '2026-05-02T08:00:00',
+      '2026-05-02T17:00:00',
+    ])
+    expect(result.draftCount).toBe(4)
+    expect(result.excluded).toEqual([])
+  })
+
+  it('excludes photos without a timestamp — a reconstruction never guesses dates', () => {
+    const dated = record()
+    const undated = record({ takenAt: undefined })
+    const result = buildDraftObservations([dated, undated], { plotCoordinates: PLOT })
+    expect(result.draftCount).toBe(1)
+    expect(result.excluded).toEqual([{ record: undated, reason: 'no-date' }])
+  })
+})
+
+describe('buildDraftObservations — geofence', () => {
+  it('keeps 99m, drops 101m, drops missing-GPS when plot coordinates are set', () => {
+    const inside = record({ latitude: PLOT.latitude + latOffset(99) })
+    const outside = record({ latitude: PLOT.latitude + latOffset(101) })
+    const noGps = record({ latitude: undefined, longitude: undefined })
+
+    const result = buildDraftObservations([inside, outside, noGps], {
+      plotCoordinates: PLOT,
+    })
+
+    expect(result.geofenceApplied).toBe(true)
+    expect(result.draftCount).toBe(1)
+    expect(result.groups[0].drafts[0].photoId).toBe(inside.id)
+    expect(result.excluded).toEqual([
+      { record: outside, reason: 'outside-geofence' },
+      { record: noGps, reason: 'no-gps' },
+    ])
+  })
+
+  it('skips the geofence gracefully when plot coordinates are missing', () => {
+    const farAway = record({ latitude: 40.4168, longitude: -3.7038 }) // Madrid
+    const noGps = record({ latitude: undefined, longitude: undefined })
+
+    const result = buildDraftObservations([farAway, noGps], {})
+
+    expect(result.geofenceApplied).toBe(false)
+    // Without a plot to measure from, all dated photos pass — the UI warns
+    // the user and lets them deselect strays.
+    expect(result.draftCount).toBe(2)
+    expect(result.excluded).toEqual([])
+  })
+
+  it('honours a custom radius', () => {
+    const at150 = record({ latitude: PLOT.latitude + latOffset(150) })
+    const wide = buildDraftObservations([at150], { plotCoordinates: PLOT, radiusMeters: 200 })
+    const tight = buildDraftObservations([at150], { plotCoordinates: PLOT, radiusMeters: 100 })
+    expect(wide.draftCount).toBe(1)
+    expect(tight.draftCount).toBe(0)
+  })
+})
+
+describe('acceptance — season reconstruction from a 30+ photo camera roll', () => {
+  it('feeds 38 photos through parse → geofence → group → draft and yields 30+ drafts grouped correctly', () => {
+    // A believable Jan–Jul 2026 season: 10 plot visits, 3 photos each,
+    // all geotagged within 100m of the plot (spread up to ~80m from it).
+    const visitDates = [
+      '2026:01:18', '2026:02:07', '2026:03:01', '2026:03:22', '2026:04:12',
+      '2026:05:03', '2026:05:24', '2026:06:14', '2026:06:28', '2026:07:12',
+    ]
+    const files: Array<{ name: string; buffer: ArrayBuffer }> = []
+    let n = 0
+    for (const date of visitDates) {
+      for (let shot = 0; shot < 3; shot++) {
+        n++
+        files.push({
+          name: `IMG_${String(n).padStart(4, '0')}.jpg`,
+          buffer: buildJpegWithExif({
+            dateTimeOriginal: `${date} ${String(9 + shot * 2).padStart(2, '0')}:15:00`,
+            latitude: PLOT.latitude + latOffset(shot * 40), // 0m, 40m, 80m north
+            longitude: PLOT.longitude,
+            littleEndian: n % 2 === 0, // exercise both byte orders
+          }),
+        })
+      }
+    }
+    // Camera-roll noise that must be filtered out, not imported:
+    files.push({
+      name: 'holiday.jpg', // 5km away
+      buffer: buildJpegWithExif({
+        dateTimeOriginal: '2026:06:20 14:00:00',
+        latitude: PLOT.latitude + latOffset(5000),
+        longitude: PLOT.longitude,
+      }),
+    })
+    files.push({
+      name: 'screenshot.jpg', // no GPS
+      buffer: buildJpegWithExif({ dateTimeOriginal: '2026:03:15 20:00:00' }),
+    })
+    files.push({
+      name: 'no-exif.jpg', // no metadata at all
+      buffer: buildJpegWithExif({}),
+    })
+    ;[...Array(5)].forEach((_, i) => {
+      files.push({
+        name: `walk-${i}.jpg`, // 101m — just outside the fence
+        buffer: buildJpegWithExif({
+          dateTimeOriginal: '2026:04:12 19:00:00',
+          latitude: PLOT.latitude + latOffset(101),
+          longitude: PLOT.longitude,
+        }),
+      })
+    })
+
+    expect(files.length).toBeGreaterThanOrEqual(30)
+
+    // parse (real EXIF byte parsing) → metadata records
+    const records: PhotoMetaRecord[] = files.map((file, i) => {
+      const exif = parseExif(file.buffer)
+      const rec: PhotoMetaRecord = { id: `p${i}`, fileName: file.name }
+      if (exif.takenAt) rec.takenAt = exif.takenAt
+      if (exif.latitude !== undefined) rec.latitude = exif.latitude
+      if (exif.longitude !== undefined) rec.longitude = exif.longitude
+      return rec
+    })
+
+    // geofence → group → draft
+    const result = buildDraftObservations(records, { plotCoordinates: PLOT })
+
+    // ≥30 draft observations out, one per genuine plot photo.
+    expect(result.draftCount).toBeGreaterThanOrEqual(30)
+    expect(result.draftCount).toBe(30)
+
+    // Grouped correctly: one group per visit date, 3 drafts each, sorted.
+    expect(result.groups).toHaveLength(10)
+    expect(result.groups.map(g => g.date)).toEqual([
+      '2026-01-18', '2026-02-07', '2026-03-01', '2026-03-22', '2026-04-12',
+      '2026-05-03', '2026-05-24', '2026-06-14', '2026-06-28', '2026-07-12',
+    ])
+    for (const group of result.groups) {
+      expect(group.drafts).toHaveLength(3)
+      const times = group.drafts.map(d => d.takenAt)
+      expect(times).toEqual([...times].sort())
+      for (const draft of group.drafts) {
+        expect(draft.date).toBe(group.date)
+        expect(draft.takenAt.slice(0, 10)).toBe(group.date)
+      }
+    }
+
+    // The noise was excluded for the right reasons.
+    const reasons = result.excluded.map(e => e.reason)
+    expect(reasons.filter(r => r === 'outside-geofence')).toHaveLength(6) // holiday + 5 walk shots
+    expect(reasons.filter(r => r === 'no-gps')).toHaveLength(1)
+    expect(reasons.filter(r => r === 'no-date')).toHaveLength(1)
+
+    // Drafts are drafts: nothing here persisted anything (pure function),
+    // and every draft still needs a human to assign a bed and confirm.
+    for (const group of result.groups) {
+      for (const draft of group.drafts) {
+        expect(draft.suggestedCaption).toBeUndefined() // vision seam unused in v1
+      }
+    }
+  })
+})

--- a/src/__tests__/services/photo-store.test.ts
+++ b/src/__tests__/services/photo-store.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Photo blob store tests. fake-indexeddb (installed in setup.ts) provides
+ * the IndexedDB implementation; blobs are plain jsdom Blobs.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  putPhoto,
+  getPhoto,
+  deletePhoto,
+  listPhotos,
+  createPhotoUrl,
+  revokePhotoUrl,
+  type StoredPhoto,
+} from '@/services/photo-store'
+
+function makePhoto(id: string, overrides: Partial<StoredPhoto> = {}): StoredPhoto {
+  return {
+    id,
+    blob: new Blob(['fake-jpeg-bytes'], { type: 'image/jpeg' }),
+    takenAt: '2026-04-12T09:30:00',
+    latitude: 55.9533,
+    longitude: -3.1883,
+    bedId: 'bed-a',
+    exifJson: JSON.stringify({ takenAt: '2026-04-12T09:30:00' }),
+    ...overrides,
+  }
+}
+
+describe('photo-store', () => {
+  beforeEach(async () => {
+    // Isolate tests: drop every record left by the previous test.
+    const photos = await listPhotos()
+    await Promise.all(photos.map(p => deletePhoto(p.id)))
+  })
+
+  it('round-trips a photo record through put/get', async () => {
+    const photo = makePhoto('photo-1')
+    await putPhoto(photo)
+
+    const loaded = await getPhoto('photo-1')
+    expect(loaded).not.toBeNull()
+    expect(loaded!.id).toBe('photo-1')
+    expect(loaded!.takenAt).toBe('2026-04-12T09:30:00')
+    expect(loaded!.latitude).toBeCloseTo(55.9533, 4)
+    expect(loaded!.bedId).toBe('bed-a')
+    expect(loaded!.exifJson).toBe(photo.exifJson)
+    // Blob fidelity can't be asserted here: fake-indexeddb's structured
+    // clone doesn't preserve jsdom Blobs (real browser IndexedDB stores
+    // Blobs natively). We can only assert the property survives the trip.
+    expect(loaded!.blob).toBeDefined()
+  })
+
+  it('returns null for an unknown id', async () => {
+    expect(await getPhoto('nope')).toBeNull()
+  })
+
+  it('overwrites on put with the same id', async () => {
+    await putPhoto(makePhoto('photo-1', { bedId: 'bed-a' }))
+    await putPhoto(makePhoto('photo-1', { bedId: 'bed-b' }))
+    const loaded = await getPhoto('photo-1')
+    expect(loaded!.bedId).toBe('bed-b')
+    expect(await listPhotos()).toHaveLength(1)
+  })
+
+  it('lists metadata without the blob payload', async () => {
+    await putPhoto(makePhoto('photo-1'))
+    await putPhoto(makePhoto('photo-2', { takenAt: '2026-05-01T10:00:00' }))
+
+    const list = await listPhotos()
+    expect(list).toHaveLength(2)
+    expect(list.map(p => p.id).sort()).toEqual(['photo-1', 'photo-2'])
+    for (const meta of list) {
+      expect(meta).not.toHaveProperty('blob')
+      expect(meta.takenAt).toBeDefined()
+    }
+  })
+
+  it('deletes idempotently', async () => {
+    await putPhoto(makePhoto('photo-1'))
+    await deletePhoto('photo-1')
+    expect(await getPhoto('photo-1')).toBeNull()
+    await expect(deletePhoto('photo-1')).resolves.toBeUndefined()
+  })
+
+  describe('object URLs', () => {
+    // jsdom has no URL.createObjectURL — stub the boundary.
+    const created: string[] = []
+    beforeEach(() => {
+      created.length = 0
+      vi.stubGlobal('URL', {
+        ...URL,
+        createObjectURL: vi.fn((blob: Blob) => {
+          const url = `blob:mock-${created.length}-${blob.size}`
+          created.push(url)
+          return url
+        }),
+        revokeObjectURL: vi.fn(),
+      })
+    })
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('creates a renderable URL for a stored photo and revokes it', async () => {
+      await putPhoto(makePhoto('photo-1'))
+      const url = await createPhotoUrl('photo-1')
+      expect(url).toBe(created[0])
+
+      revokePhotoUrl(url!)
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith(url)
+    })
+
+    it('returns null for a missing photo instead of minting a URL', async () => {
+      expect(await createPhotoUrl('missing')).toBeNull()
+      expect(URL.createObjectURL).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/__tests__/services/photo-store.test.ts
+++ b/src/__tests__/services/photo-store.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import {
   putPhoto,
+  putPhotos,
   getPhoto,
   deletePhoto,
   listPhotos,
@@ -80,6 +81,39 @@ describe('photo-store', () => {
     await deletePhoto('photo-1')
     expect(await getPhoto('photo-1')).toBeNull()
     await expect(deletePhoto('photo-1')).resolves.toBeUndefined()
+  })
+
+  describe('putPhotos (batch)', () => {
+    it('stores a whole batch in one call and every record is durable after resolve', async () => {
+      await putPhotos([makePhoto('batch-1'), makePhoto('batch-2'), makePhoto('batch-3')])
+
+      // The promise resolved on tx.oncomplete, so a fresh transaction must
+      // already see every record — no post-hoc flushing.
+      const list = await listPhotos()
+      expect(list.map(p => p.id).sort()).toEqual(['batch-1', 'batch-2', 'batch-3'])
+      expect(await getPhoto('batch-2')).not.toBeNull()
+    })
+
+    it('is a no-op for an empty batch', async () => {
+      await expect(putPhotos([])).resolves.toBeUndefined()
+      expect(await listPhotos()).toHaveLength(0)
+    })
+
+    it('rejects (and persists nothing) when a record in the batch is invalid', async () => {
+      // keyPath is 'id'; a record without one makes the put throw, which
+      // must surface as a rejection — not a silent success on request
+      // callbacks that never fire.
+      const invalid = { ...makePhoto('will-not-matter') } as Partial<StoredPhoto>
+      delete invalid.id
+      await expect(
+        putPhotos([makePhoto('batch-ok'), invalid as StoredPhoto])
+      ).rejects.toBeTruthy()
+      // All-or-nothing: the transaction was aborted, so the valid sibling
+      // that was queued before the failure must not have been committed.
+      expect(await getPhoto('batch-ok')).toBeNull()
+      expect(await getPhoto('will-not-matter')).toBeNull()
+      expect(await listPhotos()).toHaveLength(0)
+    })
   })
 
   describe('object URLs', () => {

--- a/src/app/log/import/page.tsx
+++ b/src/app/log/import/page.tsx
@@ -38,7 +38,7 @@ import {
   type DraftPipelineResult,
   type PhotoMetaRecord,
 } from '@/lib/photo-import/pipeline'
-import { putPhoto } from '@/services/photo-store'
+import { putPhotos, type StoredPhoto } from '@/services/photo-store'
 import type { Area, NewCareLogEntry } from '@/types/unified-allotment'
 
 const EXCLUSION_LABELS: Record<string, string> = {
@@ -70,6 +70,13 @@ export default function PhotoImportPage() {
   const filesRef = useRef<Map<string, File>>(new Map())
   const previewUrlsRef = useRef<Map<string, string>>(new Map())
   const [, setPreviewVersion] = useState(0)
+  // Drafts whose care-log entry has actually been written. If a save fails
+  // partway, the confirm button stays active for retry — and a retry must
+  // only process the genuinely unsaved remainder, because addCareLog
+  // appends: re-running an already-saved draft would duplicate its
+  // observation entry. (putPhotos is an idempotent overwrite by id, so
+  // photos don't have this problem.)
+  const savedPhotoIdsRef = useRef<Set<string>>(new Set())
 
   const plotCoordinates = data?.meta.coordinates
 
@@ -109,24 +116,38 @@ export default function PhotoImportPage() {
     setBedByDate({})
     revokeAllPreviews()
     filesRef.current.clear()
+    savedPhotoIdsRef.current.clear()
 
+    // Parse in parallel, but in modest chunks: each in-flight file holds its
+    // full ArrayBuffer until parsed, so unbounded Promise.all over a
+    // multi-hundred-photo camera roll would balloon memory. Eight at a time
+    // keeps the I/O pipelined without that risk; chunk results are appended
+    // in order so record order stays stable.
+    const PARSE_CONCURRENCY = 8
+    const files = Array.from(fileList)
     const records: PhotoMetaRecord[] = []
-    for (const file of Array.from(fileList)) {
-      const id = generateId('photo')
-      let exif: ReturnType<typeof parseExif> = {}
-      try {
-        exif = parseExif(await file.arrayBuffer())
-      } catch {
-        // Unreadable file — fall through with empty EXIF; the pipeline
-        // will report it as excluded rather than aborting the import.
-      }
-      filesRef.current.set(id, file)
-      previewUrlsRef.current.set(id, URL.createObjectURL(file))
-      const record: PhotoMetaRecord = { id, fileName: file.name }
-      if (exif.takenAt) record.takenAt = exif.takenAt
-      if (exif.latitude !== undefined) record.latitude = exif.latitude
-      if (exif.longitude !== undefined) record.longitude = exif.longitude
-      records.push(record)
+    for (let i = 0; i < files.length; i += PARSE_CONCURRENCY) {
+      const chunk = files.slice(i, i + PARSE_CONCURRENCY)
+      const parsed = await Promise.all(
+        chunk.map(async file => {
+          const id = generateId('photo')
+          let exif: ReturnType<typeof parseExif> = {}
+          try {
+            exif = parseExif(await file.arrayBuffer())
+          } catch {
+            // Unreadable file — fall through with empty EXIF; the pipeline
+            // will report it as excluded rather than aborting the import.
+          }
+          filesRef.current.set(id, file)
+          previewUrlsRef.current.set(id, URL.createObjectURL(file))
+          const record: PhotoMetaRecord = { id, fileName: file.name }
+          if (exif.takenAt) record.takenAt = exif.takenAt
+          if (exif.latitude !== undefined) record.latitude = exif.latitude
+          if (exif.longitude !== undefined) record.longitude = exif.longitude
+          return record
+        })
+      )
+      records.push(...parsed)
     }
 
     const pipelineResult = buildDraftObservations(records, {
@@ -143,28 +164,45 @@ export default function PhotoImportPage() {
     setSavingDate(group.date)
     setSaveError(null)
 
-    let saved = 0
+    // Only the drafts the user kept, minus anything a previous (partially
+    // failed) attempt already saved — see savedPhotoIdsRef.
+    const pending = group.drafts.filter(
+      draft =>
+        !excludedPhotos[draft.photoId] &&
+        !savedPhotoIdsRef.current.has(draft.photoId) &&
+        filesRef.current.has(draft.photoId)
+    )
+
+    // 1. All blobs into the local-only photo store in one transaction —
+    // all-or-nothing, so a failure here persists nothing and retry is safe.
+    const photos: StoredPhoto[] = pending.map(draft => {
+      const exifJson: Record<string, string | number> = { takenAt: draft.takenAt }
+      if (draft.latitude !== undefined) exifJson.latitude = draft.latitude
+      if (draft.longitude !== undefined) exifJson.longitude = draft.longitude
+      return {
+        id: draft.photoId,
+        blob: filesRef.current.get(draft.photoId)!,
+        takenAt: draft.takenAt,
+        ...(draft.latitude !== undefined ? { latitude: draft.latitude } : {}),
+        ...(draft.longitude !== undefined ? { longitude: draft.longitude } : {}),
+        bedId,
+        exifJson: JSON.stringify(exifJson),
+      }
+    })
     try {
-      for (const draft of group.drafts) {
-        if (excludedPhotos[draft.photoId]) continue
-        const file = filesRef.current.get(draft.photoId)
-        if (!file) continue
+      await putPhotos(photos)
+    } catch {
+      setSaveError(
+        `Could not save the photos for ${formatGroupDate(group.date)}. Nothing was imported for that day — please try again.`
+      )
+      setSavingDate(null)
+      return
+    }
 
-        // 1. Blob into the local-only photo store first…
-        const exifJson: Record<string, string | number> = { takenAt: draft.takenAt }
-        if (draft.latitude !== undefined) exifJson.latitude = draft.latitude
-        if (draft.longitude !== undefined) exifJson.longitude = draft.longitude
-        await putPhoto({
-          id: draft.photoId,
-          blob: file,
-          takenAt: draft.takenAt,
-          ...(draft.latitude !== undefined ? { latitude: draft.latitude } : {}),
-          ...(draft.longitude !== undefined ? { longitude: draft.longitude } : {}),
-          bedId,
-          exifJson: JSON.stringify(exifJson),
-        })
-
-        // 2. …then the observation care-log entry referencing it by id.
+    // 2. …then the observation care-log entries referencing them by id,
+    // marking each draft saved so a retry never duplicates an entry.
+    try {
+      for (const draft of pending) {
         const entry: NewCareLogEntry = {
           type: 'observation',
           date: draft.date,
@@ -173,12 +211,14 @@ export default function PhotoImportPage() {
         if (caption) entry.description = caption
         entry.photoId = draft.photoId
         addCareLog(bedId, entry)
-        saved++
+        savedPhotoIdsRef.current.add(draft.photoId)
       }
-      setConfirmedDates(prev => ({ ...prev, [group.date]: saved }))
+      const totalSaved = group.drafts.filter(d => savedPhotoIdsRef.current.has(d.photoId)).length
+      setConfirmedDates(prev => ({ ...prev, [group.date]: totalSaved }))
     } catch {
+      const savedCount = group.drafts.filter(d => savedPhotoIdsRef.current.has(d.photoId)).length
       setSaveError(
-        `Could not save all photos for ${group.date}. ${saved} saved before the error — you can retry the rest.`
+        `Could not log every photo for ${formatGroupDate(group.date)}. ${savedCount} saved so far — retry to finish the rest (already-saved photos won't be duplicated).`
       )
     } finally {
       setSavingDate(null)

--- a/src/app/log/import/page.tsx
+++ b/src/app/log/import/page.tsx
@@ -1,0 +1,461 @@
+'use client'
+
+/**
+ * Camera-roll importer — reconstruct a season from phone photos
+ * (Season Observer Phase 2, workstream A).
+ *
+ * The user points this at their photo library; we read EXIF timestamps and
+ * GPS *client-side only*, keep the photos taken within ~100m of the plot
+ * (`meta.coordinates`), group them by calendar date, and present each date
+ * as draft observations. Nothing is saved until the user assigns a bed and
+ * confirms a date — unconfirmed drafts are discarded, never persisted.
+ *
+ * Privacy: photo bytes and EXIF (including GPS) stay on this device. Blobs
+ * go to the separate `bwp-photos` IndexedDB store; the Yjs/AllotmentData
+ * document (which cloud sync, export, and share serialise) only ever holds
+ * the opaque `photoId` string on the confirmed care-log entry.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import {
+  Camera,
+  Check,
+  ChevronLeft,
+  Images,
+  Loader2,
+  MapPin,
+  MapPinOff,
+  AlertTriangle,
+} from 'lucide-react'
+import { useAllotment } from '@/hooks/useAllotment'
+import { generateId } from '@/lib/utils'
+import { todayLocalISO } from '@/lib/log-date'
+import { parseExif } from '@/lib/photo-import/exif'
+import {
+  buildDraftObservations,
+  type DraftGroup,
+  type DraftPipelineResult,
+  type PhotoMetaRecord,
+} from '@/lib/photo-import/pipeline'
+import { putPhoto } from '@/services/photo-store'
+import type { Area, NewCareLogEntry } from '@/types/unified-allotment'
+
+const EXCLUSION_LABELS: Record<string, string> = {
+  'no-date': 'no readable date (HEIC or stripped EXIF)',
+  'no-gps': 'no location data',
+  'outside-geofence': 'taken away from the plot',
+}
+
+export default function PhotoImportPage() {
+  const {
+    isLoading,
+    data,
+    selectedYear,
+    getAllAreas,
+    addCareLog,
+  } = useAllotment()
+
+  const [parsing, setParsing] = useState(false)
+  const [result, setResult] = useState<DraftPipelineResult | null>(null)
+  const [bedByDate, setBedByDate] = useState<Record<string, string>>({})
+  const [excludedPhotos, setExcludedPhotos] = useState<Record<string, boolean>>({})
+  const [captions, setCaptions] = useState<Record<string, string>>({})
+  const [confirmedDates, setConfirmedDates] = useState<Record<string, number>>({})
+  const [savingDate, setSavingDate] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Photo bytes + preview object URLs, kept outside React state (not render
+  // input except via previewVersion bump after parse).
+  const filesRef = useRef<Map<string, File>>(new Map())
+  const previewUrlsRef = useRef<Map<string, string>>(new Map())
+  const [, setPreviewVersion] = useState(0)
+
+  const plotCoordinates = data?.meta.coordinates
+
+  const revokeAllPreviews = () => {
+    for (const url of previewUrlsRef.current.values()) URL.revokeObjectURL(url)
+    previewUrlsRef.current.clear()
+  }
+
+  // Release preview object URLs on unmount so blobs don't stay pinned.
+  useEffect(() => revokeAllPreviews, [])
+
+  const beds = useMemo(
+    () =>
+      getAllAreas()
+        .filter((a: Area) => a.canHavePlantings && !a.isArchived)
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [getAllAreas]
+  )
+
+  // Confirmed entries file into the selected season via addCareLog, so only
+  // dates inside that season (and not in the future) are importable. Other
+  // groups render with an explanation instead of a confirm button.
+  const todayStr = todayLocalISO()
+  const seasonMin = `${selectedYear}-01-01`
+  const yearEnd = `${selectedYear}-12-31`
+  const seasonMax = todayStr < yearEnd ? todayStr : yearEnd
+  const isDateImportable = (date: string) => date >= seasonMin && date <= seasonMax
+
+  const handleFiles = async (fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0) return
+    setParsing(true)
+    setSaveError(null)
+    setResult(null)
+    setConfirmedDates({})
+    setExcludedPhotos({})
+    setCaptions({})
+    setBedByDate({})
+    revokeAllPreviews()
+    filesRef.current.clear()
+
+    const records: PhotoMetaRecord[] = []
+    for (const file of Array.from(fileList)) {
+      const id = generateId('photo')
+      let exif: ReturnType<typeof parseExif> = {}
+      try {
+        exif = parseExif(await file.arrayBuffer())
+      } catch {
+        // Unreadable file — fall through with empty EXIF; the pipeline
+        // will report it as excluded rather than aborting the import.
+      }
+      filesRef.current.set(id, file)
+      previewUrlsRef.current.set(id, URL.createObjectURL(file))
+      const record: PhotoMetaRecord = { id, fileName: file.name }
+      if (exif.takenAt) record.takenAt = exif.takenAt
+      if (exif.latitude !== undefined) record.latitude = exif.latitude
+      if (exif.longitude !== undefined) record.longitude = exif.longitude
+      records.push(record)
+    }
+
+    const pipelineResult = buildDraftObservations(records, {
+      plotCoordinates,
+    })
+    setResult(pipelineResult)
+    setPreviewVersion(v => v + 1)
+    setParsing(false)
+  }
+
+  const handleConfirmGroup = async (group: DraftGroup) => {
+    const bedId = bedByDate[group.date]
+    if (!bedId || savingDate) return
+    setSavingDate(group.date)
+    setSaveError(null)
+
+    let saved = 0
+    try {
+      for (const draft of group.drafts) {
+        if (excludedPhotos[draft.photoId]) continue
+        const file = filesRef.current.get(draft.photoId)
+        if (!file) continue
+
+        // 1. Blob into the local-only photo store first…
+        const exifJson: Record<string, string | number> = { takenAt: draft.takenAt }
+        if (draft.latitude !== undefined) exifJson.latitude = draft.latitude
+        if (draft.longitude !== undefined) exifJson.longitude = draft.longitude
+        await putPhoto({
+          id: draft.photoId,
+          blob: file,
+          takenAt: draft.takenAt,
+          ...(draft.latitude !== undefined ? { latitude: draft.latitude } : {}),
+          ...(draft.longitude !== undefined ? { longitude: draft.longitude } : {}),
+          bedId,
+          exifJson: JSON.stringify(exifJson),
+        })
+
+        // 2. …then the observation care-log entry referencing it by id.
+        const entry: NewCareLogEntry = {
+          type: 'observation',
+          date: draft.date,
+        }
+        const caption = captions[draft.photoId]?.trim()
+        if (caption) entry.description = caption
+        entry.photoId = draft.photoId
+        addCareLog(bedId, entry)
+        saved++
+      }
+      setConfirmedDates(prev => ({ ...prev, [group.date]: saved }))
+    } catch {
+      setSaveError(
+        `Could not save all photos for ${group.date}. ${saved} saved before the error — you can retry the rest.`
+      )
+    } finally {
+      setSavingDate(null)
+    }
+  }
+
+  const excludedSummary = useMemo(() => {
+    if (!result || result.excluded.length === 0) return null
+    const counts = new Map<string, number>()
+    for (const ex of result.excluded) {
+      counts.set(ex.reason, (counts.get(ex.reason) ?? 0) + 1)
+    }
+    return [...counts.entries()]
+      .map(([reason, count]) => `${count} ${EXCLUSION_LABELS[reason] ?? reason}`)
+      .join(', ')
+  }, [result])
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-zen-stone-50 flex items-center justify-center">
+        <p className="text-zen-stone-500">Loading…</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-zen-stone-50 zen-texture">
+      <div className="container mx-auto px-4 py-8 max-w-3xl">
+        <header className="mb-6">
+          <div className="flex items-center gap-3 mb-1">
+            <Camera className="w-6 h-6 text-zen-moss-600" />
+            <h1 className="text-zen-ink-900">Import from photos</h1>
+          </div>
+          <p className="text-zen-stone-500">
+            Rebuild your {selectedYear} log from your camera roll. Photos are read on this
+            device only — nothing is uploaded, and every entry needs your confirmation.
+          </p>
+        </header>
+
+        {/* Geofence status */}
+        <div
+          role="note"
+          className={`mb-6 flex items-start gap-2 rounded-zen border px-3 py-2 text-sm ${
+            plotCoordinates
+              ? 'bg-zen-moss-50 border-zen-moss-200 text-zen-moss-800'
+              : 'bg-zen-kitsune-50 border-zen-kitsune-200 text-zen-kitsune-800'
+          }`}
+        >
+          {plotCoordinates ? (
+            <>
+              <MapPin className="w-4 h-4 shrink-0 mt-0.5" />
+              <span>
+                Only photos taken within about 100m of your plot will be suggested.
+              </span>
+            </>
+          ) : (
+            <>
+              <MapPinOff className="w-4 h-4 shrink-0 mt-0.5" />
+              <span>
+                Your plot location isn&apos;t set, so photos can&apos;t be filtered by place —
+                every dated photo will be suggested. Untick any that aren&apos;t from the plot.
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* Step 1 — pick photos */}
+        <section className="zen-card p-4 mb-6" aria-label="Choose photos">
+          <label
+            htmlFor="photo-import-input"
+            className="flex flex-col items-center justify-center gap-2 border-2 border-dashed border-zen-stone-300 rounded-zen px-4 py-8 cursor-pointer hover:border-zen-moss-400 hover:bg-zen-stone-50 transition"
+          >
+            <Images className="w-8 h-8 text-zen-moss-600" />
+            <span className="font-medium text-zen-ink-800">Choose photos from your library</span>
+            <span className="text-sm text-zen-stone-500">
+              JPEG photos with date &amp; location work best
+            </span>
+          </label>
+          <input
+            id="photo-import-input"
+            type="file"
+            multiple
+            accept="image/*"
+            className="sr-only"
+            onChange={e => {
+              void handleFiles(e.target.files)
+              // Allow re-selecting the same files after a reset.
+              e.target.value = ''
+            }}
+          />
+        </section>
+
+        {parsing && (
+          <div className="flex items-center gap-2 text-zen-stone-600 mb-6" role="status">
+            <Loader2 className="w-5 h-5 animate-spin" />
+            Reading photo dates and locations…
+          </div>
+        )}
+
+        {saveError && (
+          <div
+            role="alert"
+            className="mb-4 flex items-start gap-2 rounded-zen bg-zen-kitsune-50 border border-zen-kitsune-200 px-3 py-2 text-sm text-zen-kitsune-800"
+          >
+            <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+            <span>{saveError}</span>
+          </div>
+        )}
+
+        {/* Step 2 — review drafts */}
+        {result && !parsing && (
+          <section aria-label="Review draft observations">
+            <div className="mb-4 text-sm text-zen-stone-600">
+              <p>
+                <strong>{result.draftCount}</strong> photo{result.draftCount === 1 ? '' : 's'} matched
+                across <strong>{result.groups.length}</strong> day{result.groups.length === 1 ? '' : 's'}.
+                {excludedSummary && <> Skipped: {excludedSummary}.</>}
+              </p>
+            </div>
+
+            {result.groups.length === 0 && (
+              <div className="zen-card p-6 text-center text-zen-stone-600">
+                No usable photos found. Photos need an EXIF date
+                {plotCoordinates ? ' and a location near your plot' : ''} to be suggested.
+              </div>
+            )}
+
+            {result.groups.map(group => {
+              const importable = isDateImportable(group.date)
+              const confirmedCount = confirmedDates[group.date]
+              const isConfirmed = confirmedCount !== undefined
+              const includedCount = group.drafts.filter(d => !excludedPhotos[d.photoId]).length
+              const bedId = bedByDate[group.date] ?? ''
+              return (
+                <div key={group.date} className="zen-card p-4 mb-4">
+                  <div className="flex items-center justify-between mb-3 gap-2 flex-wrap">
+                    <h2 className="font-medium text-zen-ink-800">
+                      {formatGroupDate(group.date)}
+                      <span className="text-zen-stone-400 font-normal text-sm ml-2">
+                        {group.drafts.length} photo{group.drafts.length === 1 ? '' : 's'}
+                      </span>
+                    </h2>
+                    {isConfirmed && (
+                      <span className="inline-flex items-center gap-1 text-sm text-zen-moss-700 font-medium">
+                        <Check className="w-4 h-4" />
+                        {confirmedCount} saved
+                      </span>
+                    )}
+                  </div>
+
+                  {!importable && (
+                    <p className="text-sm text-zen-kitsune-800 bg-zen-kitsune-50 border border-zen-kitsune-200 rounded-zen px-3 py-2 mb-3">
+                      This date is outside the active {selectedYear} season, so it can&apos;t be
+                      imported right now. Switch the active year on the Allotment page to file it.
+                    </p>
+                  )}
+
+                  {/* Photo thumbnails */}
+                  <div className="grid grid-cols-3 sm:grid-cols-4 gap-3 mb-3">
+                    {group.drafts.map(draft => {
+                      const url = previewUrlsRef.current.get(draft.photoId)
+                      const excluded = !!excludedPhotos[draft.photoId]
+                      return (
+                        <div key={draft.photoId} className="space-y-1">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              !isConfirmed &&
+                              setExcludedPhotos(prev => ({
+                                ...prev,
+                                [draft.photoId]: !prev[draft.photoId],
+                              }))
+                            }
+                            aria-pressed={!excluded}
+                            aria-label={`${excluded ? 'Include' : 'Exclude'} photo ${draft.fileName}`}
+                            className={`relative block w-full aspect-square overflow-hidden rounded-zen border-2 transition ${
+                              excluded
+                                ? 'border-zen-stone-200 opacity-40'
+                                : 'border-zen-moss-400'
+                            }`}
+                          >
+                            {url ? (
+                              // eslint-disable-next-line @next/next/no-img-element -- local object URL, next/image can't optimise it
+                              <img
+                                src={url}
+                                alt={`Photo taken ${draft.takenAt.replace('T', ' at ')}`}
+                                className="w-full h-full object-cover"
+                              />
+                            ) : (
+                              <span className="flex items-center justify-center w-full h-full bg-zen-stone-100 text-zen-stone-400">
+                                <Camera className="w-6 h-6" />
+                              </span>
+                            )}
+                            {!excluded && (
+                              <span className="absolute top-1 right-1 bg-zen-moss-600 text-white rounded-full p-0.5">
+                                <Check className="w-3 h-3" />
+                              </span>
+                            )}
+                          </button>
+                          {!isConfirmed && !excluded && (
+                            <input
+                              type="text"
+                              placeholder="Note (optional)"
+                              value={captions[draft.photoId] ?? ''}
+                              onChange={e =>
+                                setCaptions(prev => ({ ...prev, [draft.photoId]: e.target.value }))
+                              }
+                              className="w-full text-xs px-2 py-1 border border-zen-stone-200 rounded-zen"
+                              aria-label={`Note for photo ${draft.fileName}`}
+                            />
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+
+                  {/* Bed + confirm */}
+                  {importable && !isConfirmed && (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <select
+                        value={bedId}
+                        onChange={e =>
+                          setBedByDate(prev => ({ ...prev, [group.date]: e.target.value }))
+                        }
+                        className="min-h-[44px] px-3 border border-zen-stone-200 rounded-zen bg-white text-sm"
+                        aria-label={`Bed for ${group.date}`}
+                      >
+                        <option value="">Which bed?</option>
+                        {beds.map(bed => (
+                          <option key={bed.id} value={bed.id}>
+                            {bed.icon ? `${bed.icon} ` : ''}{bed.name}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => void handleConfirmGroup(group)}
+                        disabled={!bedId || includedCount === 0 || savingDate !== null}
+                        className="min-h-[44px] px-4 rounded-zen bg-zen-moss-600 text-white text-sm font-medium inline-flex items-center gap-2 disabled:opacity-40 hover:bg-zen-moss-700 transition"
+                      >
+                        {savingDate === group.date ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <Check className="w-4 h-4" />
+                        )}
+                        Save {includedCount} observation{includedCount === 1 ? '' : 's'}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </section>
+        )}
+
+        <div className="mt-8 flex items-center justify-between text-sm">
+          <Link
+            href="/log"
+            className="inline-flex items-center gap-1 text-zen-stone-500 hover:text-zen-moss-700"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Back to Quick Log
+          </Link>
+          <span className="text-zen-stone-400">Photos stay on this device</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** "2026-04-12" -> "Saturday 12 April 2026" (locale-aware, UTC-safe). */
+function formatGroupDate(date: string): string {
+  const dt = new Date(`${date}T00:00:00`)
+  if (Number.isNaN(dt.getTime())) return date
+  return dt.toLocaleDateString(undefined, {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -27,6 +27,7 @@ import {
   AlertTriangle,
   StickyNote,
   Flower2,
+  Camera,
   Check,
   ChevronLeft,
   ClipboardList,
@@ -472,6 +473,17 @@ export default function QuickLogPage() {
             )}
           </>
         )}
+
+        {/* Retroactive capture: rebuild the season from camera-roll photos */}
+        <div className="mt-6">
+          <Link
+            href="/log/import"
+            className="inline-flex items-center gap-2 text-sm text-zen-moss-700 hover:text-zen-moss-800 font-medium"
+          >
+            <Camera className="w-4 h-4" />
+            Import observations from photos
+          </Link>
+        </div>
 
         <div className="mt-8 flex items-center justify-between text-sm">
           <Link href="/allotment" className="inline-flex items-center gap-1 text-zen-stone-500 hover:text-zen-moss-700">

--- a/src/lib/photo-import/exif.ts
+++ b/src/lib/photo-import/exif.ts
@@ -1,0 +1,262 @@
+/**
+ * Minimal pure EXIF parser for the camera-roll importer (Season Observer
+ * Phase 2, ADR-free: no new dependency).
+ *
+ * Scope is deliberately tiny — the importer only needs two facts per photo:
+ * when it was taken (DateTimeOriginal) and where (GPS latitude/longitude).
+ * A full EXIF library (exifr ~50KB min) would be the only consumer of 95% of
+ * its surface, so we parse the JPEG APP1/TIFF structure by hand instead:
+ * deterministic, dependency-free, and fully unit-testable against
+ * synthesised byte fixtures.
+ *
+ * Everything runs client-side over an ArrayBuffer. Nothing here touches the
+ * network — EXIF data (including GPS) never leaves the device.
+ *
+ * Format notes:
+ * - JPEG is a sequence of 0xFFxx segments after the 0xFFD8 SOI marker.
+ * - EXIF lives in an APP1 (0xFFE1) segment prefixed with "Exif\0\0",
+ *   followed by a TIFF block ("II"/"MM" byte order, 0x2A, IFD0 offset).
+ * - IFD0 points at the Exif sub-IFD (tag 0x8769, holds DateTimeOriginal)
+ *   and the GPS sub-IFD (tag 0x8825, holds latitude/longitude rationals).
+ * - HEIC/HEIF (ISO BMFF) is intentionally out of scope; callers surface
+ *   those files as "no readable EXIF" and the user can convert or skip.
+ */
+
+/** Parsed subset of EXIF the importer cares about. */
+export interface ExifData {
+  /** DateTimeOriginal as a naive local ISO string, e.g. "2026-04-12T09:30:00". */
+  takenAt?: string
+  /** Decimal degrees, negative = south. */
+  latitude?: number
+  /** Decimal degrees, negative = west. */
+  longitude?: number
+}
+
+// TIFF/EXIF tag ids
+const TAG_EXIF_IFD_POINTER = 0x8769
+const TAG_GPS_IFD_POINTER = 0x8825
+const TAG_DATETIME = 0x0132 // IFD0 fallback
+const TAG_DATETIME_ORIGINAL = 0x9003
+const TAG_DATETIME_DIGITIZED = 0x9004
+const TAG_GPS_LAT_REF = 0x0001
+const TAG_GPS_LAT = 0x0002
+const TAG_GPS_LON_REF = 0x0003
+const TAG_GPS_LON = 0x0004
+
+const IFD_ENTRY_SIZE = 12
+
+interface IfdEntry {
+  tag: number
+  type: number
+  count: number
+  /** Absolute offset (within the TIFF block) of the value bytes. */
+  valueOffset: number
+}
+
+/**
+ * Convert an EXIF "YYYY:MM:DD HH:MM:SS" timestamp to a naive local ISO
+ * string ("YYYY-MM-DDTHH:MM:SS"), or undefined if malformed. EXIF has no
+ * timezone; we keep the camera's local wall-clock time, which is exactly
+ * what "what happened on the plot that day" wants.
+ */
+export function exifDateToIso(raw: string): string | undefined {
+  const m = /^(\d{4}):(\d{2}):(\d{2})[ T](\d{2}):(\d{2}):(\d{2})/.exec(raw.trim())
+  if (!m) return undefined
+  const [, y, mo, d, h, mi, s] = m
+  const month = Number(mo)
+  const day = Number(d)
+  if (month < 1 || month > 12 || day < 1 || day > 31) return undefined
+  if (Number(h) > 23 || Number(mi) > 59 || Number(s) > 60) return undefined
+  return `${y}-${mo}-${d}T${h}:${mi}:${s}`
+}
+
+/**
+ * Read a single LONG (uint32) value from an IFD entry — used for the
+ * Exif/GPS sub-IFD pointer tags. `entry.valueOffset` is the position of the
+ * value bytes (inline for 4-byte values), so the pointer itself must be
+ * dereferenced from there.
+ */
+function readLong(
+  view: DataView,
+  tiffStart: number,
+  entry: IfdEntry,
+  little: boolean
+): number | undefined {
+  const start = tiffStart + entry.valueOffset
+  if (start + 4 > view.byteLength) return undefined
+  return view.getUint32(start, little)
+}
+
+/** Read a NUL-terminated ASCII value from an IFD entry. */
+function readAscii(view: DataView, tiffStart: number, entry: IfdEntry): string | undefined {
+  const start = tiffStart + entry.valueOffset
+  if (start + entry.count > view.byteLength) return undefined
+  let out = ''
+  for (let i = 0; i < entry.count; i++) {
+    const c = view.getUint8(start + i)
+    if (c === 0) break
+    out += String.fromCharCode(c)
+  }
+  return out
+}
+
+/** Read `count` unsigned rationals (numerator/denominator uint32 pairs). */
+function readRationals(
+  view: DataView,
+  tiffStart: number,
+  entry: IfdEntry,
+  little: boolean
+): number[] | undefined {
+  const start = tiffStart + entry.valueOffset
+  if (start + entry.count * 8 > view.byteLength) return undefined
+  const out: number[] = []
+  for (let i = 0; i < entry.count; i++) {
+    const num = view.getUint32(start + i * 8, little)
+    const den = view.getUint32(start + i * 8 + 4, little)
+    if (den === 0) return undefined
+    out.push(num / den)
+  }
+  return out
+}
+
+/** Degrees/minutes/seconds rationals -> signed decimal degrees. */
+function dmsToDecimal(dms: number[], ref: string | undefined, negativeRef: string): number | undefined {
+  const [deg = 0, min = 0, sec = 0] = dms
+  if (!Number.isFinite(deg) || !Number.isFinite(min) || !Number.isFinite(sec)) return undefined
+  const decimal = deg + min / 60 + sec / 3600
+  const sign = ref?.toUpperCase() === negativeRef ? -1 : 1
+  return sign * decimal
+}
+
+/**
+ * Parse one IFD into its entries. Returns entries plus the raw value word so
+ * pointer tags (type LONG stored inline) resolve without re-reading.
+ */
+function readIfd(
+  view: DataView,
+  tiffStart: number,
+  ifdOffset: number,
+  little: boolean
+): IfdEntry[] {
+  const base = tiffStart + ifdOffset
+  if (base + 2 > view.byteLength) return []
+  const count = view.getUint16(base, little)
+  const entries: IfdEntry[] = []
+  for (let i = 0; i < count; i++) {
+    const at = base + 2 + i * IFD_ENTRY_SIZE
+    if (at + IFD_ENTRY_SIZE > view.byteLength) break
+    const tag = view.getUint16(at, little)
+    const type = view.getUint16(at + 2, little)
+    const cnt = view.getUint32(at + 4, little)
+    // Types: 1=BYTE 2=ASCII 3=SHORT 4=LONG 5=RATIONAL — sizes in bytes:
+    const typeSize = type === 1 || type === 2 ? 1 : type === 3 ? 2 : type === 4 ? 4 : type === 5 ? 8 : 0
+    if (typeSize === 0) continue
+    const byteLen = typeSize * cnt
+    // Values <= 4 bytes are stored inline in the value word; larger values
+    // store an offset (relative to the TIFF header) there instead.
+    const valueOffset = byteLen <= 4 ? at + 8 - tiffStart : view.getUint32(at + 8, little)
+    entries.push({ tag, type, count: cnt, valueOffset })
+  }
+  return entries
+}
+
+/** Locate the TIFF block inside a JPEG's APP1 Exif segment. */
+function findTiffStart(view: DataView): number | null {
+  if (view.byteLength < 4 || view.getUint16(0) !== 0xffd8) return null
+  let offset = 2
+  // Walk JPEG segments looking for APP1 "Exif\0\0".
+  while (offset + 4 <= view.byteLength) {
+    if (view.getUint8(offset) !== 0xff) return null
+    const marker = view.getUint8(offset + 1)
+    // Standalone markers without a length (RSTn, TEM) shouldn't appear before
+    // scan data; stop at SOS (0xDA) — EXIF always precedes it.
+    if (marker === 0xda) return null
+    const length = view.getUint16(offset + 2)
+    if (length < 2) return null
+    if (marker === 0xe1 && offset + 4 + 6 <= view.byteLength) {
+      const isExif =
+        view.getUint8(offset + 4) === 0x45 && // E
+        view.getUint8(offset + 5) === 0x78 && // x
+        view.getUint8(offset + 6) === 0x69 && // i
+        view.getUint8(offset + 7) === 0x66 && // f
+        view.getUint8(offset + 8) === 0x00 &&
+        view.getUint8(offset + 9) === 0x00
+      if (isExif) return offset + 10
+    }
+    offset += 2 + length
+  }
+  return null
+}
+
+/**
+ * Extract DateTimeOriginal + GPS coordinates from a JPEG buffer.
+ * Returns an empty object for anything unreadable (non-JPEG, no EXIF,
+ * truncated data) — the importer treats those photos as "no metadata"
+ * rather than erroring.
+ */
+export function parseExif(buffer: ArrayBuffer): ExifData {
+  const view = new DataView(buffer)
+  const tiffStart = findTiffStart(view)
+  if (tiffStart === null) return {}
+  if (tiffStart + 8 > view.byteLength) return {}
+
+  const byteOrder = view.getUint16(tiffStart)
+  const little = byteOrder === 0x4949 // "II"
+  if (!little && byteOrder !== 0x4d4d) return {} // not "MM" either
+  if (view.getUint16(tiffStart + 2, little) !== 0x002a) return {}
+
+  const ifd0Offset = view.getUint32(tiffStart + 4, little)
+  const ifd0 = readIfd(view, tiffStart, ifd0Offset, little)
+
+  const result: ExifData = {}
+
+  // Date: prefer DateTimeOriginal, then DateTimeDigitized, then IFD0 DateTime.
+  const exifPointer = ifd0.find(e => e.tag === TAG_EXIF_IFD_POINTER)
+  const exifIfdOffset = exifPointer ? readLong(view, tiffStart, exifPointer, little) : undefined
+  let dateRaw: string | undefined
+  if (exifIfdOffset !== undefined) {
+    const exifIfd = readIfd(view, tiffStart, exifIfdOffset, little)
+    const original = exifIfd.find(e => e.tag === TAG_DATETIME_ORIGINAL)
+    const digitized = exifIfd.find(e => e.tag === TAG_DATETIME_DIGITIZED)
+    const entry = original ?? digitized
+    if (entry) dateRaw = readAscii(view, tiffStart, entry)
+  }
+  if (!dateRaw) {
+    const fallback = ifd0.find(e => e.tag === TAG_DATETIME)
+    if (fallback) dateRaw = readAscii(view, tiffStart, fallback)
+  }
+  if (dateRaw) {
+    const iso = exifDateToIso(dateRaw)
+    if (iso) result.takenAt = iso
+  }
+
+  // GPS
+  const gpsPointer = ifd0.find(e => e.tag === TAG_GPS_IFD_POINTER)
+  const gpsIfdOffset = gpsPointer ? readLong(view, tiffStart, gpsPointer, little) : undefined
+  if (gpsIfdOffset !== undefined) {
+    const gpsIfd = readIfd(view, tiffStart, gpsIfdOffset, little)
+    const latEntry = gpsIfd.find(e => e.tag === TAG_GPS_LAT)
+    const lonEntry = gpsIfd.find(e => e.tag === TAG_GPS_LON)
+    const latRefEntry = gpsIfd.find(e => e.tag === TAG_GPS_LAT_REF)
+    const lonRefEntry = gpsIfd.find(e => e.tag === TAG_GPS_LON_REF)
+    if (latEntry && lonEntry) {
+      const latDms = readRationals(view, tiffStart, latEntry, little)
+      const lonDms = readRationals(view, tiffStart, lonEntry, little)
+      const latRef = latRefEntry ? readAscii(view, tiffStart, latRefEntry) : undefined
+      const lonRef = lonRefEntry ? readAscii(view, tiffStart, lonRefEntry) : undefined
+      if (latDms && lonDms) {
+        const lat = dmsToDecimal(latDms, latRef, 'S')
+        const lon = dmsToDecimal(lonDms, lonRef, 'W')
+        if (
+          lat !== undefined && lon !== undefined &&
+          Math.abs(lat) <= 90 && Math.abs(lon) <= 180
+        ) {
+          result.latitude = lat
+          result.longitude = lon
+        }
+      }
+    }
+  }
+
+  return result
+}

--- a/src/lib/photo-import/exif.ts
+++ b/src/lib/photo-import/exif.ts
@@ -45,6 +45,9 @@ const TAG_GPS_LON = 0x0004
 
 const IFD_ENTRY_SIZE = 12
 
+/** Byte size per element of the TIFF field types we handle: 1=BYTE, 2=ASCII, 3=SHORT, 4=LONG, 5=RATIONAL. */
+const TYPE_SIZES: Record<number, number> = { 1: 1, 2: 1, 3: 2, 4: 4, 5: 8 }
+
 interface IfdEntry {
   tag: number
   type: number
@@ -58,16 +61,20 @@ interface IfdEntry {
  * string ("YYYY-MM-DDTHH:MM:SS"), or undefined if malformed. EXIF has no
  * timezone; we keep the camera's local wall-clock time, which is exactly
  * what "what happened on the plot that day" wants.
+ *
+ * Impossible calendar dates (e.g. 2026:02:31) are rejected by round-tripping
+ * the date part through a UTC Date — an overflowed value (Feb 31 → Mar 3)
+ * won't match what was written. Same technique as `normalizeLogDate`.
  */
 export function exifDateToIso(raw: string): string | undefined {
   const m = /^(\d{4}):(\d{2}):(\d{2})[ T](\d{2}):(\d{2}):(\d{2})/.exec(raw.trim())
   if (!m) return undefined
   const [, y, mo, d, h, mi, s] = m
-  const month = Number(mo)
-  const day = Number(d)
-  if (month < 1 || month > 12 || day < 1 || day > 31) return undefined
+  const datePart = `${y}-${mo}-${d}`
+  const dt = new Date(`${datePart}T00:00:00Z`)
+  if (Number.isNaN(dt.getTime()) || dt.toISOString().slice(0, 10) !== datePart) return undefined
   if (Number(h) > 23 || Number(mi) > 59 || Number(s) > 60) return undefined
-  return `${y}-${mo}-${d}T${h}:${mi}:${s}`
+  return `${datePart}T${h}:${mi}:${s}`
 }
 
 /**
@@ -148,9 +155,8 @@ function readIfd(
     const tag = view.getUint16(at, little)
     const type = view.getUint16(at + 2, little)
     const cnt = view.getUint32(at + 4, little)
-    // Types: 1=BYTE 2=ASCII 3=SHORT 4=LONG 5=RATIONAL — sizes in bytes:
-    const typeSize = type === 1 || type === 2 ? 1 : type === 3 ? 2 : type === 4 ? 4 : type === 5 ? 8 : 0
-    if (typeSize === 0) continue
+    const typeSize = TYPE_SIZES[type]
+    if (typeSize === undefined) continue
     const byteLen = typeSize * cnt
     // Values <= 4 bytes are stored inline in the value word; larger values
     // store an offset (relative to the TIFF header) there instead.

--- a/src/lib/photo-import/geofence.ts
+++ b/src/lib/photo-import/geofence.ts
@@ -1,0 +1,47 @@
+/**
+ * Geofence maths for the camera-roll importer.
+ *
+ * Pure and deterministic: given a photo's GPS coordinates and the plot's
+ * coordinates (`meta.coordinates`), decide whether the photo was taken at
+ * the plot. All computation is local — coordinates never leave the device.
+ */
+
+export interface LatLon {
+  latitude: number
+  longitude: number
+}
+
+/** Default geofence radius: "within ~100m of the plot". */
+export const DEFAULT_GEOFENCE_RADIUS_METERS = 100
+
+/** Mean Earth radius (IUGG) in metres. */
+const EARTH_RADIUS_METERS = 6371008.8
+
+/**
+ * Great-circle distance between two coordinates in metres (haversine).
+ * Accurate to well under a metre at geofence scales.
+ */
+export function haversineDistanceMeters(a: LatLon, b: LatLon): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+  const dLat = toRad(b.latitude - a.latitude)
+  const dLon = toRad(b.longitude - a.longitude)
+  const lat1 = toRad(a.latitude)
+  const lat2 = toRad(b.latitude)
+
+  const sinLat = Math.sin(dLat / 2)
+  const sinLon = Math.sin(dLon / 2)
+  const h = sinLat * sinLat + Math.cos(lat1) * Math.cos(lat2) * sinLon * sinLon
+  return 2 * EARTH_RADIUS_METERS * Math.asin(Math.min(1, Math.sqrt(h)))
+}
+
+/**
+ * Is `point` within `radiusMeters` of `center`? Boundary-inclusive
+ * (exactly 100m counts as "at the plot").
+ */
+export function isWithinGeofence(
+  point: LatLon,
+  center: LatLon,
+  radiusMeters: number = DEFAULT_GEOFENCE_RADIUS_METERS
+): boolean {
+  return haversineDistanceMeters(point, center) <= radiusMeters
+}

--- a/src/lib/photo-import/pipeline.ts
+++ b/src/lib/photo-import/pipeline.ts
@@ -1,0 +1,157 @@
+/**
+ * Draft-observation pipeline for the camera-roll importer:
+ * photo metadata -> geofence -> group by calendar date -> draft observations.
+ *
+ * Pure and deterministic (no I/O, no Date.now) so the whole reconstruction
+ * path is unit-testable with fixture metadata. Drafts are exactly that —
+ * drafts. Nothing here writes to AllotmentData or the photo store; only a
+ * human confirming a draft in the review UI persists anything, and
+ * unconfirmed drafts are simply discarded.
+ */
+
+import {
+  DEFAULT_GEOFENCE_RADIUS_METERS,
+  isWithinGeofence,
+  type LatLon,
+} from './geofence'
+
+/** Metadata extracted from one photo file (EXIF already parsed). */
+export interface PhotoMetaRecord {
+  /** Stable id for this candidate photo; becomes the stored photo id on confirm. */
+  id: string
+  fileName: string
+  /** Naive local ISO timestamp from EXIF DateTimeOriginal, if present. */
+  takenAt?: string
+  latitude?: number
+  longitude?: number
+}
+
+/**
+ * One reviewable draft observation, derived from one photo.
+ *
+ * Vision seam: `suggestedCaption` is where a future local image annotator
+ * (see `DraftAnnotator`) would put a machine-suggested description for the
+ * user to accept or edit. v1 never sets it — drafts stay caption-less until
+ * the human types one.
+ */
+export interface DraftObservation {
+  photoId: string
+  fileName: string
+  /** Grouping key, local calendar date YYYY-MM-DD. */
+  date: string
+  takenAt: string
+  latitude?: number
+  longitude?: number
+  suggestedCaption?: string
+}
+
+/**
+ * Seam for a future local (on-device, human-confirmed) vision captioner.
+ * Implementations must be pure over their inputs and must not perform
+ * network calls — the importer's privacy contract is "nothing leaves the
+ * device". v1 ships no implementation.
+ */
+export interface DraftAnnotator {
+  annotate(
+    photo: Blob,
+    draft: DraftObservation
+  ): Promise<Pick<DraftObservation, 'suggestedCaption'>>
+}
+
+/** Drafts for one calendar date, oldest photo first. */
+export interface DraftGroup {
+  date: string
+  drafts: DraftObservation[]
+}
+
+/** Why a photo was left out of the drafts, for honest UI reporting. */
+export interface ExcludedPhoto {
+  record: PhotoMetaRecord
+  reason: 'no-date' | 'no-gps' | 'outside-geofence'
+}
+
+export interface DraftPipelineResult {
+  /** Date groups, oldest date first. */
+  groups: DraftGroup[]
+  /** Total drafts across all groups. */
+  draftCount: number
+  excluded: ExcludedPhoto[]
+  /** False when plot coordinates were missing and the geofence was skipped. */
+  geofenceApplied: boolean
+}
+
+export interface DraftPipelineOptions {
+  /** Plot coordinates (`meta.coordinates`). Undefined disables the geofence. */
+  plotCoordinates?: LatLon
+  radiusMeters?: number
+}
+
+/**
+ * Run parsed photo metadata through geofence + date grouping and emit
+ * reviewable draft observations.
+ *
+ * Rules:
+ * - No EXIF timestamp -> excluded ('no-date'): a season reconstruction is
+ *   useless without a date, and guessing one would fabricate history.
+ * - Geofence on (plot coordinates known): photos without GPS are excluded
+ *   ('no-gps'), photos beyond the radius are excluded ('outside-geofence').
+ * - Geofence off (no plot coordinates): every dated photo passes; the UI
+ *   tells the user filtering was skipped so they can deselect strays.
+ */
+export function buildDraftObservations(
+  records: PhotoMetaRecord[],
+  options: DraftPipelineOptions = {}
+): DraftPipelineResult {
+  const { plotCoordinates, radiusMeters = DEFAULT_GEOFENCE_RADIUS_METERS } = options
+  const excluded: ExcludedPhoto[] = []
+  const drafts: DraftObservation[] = []
+
+  for (const record of records) {
+    if (!record.takenAt) {
+      excluded.push({ record, reason: 'no-date' })
+      continue
+    }
+    if (plotCoordinates) {
+      if (record.latitude === undefined || record.longitude === undefined) {
+        excluded.push({ record, reason: 'no-gps' })
+        continue
+      }
+      const point = { latitude: record.latitude, longitude: record.longitude }
+      if (!isWithinGeofence(point, plotCoordinates, radiusMeters)) {
+        excluded.push({ record, reason: 'outside-geofence' })
+        continue
+      }
+    }
+    const draft: DraftObservation = {
+      photoId: record.id,
+      fileName: record.fileName,
+      date: record.takenAt.slice(0, 10),
+      takenAt: record.takenAt,
+    }
+    if (record.latitude !== undefined) draft.latitude = record.latitude
+    if (record.longitude !== undefined) draft.longitude = record.longitude
+    drafts.push(draft)
+  }
+
+  // Group by calendar date; groups oldest-first, photos within a group in
+  // time order — the natural way to relive a season.
+  const byDate = new Map<string, DraftObservation[]>()
+  for (const draft of drafts) {
+    const group = byDate.get(draft.date)
+    if (group) group.push(draft)
+    else byDate.set(draft.date, [draft])
+  }
+  const groups: DraftGroup[] = [...byDate.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, groupDrafts]) => ({
+      date,
+      drafts: [...groupDrafts].sort((a, b) => a.takenAt.localeCompare(b.takenAt)),
+    }))
+
+  return {
+    groups,
+    draftCount: drafts.length,
+    excluded,
+    geofenceApplied: plotCoordinates !== undefined,
+  }
+}

--- a/src/services/photo-store.ts
+++ b/src/services/photo-store.ts
@@ -11,6 +11,11 @@
  * This is a minimal promise wrapper over raw IndexedDB — no Dexie, no second
  * storage framework (y-indexeddb owns the *structured* data; this DB holds
  * binary blobs only).
+ *
+ * Durability: IndexedDB writes are only guaranteed once the *transaction*
+ * completes — a request's `onsuccess` can fire and the transaction still
+ * abort afterwards (e.g. quota exceeded at commit). Every promise here
+ * therefore resolves on `tx.oncomplete`, never on request success alone.
  */
 
 export interface StoredPhoto {
@@ -54,28 +59,77 @@ function openDb(): Promise<IDBDatabase> {
   })
 }
 
-/** Run one operation in its own transaction, closing the db afterwards. */
-async function withStore<T>(
+/**
+ * Run `work` against the object store in its own transaction, resolving with
+ * `getResult()` only once the transaction has committed (see the durability
+ * note above), and closing the db afterwards. Rejects on transaction error
+ * or abort; `work` may also wire per-request rejection via the `reject` it
+ * receives.
+ */
+async function inTransaction<T>(
   mode: IDBTransactionMode,
-  operation: (store: IDBObjectStore) => IDBRequest<T>
+  work: (store: IDBObjectStore, reject: (reason: unknown) => void) => () => T
 ): Promise<T> {
   const db = await openDb()
   try {
     return await new Promise<T>((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, mode)
-      const request = operation(tx.objectStore(STORE_NAME))
-      request.onsuccess = () => resolve(request.result)
-      request.onerror = () => reject(request.error ?? new Error('Photo store operation failed'))
+      tx.onerror = () => reject(tx.error ?? new Error('Photo store transaction failed'))
       tx.onabort = () => reject(tx.error ?? new Error('Photo store transaction aborted'))
+      let getResult: () => T
+      try {
+        getResult = work(tx.objectStore(STORE_NAME), reject)
+      } catch (err) {
+        // A synchronous throw (e.g. a record that can't provide the keyPath)
+        // must abort the transaction, or requests issued before the throw
+        // would still auto-commit — breaking all-or-nothing semantics.
+        try {
+          tx.abort()
+        } catch {
+          // Already aborting/finished — nothing more to do.
+        }
+        reject(err)
+        return
+      }
+      tx.oncomplete = () => resolve(getResult())
     })
   } finally {
     db.close()
   }
 }
 
-/** Store (or overwrite) a photo record. */
+/** Run one IDB request in its own transaction; resolve its result on commit. */
+function withStore<T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> {
+  return inTransaction<T>(mode, (store, reject) => {
+    const request = operation(store)
+    request.onerror = () =>
+      reject(request.error ?? new Error('Photo store operation failed'))
+    return () => request.result
+  })
+}
+
+/**
+ * Store (or overwrite) a batch of photo records in a single transaction.
+ * All-or-nothing: if any record fails, the transaction aborts and none of
+ * the batch is persisted. Resolves only after the transaction commits.
+ */
+export async function putPhotos(photos: StoredPhoto[]): Promise<void> {
+  if (photos.length === 0) return
+  await inTransaction<void>('readwrite', (store, reject) => {
+    for (const photo of photos) {
+      const request = store.put(photo)
+      request.onerror = () => reject(request.error ?? new Error('Photo store put failed'))
+    }
+    return () => undefined
+  })
+}
+
+/** Store (or overwrite) a single photo record. */
 export async function putPhoto(photo: StoredPhoto): Promise<void> {
-  await withStore('readwrite', store => store.put(photo))
+  await putPhotos([photo])
 }
 
 /** Fetch one photo record (with blob), or null if absent. */
@@ -89,13 +143,26 @@ export async function deletePhoto(id: string): Promise<void> {
   await withStore('readwrite', store => store.delete(id))
 }
 
-/** List all stored photos' metadata (blobs omitted to keep it cheap). */
+/**
+ * List all stored photos' metadata. Iterates with a cursor, stripping the
+ * `blob` from each record as it streams past, so at most one record's blob
+ * is materialised at a time (rather than `getAll()` holding every blob in
+ * memory simultaneously).
+ */
 export async function listPhotos(): Promise<StoredPhotoMeta[]> {
-  const all = await withStore<StoredPhoto[]>('readonly', store => store.getAll())
-  return all.map(photo => {
-    const meta: StoredPhotoMeta & { blob?: Blob } = { ...photo }
-    delete meta.blob
-    return meta
+  return inTransaction<StoredPhotoMeta[]>('readonly', (store, reject) => {
+    const metas: StoredPhotoMeta[] = []
+    const request = store.openCursor()
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (!cursor) return
+      const meta: StoredPhotoMeta & { blob?: Blob } = { ...(cursor.value as StoredPhoto) }
+      delete meta.blob
+      metas.push(meta)
+      cursor.continue()
+    }
+    request.onerror = () => reject(request.error ?? new Error('Photo store cursor failed'))
+    return () => metas
   })
 }
 

--- a/src/services/photo-store.ts
+++ b/src/services/photo-store.ts
@@ -1,0 +1,116 @@
+/**
+ * Photo blob store — plain IndexedDB, separate from the Yjs document.
+ *
+ * Photos are binary and local-only. They deliberately do NOT live in
+ * AllotmentData / the Yjs doc: blobs would bloat the CRDT state that cloud
+ * sync pushes to Supabase, and photo EXIF (GPS!) must never ride along with
+ * the JSON export / share / GDPR payloads, all of which serialise
+ * AllotmentData. Only the small `CareLogEntry.photoId` string reference
+ * lives in the CRDT; the bytes stay on this device, in this database.
+ *
+ * This is a minimal promise wrapper over raw IndexedDB — no Dexie, no second
+ * storage framework (y-indexeddb owns the *structured* data; this DB holds
+ * binary blobs only).
+ */
+
+export interface StoredPhoto {
+  /** Matches `CareLogEntry.photoId` on the confirmed observation. */
+  id: string
+  blob: Blob
+  /** Naive local ISO timestamp from EXIF, if the photo had one. */
+  takenAt?: string
+  latitude?: number
+  longitude?: number
+  /** Area the confirmed observation was filed under. */
+  bedId?: string
+  plantingId?: string
+  /** JSON string of the parsed EXIF subset (local-only, never exported). */
+  exifJson?: string
+}
+
+/** Metadata-only view (no blob) for listings. */
+export type StoredPhotoMeta = Omit<StoredPhoto, 'blob'>
+
+const DB_NAME = 'bwp-photos'
+const DB_VERSION = 1
+const STORE_NAME = 'photos'
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB is not available in this environment'))
+      return
+    }
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error('Failed to open photo store'))
+    request.onblocked = () => reject(new Error('Photo store open blocked by another connection'))
+  })
+}
+
+/** Run one operation in its own transaction, closing the db afterwards. */
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> {
+  const db = await openDb()
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, mode)
+      const request = operation(tx.objectStore(STORE_NAME))
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error ?? new Error('Photo store operation failed'))
+      tx.onabort = () => reject(tx.error ?? new Error('Photo store transaction aborted'))
+    })
+  } finally {
+    db.close()
+  }
+}
+
+/** Store (or overwrite) a photo record. */
+export async function putPhoto(photo: StoredPhoto): Promise<void> {
+  await withStore('readwrite', store => store.put(photo))
+}
+
+/** Fetch one photo record (with blob), or null if absent. */
+export async function getPhoto(id: string): Promise<StoredPhoto | null> {
+  const result = await withStore<StoredPhoto | undefined>('readonly', store => store.get(id))
+  return result ?? null
+}
+
+/** Delete a photo record. Idempotent. */
+export async function deletePhoto(id: string): Promise<void> {
+  await withStore('readwrite', store => store.delete(id))
+}
+
+/** List all stored photos' metadata (blobs omitted to keep it cheap). */
+export async function listPhotos(): Promise<StoredPhotoMeta[]> {
+  const all = await withStore<StoredPhoto[]>('readonly', store => store.getAll())
+  return all.map(photo => {
+    const meta: StoredPhotoMeta & { blob?: Blob } = { ...photo }
+    delete meta.blob
+    return meta
+  })
+}
+
+/**
+ * Object URL for rendering a stored photo, or null if it doesn't exist.
+ * Callers own the URL and must release it with `revokePhotoUrl` (e.g. in a
+ * useEffect cleanup) or the blob stays pinned in memory.
+ */
+export async function createPhotoUrl(id: string): Promise<string | null> {
+  const photo = await getPhoto(id)
+  if (!photo) return null
+  return URL.createObjectURL(photo.blob)
+}
+
+/** Release an object URL produced by `createPhotoUrl`. */
+export function revokePhotoUrl(url: string): void {
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary

Closes the last open Season Observer Phase-1 acceptance criterion: reconstructing the Jan–Jul 2026 season retroactively from the phone photo library — entirely on-device, human-confirmed only.

**What's new**

- **`/log/import`** (linked from Quick Log): pick photos with the browser File API → EXIF `DateTimeOriginal` + GPS are read client-side → photos within ~100m of the plot (`meta.coordinates`) are grouped by calendar date → each date renders as **draft observations** with thumbnails, per-photo include/exclude, and an optional note. The user assigns a bed and confirms; only then is anything persisted. Unconfirmed drafts are discarded. Groups outside the active season are blocked from import (same misfiling guard as `/log`).
- **`src/lib/photo-import/exif.ts`** — small pure JPEG/EXIF parser for exactly the two fields the importer needs (DateTimeOriginal, GPS DMS→decimal), both TIFF byte orders, tolerant of truncated/absent EXIF.
- **`src/lib/photo-import/geofence.ts`** — pure haversine distance + boundary-inclusive ~100m geofence. Missing plot coordinates disables the geofence gracefully with clear UI messaging.
- **`src/lib/photo-import/pipeline.ts`** — pure, deterministic parse → geofence → group-by-date → draft pipeline with honest exclusion reasons (`no-date` / `no-gps` / `outside-geofence`).
- **`src/services/photo-store.ts`** — separate plain-IndexedDB blob store (`bwp-photos`) with `put`/`get`/`delete`/`list` + object-URL render/cleanup. On confirm, the blob goes here and the observation care-log entry is written through the existing `addCareLog` write path with `CareLogEntry.photoId` (v23, already wired) set. No schema change, no migration.

**Dependency decision:** no new npm dependency. The repo's philosophy is a lean dependency list and hand-rolled deterministic libs with heavy tests (`agronomy.ts`, `log-date.ts`); a full EXIF library (e.g. `exifr`) would ship a large mostly-unused surface for two tags. The ~230-line parser is fully covered by synthesised byte fixtures instead.

**Privacy (local-first guarantee):** photo bytes, EXIF, and GPS never leave the device and never enter `AllotmentData`/the Yjs doc — only the opaque `photoId` string does. Since JSON export, share, GDPR export, and cloud sync all serialise `AllotmentData` (verified in `useDataTransfer`, `/api/share`, `/api/account`, `sync-binary`), none of them can carry photo location data. No network calls anywhere in this workstream.

**Vision seam (deferred by design):** `DraftObservation.suggestedCaption` + the `DraftAnnotator` interface in `pipeline.ts` are where a future local, human-confirmed captioner slots in; v1 ships no implementation.

**Reused from Phase 1 / existing code:** v23 `CareLogEntry.photoId`/observation types, the `useAllotment` → `addCareLog` → `mutate(fn)` Yjs write path, `todayLocalISO`/season-bounds guard from `/log`, `generateId`, zen-theme UI patterns from the Quick Log page.

**Known limitation:** HEIC/HEIF EXIF is not parsed (ISO BMFF container); those photos are surfaced to the user as "no readable date" and skipped rather than silently dropped.

## Related issue

Closes the open Phase-1 acceptance item tracked in `docs/plans/season-observer.md` (camera-roll importer, ≥30 draft observations).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Checklist

- [x] I have tested my changes — `npm run type-check`, `npm run lint`, `npm run test:unit` (1188 passed, 34 new: EXIF byte fixtures both endians, 99m/100m/101m geofence boundaries, date grouping, photo-store round-trip via fake-indexeddb, and a 38-photo end-to-end acceptance test asserting 30 drafts in 10 correctly-ordered date groups), and `npm run build` all pass.
- [x] I have updated documentation if needed — `docs/plans/current-plan.md` and `docs/plans/season-observer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6RGfSq4UvpKrZhbDTnxpd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6RGfSq4UvpKrZhbDTnxpd)_