### PR TITLE
Season Observer Phase 2b: derived metrics + rules engine + /season-review

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,22 @@
 # Current Plan
 
-Last updated: 2026-07-13 (Season Observer camera-roll EXIF importer shipped)
+Last updated: 2026-07-13 (Season Observer Phase 2b rules engine shipped)
+
+## Season Observer — Phase 2b: derived metrics + rules engine (shipped)
+
+The learn half of the plan → observe → learn loop, fully deterministic (no
+LLM). `src/lib/season-review/metrics.ts` derives tested metrics from a
+season's plantings/care-logs + archived weather + the 10-year baseline (GDD,
+soil temp at sowing, dry spells, monthly water balance, heat-stress days,
+actual-vs-typical germination, monthly anomalies). `rules.ts` runs 10
+conservative rules over them and emits a structured `findings[]` array —
+every number traceable to a tested metric, and every rule silent on
+missing/thin data (false positives are the failure mode). The new
+`/season-review` page (More menu + linked from `/log`) renders the findings,
+a monthly weather-vs-baseline table, and per-planting metrics, degrading
+gracefully with no coordinates / no cached weather / sparse logs. Findings
+are computed on demand, never persisted. Phase 2c (report narration) remains
+an open decision — see `docs/plans/season-observer.md`.
 
 ## Season Observer — camera-roll photo import (shipped)
 

--- a/docs/plans/season-observer.md
+++ b/docs/plans/season-observer.md
@@ -118,12 +118,34 @@ retrospective report. Coordinates stay in local cache keys only (rounded
 ~1 km), never logged, absent from exported types. Reuse `frost-dates.ts` for
 the frost metric.
 
-### Derived metrics + rules engine (Phase 2b)
-Deterministic code over logs + weather: GDD accumulation, soil temp at sowing,
-dry spells, water balance, heat-stress days, days-to-germinate vs typical,
-anomaly vs baseline. Emit a structured `findings[]` array (8–12 well-tested
-rules; false positives are the failure mode). `src/lib/agronomy.ts` is the
-reference input.
+### Derived metrics + rules engine (Phase 2b) — **shipped**
+Deterministic code over logs + weather, all in `src/lib/season-review/`:
+
+- `metrics.ts` — pure derived metrics over `SeasonWeather`/`WeatherBaseline` +
+  plantings/care-logs: GDD accumulation (coverage-gated), soil temp at sowing,
+  sustained soil-threshold detection, dry spells, monthly water balance
+  (rain − ET₀), heat-stress day counts, frost-in-window, actual
+  days-to-germinate (sow → `germinated` care log), monthly actuals + anomalies
+  vs the 10-year baseline (same coverage rules as `computeBaseline`, so the
+  comparison is like-for-like).
+- `rules.ts` — `evaluateSeason()` runs 10 rules and emits a structured
+  `findings[]` array (`findings.ts`: id, ruleId, severity info/notice/warning,
+  plain-English summary, the metric values behind it, and the bed/planting
+  entities). Rules: cold-soil sowing, slow germination, frost after tender
+  planting-out, heat-stress days (escalates when bolting was logged), monthly
+  temp/rain/sunshine anomalies vs baseline, dry spells (cross-referenced with
+  watering logs — only when the user logs watering at all), monthly water
+  deficit, and pest/disease clusters (log-only, works without weather).
+  Every rule stays silent on missing/thin data — metrics return null under
+  coverage floors and the engine emits nothing rather than guess; the sparse
+  fixture asserts exactly that. `computePlantingMetrics()` powers the page's
+  per-planting table.
+- `/season-review` page — deterministic rendering only (no narration): year
+  picker, findings list, monthly weather vs baseline table, per-planting
+  metrics, with graceful no-coordinates / no-cached-weather / sparse-log
+  states. Linked from the More menu and from `/log`. Findings are computed on
+  demand — nothing new is persisted in the Yjs doc, and coordinates never
+  appear in findings.
 
 ### Report narration (Phase 2c) — **open decision**
 The brief mandates local Ollama only (privacy-first). The repo's only LLM path

--- a/src/__tests__/lib/season-review/metrics.test.ts
+++ b/src/__tests__/lib/season-review/metrics.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect } from 'vitest'
+import type { SeasonDailyRecord, SeasonWeather } from '@/lib/weather/open-meteo-archive'
+import type { WeatherBaseline } from '@/lib/weather/weather-baseline'
+import type { CareLogEntry, Planting } from '@/types/unified-allotment'
+import {
+  accumulateGdd,
+  computeMonthlyActuals,
+  computeMonthlyAnomalies,
+  countHeatStressDays,
+  daySpan,
+  daysInWindow,
+  daysToGermination,
+  findDrySpells,
+  firstSoilTempAtOrAbove,
+  frostDaysInWindow,
+  monthlyWaterBalance,
+  soilTempOn,
+} from '@/lib/season-review/metrics'
+
+function makeDay(date: string, overrides: Partial<SeasonDailyRecord> = {}): SeasonDailyRecord {
+  return {
+    date,
+    tempMaxC: 16,
+    tempMinC: 8,
+    tempMeanC: 12,
+    precipitationMm: 2,
+    shortwaveRadiationMJm2: 15,
+    et0Mm: 2,
+    sunshineHours: 5,
+    daylightHours: 14,
+    weatherCode: 3,
+    soilTempMean0to7C: 10,
+    soilTempMean7to28C: 11,
+    soilMoistureMean0to7: 0.2,
+    ...overrides,
+  }
+}
+
+/** All ISO dates from start to end inclusive. */
+function datesBetween(start: string, end: string): string[] {
+  const dates: string[] = []
+  let t = Date.parse(`${start}T00:00:00Z`)
+  const endT = Date.parse(`${end}T00:00:00Z`)
+  while (t <= endT) {
+    dates.push(new Date(t).toISOString().slice(0, 10))
+    t += 86_400_000
+  }
+  return dates
+}
+
+/** A full-year season with per-date overrides. */
+function buildSeason(
+  year: number,
+  overrides: Record<string, Partial<SeasonDailyRecord>> = {}
+): SeasonWeather {
+  const days = datesBetween(`${year}-01-01`, `${year}-12-31`).map((date) =>
+    makeDay(date, overrides[date])
+  )
+  return { year, days, complete: true, fetchedAt: '2026-01-01T00:00:00Z' }
+}
+
+function overrideRange(
+  start: string,
+  end: string,
+  values: Partial<SeasonDailyRecord>
+): Record<string, Partial<SeasonDailyRecord>> {
+  const result: Record<string, Partial<SeasonDailyRecord>> = {}
+  for (const date of datesBetween(start, end)) result[date] = values
+  return result
+}
+
+describe('daySpan', () => {
+  it('is inclusive', () => {
+    expect(daySpan('2025-03-10', '2025-03-10')).toBe(1)
+    expect(daySpan('2025-03-10', '2025-03-12')).toBe(3)
+  })
+
+  it('returns 0 for malformed dates', () => {
+    expect(daySpan('not-a-date', '2025-03-12')).toBe(0)
+  })
+})
+
+describe('daysInWindow', () => {
+  it('filters inclusively by date', () => {
+    const season = buildSeason(2025)
+    const window = daysInWindow(season.days, '2025-06-01', '2025-06-03')
+    expect(window.map((d) => d.date)).toEqual(['2025-06-01', '2025-06-02', '2025-06-03'])
+  })
+})
+
+describe('accumulateGdd', () => {
+  it('sums degrees above the base temperature', () => {
+    const season = buildSeason(2025) // tempMeanC 12 every day
+    const result = accumulateGdd(season.days, 5, '2025-06-01', '2025-06-10')
+    // 10 days × (12 − 5)
+    expect(result).toEqual({ gdd: 70, daysWithData: 10, windowDays: 10 })
+  })
+
+  it('never counts negative daily GDD', () => {
+    const season = buildSeason(2025, overrideRange('2025-06-01', '2025-06-05', { tempMeanC: 3 }))
+    const result = accumulateGdd(season.days, 5, '2025-06-01', '2025-06-10')
+    // 5 cold days contribute 0, 5 days × 7
+    expect(result?.gdd).toBe(35)
+  })
+
+  it('falls back to (max+min)/2 when the daily mean is missing', () => {
+    const season = buildSeason(
+      2025,
+      overrideRange('2025-06-01', '2025-06-10', { tempMeanC: null, tempMaxC: 20, tempMinC: 10 })
+    )
+    const result = accumulateGdd(season.days, 5, '2025-06-01', '2025-06-10')
+    // mean = 15 → 10 × 10
+    expect(result?.gdd).toBe(100)
+  })
+
+  it('returns null when coverage is too thin', () => {
+    const season = buildSeason(
+      2025,
+      overrideRange('2025-06-01', '2025-06-07', { tempMeanC: null, tempMaxC: null, tempMinC: null })
+    )
+    // 3 of 10 days have data — far below the 80% coverage floor.
+    expect(accumulateGdd(season.days, 5, '2025-06-01', '2025-06-10')).toBeNull()
+  })
+
+  it('returns null for an inverted window', () => {
+    const season = buildSeason(2025)
+    expect(accumulateGdd(season.days, 5, '2025-06-10', '2025-06-01')).toBeNull()
+  })
+})
+
+describe('soilTempOn', () => {
+  it('returns the soil temperature for the exact date', () => {
+    const season = buildSeason(2025, { '2025-03-10': { soilTempMean0to7C: 4.2 } })
+    expect(soilTempOn(season.days, '2025-03-10')).toBe(4.2)
+  })
+
+  it('returns null when the date has no record or no reading', () => {
+    const season = buildSeason(2025, { '2025-03-10': { soilTempMean0to7C: null } })
+    expect(soilTempOn(season.days, '2025-03-10')).toBeNull()
+    expect(soilTempOn(season.days, '2030-01-01')).toBeNull()
+  })
+})
+
+describe('firstSoilTempAtOrAbove', () => {
+  it('finds the start of the first 3-day run at/above the threshold', () => {
+    const season = buildSeason(2025, {
+      ...overrideRange('2025-03-01', '2025-03-31', { soilTempMean0to7C: 4 }),
+      // A single warm blip must not count.
+      '2025-03-15': { soilTempMean0to7C: 8 },
+      ...overrideRange('2025-04-01', '2025-04-30', { soilTempMean0to7C: 7.5 }),
+    })
+    expect(firstSoilTempAtOrAbove(season.days, 7, '2025-03-01')).toBe('2025-04-01')
+  })
+
+  it('treats a missing reading as breaking the run', () => {
+    const season = buildSeason(2025, {
+      ...overrideRange('2025-03-01', '2025-03-31', { soilTempMean0to7C: 4 }),
+      ...overrideRange('2025-04-01', '2025-04-30', { soilTempMean0to7C: 7.5 }),
+      '2025-04-02': { soilTempMean0to7C: null },
+    })
+    expect(firstSoilTempAtOrAbove(season.days, 7, '2025-03-01')).toBe('2025-04-03')
+  })
+
+  it('returns null when the threshold is never sustained', () => {
+    const season = buildSeason(2025, overrideRange('2025-01-01', '2025-12-31', { soilTempMean0to7C: 4 }))
+    expect(firstSoilTempAtOrAbove(season.days, 7, '2025-01-01')).toBeNull()
+  })
+})
+
+describe('findDrySpells', () => {
+  it('finds a spell of consecutive dry days with its rain total', () => {
+    const season = buildSeason(2025, overrideRange('2025-07-02', '2025-07-19', { precipitationMm: 0.1 }))
+    const spells = findDrySpells(season.days, 14)
+    expect(spells).toEqual([
+      { start: '2025-07-02', end: '2025-07-19', lengthDays: 18, totalRainMm: 1.8 },
+    ])
+  })
+
+  it('ignores spells shorter than the minimum', () => {
+    const season = buildSeason(2025, overrideRange('2025-07-02', '2025-07-10', { precipitationMm: 0 }))
+    expect(findDrySpells(season.days, 14)).toEqual([])
+  })
+
+  it('breaks a spell on a missing precipitation reading', () => {
+    const season = buildSeason(2025, {
+      ...overrideRange('2025-07-01', '2025-07-30', { precipitationMm: 0 }),
+      '2025-07-15': { precipitationMm: null },
+    })
+    const spells = findDrySpells(season.days, 14)
+    // 1–14 July is 14 days; 16–30 July is 15 days.
+    expect(spells.map((s) => [s.start, s.end])).toEqual([
+      ['2025-07-01', '2025-07-14'],
+      ['2025-07-16', '2025-07-30'],
+    ])
+  })
+
+  it('breaks a spell on a wet day (> 1mm)', () => {
+    const season = buildSeason(2025, {
+      ...overrideRange('2025-07-01', '2025-07-20', { precipitationMm: 0.5 }),
+      '2025-07-10': { precipitationMm: 6 },
+    })
+    expect(findDrySpells(season.days, 14)).toEqual([])
+  })
+})
+
+describe('monthlyWaterBalance', () => {
+  it('computes rain minus ET0 for a fully-covered month', () => {
+    const season = buildSeason(2025, overrideRange('2025-07-01', '2025-07-31', { precipitationMm: 0.5, et0Mm: 3 }))
+    expect(monthlyWaterBalance(season, 7)).toEqual({
+      month: 7,
+      rainMm: 15.5,
+      et0Mm: 93,
+      balanceMm: -77.5,
+    })
+  })
+
+  it('returns null when either series lacks coverage', () => {
+    const season = buildSeason(2025, overrideRange('2025-07-01', '2025-07-10', { et0Mm: null }))
+    expect(monthlyWaterBalance(season, 7)).toBeNull()
+  })
+})
+
+describe('countHeatStressDays', () => {
+  it('counts days at or above the threshold', () => {
+    const season = buildSeason(2025, {
+      '2025-06-10': { tempMaxC: 30 },
+      '2025-06-15': { tempMaxC: 31.5 },
+      '2025-06-20': { tempMaxC: 30 },
+    })
+    const result = countHeatStressDays(season.days, 30, '2025-06-01', '2025-06-30')
+    expect(result?.count).toBe(3)
+    expect(result?.dates).toEqual(['2025-06-10', '2025-06-15', '2025-06-20'])
+  })
+
+  it('returns null when max-temperature coverage is too thin', () => {
+    const season = buildSeason(2025, overrideRange('2025-06-01', '2025-06-20', { tempMaxC: null }))
+    expect(countHeatStressDays(season.days, 30, '2025-06-01', '2025-06-30')).toBeNull()
+  })
+})
+
+describe('frostDaysInWindow', () => {
+  it('returns frost dates and the coldest minimum', () => {
+    const season = buildSeason(2025, {
+      '2025-05-12': { tempMinC: -1.3 },
+      '2025-05-14': { tempMinC: 0 },
+    })
+    expect(frostDaysInWindow(season.days, '2025-05-05', '2025-05-31')).toEqual({
+      dates: ['2025-05-12', '2025-05-14'],
+      minTempC: -1.3,
+    })
+  })
+
+  it('returns null when no frost occurred in the window', () => {
+    const season = buildSeason(2025)
+    expect(frostDaysInWindow(season.days, '2025-05-05', '2025-05-31')).toBeNull()
+  })
+})
+
+describe('daysToGermination', () => {
+  const planting: Planting = { id: 'p1', plantId: 'peas', sowDate: '2025-03-10' }
+  const log = (overrides: Partial<CareLogEntry>): CareLogEntry => ({
+    id: 'log-1',
+    type: 'germinated',
+    date: '2025-04-03',
+    plantingId: 'p1',
+    ...overrides,
+  })
+
+  it('measures sow → earliest germination log for the planting', () => {
+    const logs = [log({ id: 'a', date: '2025-04-05' }), log({ id: 'b', date: '2025-04-03' })]
+    expect(daysToGermination(planting, logs)).toEqual({
+      sowDate: '2025-03-10',
+      germinatedDate: '2025-04-03',
+      days: 24,
+    })
+  })
+
+  it('ignores germination logs for other plantings or before sowing', () => {
+    expect(daysToGermination(planting, [log({ plantingId: 'other' })])).toBeNull()
+    expect(daysToGermination(planting, [log({ date: '2025-03-01' })])).toBeNull()
+  })
+
+  it('returns null without a sow date or without a germination log', () => {
+    expect(daysToGermination({ id: 'p2', plantId: 'peas' }, [log({ plantingId: 'p2' })])).toBeNull()
+    expect(daysToGermination(planting, [log({ type: 'observation' })])).toBeNull()
+  })
+})
+
+describe('computeMonthlyActuals', () => {
+  it('aggregates monthly mean temperature, rain and sunshine totals', () => {
+    const season = buildSeason(2025, overrideRange('2025-06-01', '2025-06-30', { tempMeanC: 14, precipitationMm: 1, sunshineHours: 6 }))
+    const june = computeMonthlyActuals(season).find((m) => m.month === 6)
+    expect(june).toEqual({ month: 6, meanTempC: 14, rainfallMm: 30, sunshineHours: 180 })
+  })
+
+  it('nulls metrics without enough coverage', () => {
+    const season = buildSeason(2025, {
+      ...overrideRange('2025-06-01', '2025-06-15', { tempMeanC: null }),
+      ...overrideRange('2025-06-01', '2025-06-05', { tempMeanC: null, precipitationMm: null }),
+    })
+    const june = computeMonthlyActuals(season).find((m) => m.month === 6)
+    // 15 days of temp (< 20 needed), 25/30 rain days (< 90% coverage).
+    expect(june?.meanTempC).toBeNull()
+    expect(june?.rainfallMm).toBeNull()
+    expect(june?.sunshineHours).toBe(150)
+  })
+})
+
+describe('computeMonthlyAnomalies', () => {
+  const baseline: WeatherBaseline = {
+    startYear: 2015,
+    endYear: 2024,
+    yearsUsed: [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024],
+    months: Array.from({ length: 12 }, (_, i) => ({
+      month: i + 1,
+      meanTempC: 14,
+      totalRainfallMm: 60,
+      sunshineHours: 150,
+      yearsUsed: 10,
+    })),
+    computedAt: '2026-01-01T00:00:00Z',
+  }
+
+  it('computes temperature delta and rain/sunshine ratios', () => {
+    const season = buildSeason(2025, overrideRange('2025-06-01', '2025-06-30', { tempMeanC: 12.2, precipitationMm: 1, sunshineHours: 2 }))
+    const june = computeMonthlyAnomalies(computeMonthlyActuals(season), baseline).find(
+      (m) => m.month === 6
+    )
+    expect(june?.tempDeltaC).toBe(-1.8)
+    expect(june?.rainRatio).toBe(0.5)
+    expect(june?.sunshineRatio).toBe(0.4)
+  })
+
+  it('nulls comparisons when either side is missing', () => {
+    const season = buildSeason(2025, overrideRange('2025-06-01', '2025-06-30', { tempMeanC: null, tempMaxC: null, tempMinC: null }))
+    const noTempBaseline: WeatherBaseline = {
+      ...baseline,
+      months: baseline.months.map((m) => (m.month === 7 ? { ...m, totalRainfallMm: null } : m)),
+    }
+    const anomalies = computeMonthlyAnomalies(computeMonthlyActuals(season), noTempBaseline)
+    expect(anomalies.find((m) => m.month === 6)?.tempDeltaC).toBeNull()
+    expect(anomalies.find((m) => m.month === 7)?.rainRatio).toBeNull()
+  })
+
+  it('refuses a rain ratio against a near-zero baseline month', () => {
+    const dryBaseline: WeatherBaseline = {
+      ...baseline,
+      months: baseline.months.map((m) => ({ ...m, totalRainfallMm: 2 })),
+    }
+    const season = buildSeason(2025)
+    const anomalies = computeMonthlyAnomalies(computeMonthlyActuals(season), dryBaseline)
+    expect(anomalies.every((m) => m.rainRatio === null)).toBe(true)
+  })
+})

--- a/src/__tests__/lib/season-review/metrics.test.ts
+++ b/src/__tests__/lib/season-review/metrics.test.ts
@@ -284,6 +284,12 @@ describe('daysToGermination', () => {
     expect(daysToGermination({ id: 'p2', plantId: 'peas' }, [log({ plantingId: 'p2' })])).toBeNull()
     expect(daysToGermination(planting, [log({ type: 'observation' })])).toBeNull()
   })
+
+  it('treats an unparseable sow date as missing data, not a negative interval', () => {
+    // Sorts before the log date so the entry still matches, but doesn't parse.
+    const mangled: Planting = { id: 'p1', plantId: 'peas', sowDate: '2025-04-99' }
+    expect(daysToGermination(mangled, [log({ date: '2025-05-01' })])).toBeNull()
+  })
 })
 
 describe('computeMonthlyActuals', () => {

--- a/src/__tests__/lib/season-review/rules.test.ts
+++ b/src/__tests__/lib/season-review/rules.test.ts
@@ -413,6 +413,18 @@ describe('rule: dry-spell', () => {
     expect(finding.metrics.wateringsLogged).toBeUndefined()
   })
 
+  it('ignores watering logs from other years when judging the spell', () => {
+    // A stray watering entry dated last year must not trigger the false
+    // warning that this year's spell went unwatered.
+    const strayLog = water('w0', `${YEAR - 1}-07-05`)
+    const findings = evaluateSeason(
+      makeInput({ weather: drySummer(), seasonRecord: makeSeasonRecord([], [strayLog]) })
+    )
+    const [finding] = byRule(findings, 'dry-spell')
+    expect(finding.severity).toBe('notice')
+    expect(finding.summary).not.toContain('watering')
+  })
+
   it('ignores dry spells outside the growing season', () => {
     const winterDry = buildWeather(
       overrideRange(`${YEAR}-01-05`, `${YEAR}-01-25`, { precipitationMm: 0 })
@@ -483,6 +495,24 @@ describe('rule: pest-disease-cluster', () => {
     ]
     const findings = evaluateSeason(makeInput({ seasonRecord: makeSeasonRecord([], logs) }))
     expect(byRule(findings, 'pest-disease-cluster')[0]?.severity).toBe('warning')
+  })
+
+  it('picks the largest 30-day run when logs straggle beyond the window', () => {
+    // 5 logs over 6 weeks: the densest 30-day window holds the middle four.
+    const logs = [
+      pest('p1', `${YEAR}-06-01`),
+      pest('p2', `${YEAR}-06-20`),
+      pest('p3', `${YEAR}-06-25`),
+      pest('p4', `${YEAR}-07-01`),
+      pest('p5', `${YEAR}-07-15`),
+    ]
+    const findings = evaluateSeason(makeInput({ seasonRecord: makeSeasonRecord([], logs) }))
+    const [finding] = byRule(findings, 'pest-disease-cluster')
+    expect(finding.metrics).toMatchObject({
+      observationCount: 4,
+      firstDate: `${YEAR}-06-20`,
+      lastDate: `${YEAR}-07-15`,
+    })
   })
 
   it('does not mix types or count logs spread beyond the window', () => {

--- a/src/__tests__/lib/season-review/rules.test.ts
+++ b/src/__tests__/lib/season-review/rules.test.ts
@@ -543,6 +543,17 @@ describe('evaluateSeason', () => {
     expect(evaluateSeason(makeInput())).toEqual([])
   })
 
+  it('stays silent instead of throwing on a malformed planting date', () => {
+    // Passes the year-prefix check and sorts inside the season, but is not a
+    // parseable date; the frost rule's date arithmetic must skip it, not
+    // crash the whole review.
+    const mangled: Planting = { id: 'm1', plantId: 'courgette', transplantDate: `${YEAR}-05-99` }
+    const findings = evaluateSeason(
+      makeInput({ weather: buildWeather(), seasonRecord: makeSeasonRecord([mangled]) })
+    )
+    expect(findings).toEqual([])
+  })
+
   it('orders findings most severe first', () => {
     const findings: Finding[] = [
       { id: 'a', ruleId: 'r', severity: 'info', summary: '', metrics: {}, entities: [] },

--- a/src/__tests__/lib/season-review/rules.test.ts
+++ b/src/__tests__/lib/season-review/rules.test.ts
@@ -1,0 +1,564 @@
+import { describe, it, expect } from 'vitest'
+import type { SeasonDailyRecord, SeasonWeather } from '@/lib/weather/open-meteo-archive'
+import type { WeatherBaseline } from '@/lib/weather/weather-baseline'
+import type {
+  Area,
+  CareLogEntry,
+  Planting,
+  SeasonRecord,
+} from '@/types/unified-allotment'
+import { sortFindings, type Finding } from '@/lib/season-review/findings'
+import {
+  computePlantingMetrics,
+  evaluateSeason,
+  type SeasonReviewInput,
+} from '@/lib/season-review/rules'
+
+const YEAR = 2025
+
+// ---------------------------------------------------------------------------
+// Fixtures — a synthetic plot, season and weather the rules run over.
+// ---------------------------------------------------------------------------
+
+function makeDay(date: string, overrides: Partial<SeasonDailyRecord> = {}): SeasonDailyRecord {
+  return {
+    date,
+    tempMaxC: 16,
+    tempMinC: 8,
+    tempMeanC: 12,
+    precipitationMm: 2,
+    shortwaveRadiationMJm2: 15,
+    et0Mm: 2,
+    sunshineHours: 5,
+    daylightHours: 14,
+    weatherCode: 3,
+    soilTempMean0to7C: 10,
+    soilTempMean7to28C: 11,
+    soilMoistureMean0to7: 0.2,
+    ...overrides,
+  }
+}
+
+function datesBetween(start: string, end: string): string[] {
+  const dates: string[] = []
+  let t = Date.parse(`${start}T00:00:00Z`)
+  const endT = Date.parse(`${end}T00:00:00Z`)
+  while (t <= endT) {
+    dates.push(new Date(t).toISOString().slice(0, 10))
+    t += 86_400_000
+  }
+  return dates
+}
+
+function buildWeather(
+  overrides: Record<string, Partial<SeasonDailyRecord>> = {}
+): SeasonWeather {
+  const days = datesBetween(`${YEAR}-01-01`, `${YEAR}-12-31`).map((date) =>
+    makeDay(date, overrides[date])
+  )
+  return { year: YEAR, days, complete: true, fetchedAt: '2026-01-01T00:00:00Z' }
+}
+
+function overrideRange(
+  start: string,
+  end: string,
+  values: Partial<SeasonDailyRecord>
+): Record<string, Partial<SeasonDailyRecord>> {
+  const result: Record<string, Partial<SeasonDailyRecord>> = {}
+  for (const date of datesBetween(start, end)) result[date] = values
+  return result
+}
+
+/** Baseline matching the fixture weather's defaults, so only crafted deviations flag. */
+function makeBaseline(
+  perMonth: Partial<Record<number, { meanTempC?: number; totalRainfallMm?: number; sunshineHours?: number }>> = {}
+): WeatherBaseline {
+  return {
+    startYear: YEAR - 10,
+    endYear: YEAR - 1,
+    yearsUsed: Array.from({ length: 10 }, (_, i) => YEAR - 10 + i),
+    months: Array.from({ length: 12 }, (_, i) => ({
+      month: i + 1,
+      meanTempC: 12,
+      totalRainfallMm: 62,
+      sunshineHours: 155,
+      yearsUsed: 10,
+      ...perMonth[i + 1],
+    })),
+    computedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+const BED_A: Area = {
+  id: 'bed-a',
+  name: 'Bed A',
+  kind: 'rotation-bed',
+  canHavePlantings: true,
+}
+
+function makeInput(overrides: Partial<SeasonReviewInput> = {}): SeasonReviewInput {
+  return {
+    year: YEAR,
+    areas: [BED_A],
+    seasonRecord: null,
+    weather: null,
+    baseline: null,
+    ...overrides,
+  }
+}
+
+function makeSeasonRecord(plantings: Planting[], careLogs: CareLogEntry[] = []): SeasonRecord {
+  return {
+    year: YEAR,
+    status: 'historical',
+    areas: [{ areaId: 'bed-a', plantings, careLogs }],
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+function byRule(findings: Finding[], ruleId: string): Finding[] {
+  return findings.filter((f) => f.ruleId === ruleId)
+}
+
+// ---------------------------------------------------------------------------
+// R1 cold-soil-sowing
+// ---------------------------------------------------------------------------
+
+describe('rule: cold-soil-sowing', () => {
+  // Peas need 5°C soil; keep it at 3.5°C through March, warm from 1 April.
+  const coldMarchWeather = () =>
+    buildWeather({
+      ...overrideRange(`${YEAR}-03-01`, `${YEAR}-03-31`, { soilTempMean0to7C: 3.5 }),
+      ...overrideRange(`${YEAR}-04-01`, `${YEAR}-04-30`, { soilTempMean0to7C: 6 }),
+    })
+  const peas: Planting = {
+    id: 'peas-1',
+    plantId: 'peas',
+    sowDate: `${YEAR}-03-10`,
+    sowMethod: 'outdoor',
+  }
+
+  it('flags an outdoor sowing into too-cold soil, with the recovery date and germination interval', () => {
+    const germinated: CareLogEntry = {
+      id: 'g1',
+      type: 'germinated',
+      date: `${YEAR}-04-03`,
+      plantingId: 'peas-1',
+    }
+    const findings = evaluateSeason(
+      makeInput({
+        weather: coldMarchWeather(),
+        seasonRecord: makeSeasonRecord([peas], [germinated]),
+      })
+    )
+    const [finding] = byRule(findings, 'cold-soil-sowing')
+    expect(finding).toBeDefined()
+    expect(finding.severity).toBe('warning')
+    expect(finding.summary).toContain('3.5°C')
+    expect(finding.summary).toContain('22 days later')
+    expect(finding.summary).toContain('Germination took 24 days (typically ~10)')
+    expect(finding.metrics).toMatchObject({
+      sowDate: `${YEAR}-03-10`,
+      soilTempAtSowC: 3.5,
+      minSoilTempGerminationC: 5,
+      soilReachedThresholdOn: `${YEAR}-04-01`,
+      daysUntilSoilReached: 22,
+      actualDaysToGerminate: 24,
+      typicalDaysToGerminate: 10,
+    })
+    expect(finding.entities[0]).toMatchObject({
+      areaId: 'bed-a',
+      areaName: 'Bed A',
+      plantingId: 'peas-1',
+      plantId: 'peas',
+    })
+    // The same planting is not double-reported by slow-germination.
+    expect(byRule(findings, 'slow-germination')).toEqual([])
+  })
+
+  it('stays silent when the soil was warm enough at sowing', () => {
+    const findings = evaluateSeason(
+      makeInput({
+        weather: buildWeather(), // 10°C soil everywhere
+        seasonRecord: makeSeasonRecord([peas]),
+      })
+    )
+    expect(byRule(findings, 'cold-soil-sowing')).toEqual([])
+  })
+
+  it('stays silent for indoor sowings and when the sow-date soil reading is missing', () => {
+    const indoor: Planting = { ...peas, id: 'peas-2', sowMethod: 'indoor' }
+    const noReading = buildWeather({ [`${YEAR}-03-10`]: { soilTempMean0to7C: null } })
+    const findings = evaluateSeason(
+      makeInput({
+        weather: noReading,
+        seasonRecord: makeSeasonRecord([indoor, { ...peas, id: 'peas-3' }]),
+      })
+    )
+    expect(byRule(findings, 'cold-soil-sowing')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// R2 slow-germination
+// ---------------------------------------------------------------------------
+
+describe('rule: slow-germination', () => {
+  it('flags germination far beyond typical (works without weather)', () => {
+    // Carrots typically germinate in ~16 days; 30 days ≥ 1.5× and ≥ +5.
+    const carrot: Planting = { id: 'c1', plantId: 'carrot', sowDate: `${YEAR}-04-01`, sowMethod: 'outdoor' }
+    const log: CareLogEntry = { id: 'g1', type: 'germinated', date: `${YEAR}-05-01`, plantingId: 'c1' }
+    const findings = evaluateSeason(makeInput({ seasonRecord: makeSeasonRecord([carrot], [log]) }))
+    const [finding] = byRule(findings, 'slow-germination')
+    expect(finding).toBeDefined()
+    expect(finding.severity).toBe('notice')
+    expect(finding.metrics).toMatchObject({ actualDaysToGerminate: 30, typicalDaysToGerminate: 16 })
+  })
+
+  it('stays silent for germination within the normal range', () => {
+    const carrot: Planting = { id: 'c1', plantId: 'carrot', sowDate: `${YEAR}-04-01` }
+    const log: CareLogEntry = { id: 'g1', type: 'germinated', date: `${YEAR}-04-19`, plantingId: 'c1' }
+    const findings = evaluateSeason(makeInput({ seasonRecord: makeSeasonRecord([carrot], [log]) }))
+    expect(byRule(findings, 'slow-germination')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// R3 frost-after-tender-planting
+// ---------------------------------------------------------------------------
+
+describe('rule: frost-after-tender-planting', () => {
+  it('flags a frost shortly after a tender crop went outside', () => {
+    const courgette: Planting = { id: 'z1', plantId: 'courgette', transplantDate: `${YEAR}-05-05` }
+    const weather = buildWeather({ [`${YEAR}-05-12`]: { tempMinC: -1.3 } })
+    const findings = evaluateSeason(
+      makeInput({ weather, seasonRecord: makeSeasonRecord([courgette]) })
+    )
+    const [finding] = byRule(findings, 'frost-after-tender-planting')
+    expect(finding).toBeDefined()
+    expect(finding.severity).toBe('warning')
+    expect(finding.summary).toContain('12 May')
+    expect(finding.metrics).toMatchObject({ firstFrostDate: `${YEAR}-05-12`, minTempC: -1.3, frostDays: 1 })
+  })
+
+  it('stays silent for frost-tolerant crops and frosts outside the window', () => {
+    const peas: Planting = { id: 'p1', plantId: 'peas', sowDate: `${YEAR}-03-10`, sowMethod: 'outdoor' }
+    const courgette: Planting = { id: 'z1', plantId: 'courgette', transplantDate: `${YEAR}-05-05` }
+    // Frost in March (before courgettes were out) and late August (past the 45-day window).
+    const weather = buildWeather({
+      [`${YEAR}-03-12`]: { tempMinC: -2 },
+      [`${YEAR}-08-20`]: { tempMinC: -1 },
+    })
+    const findings = evaluateSeason(
+      makeInput({ weather, seasonRecord: makeSeasonRecord([peas, courgette]) })
+    )
+    expect(byRule(findings, 'frost-after-tender-planting')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// R4 heat-stress
+// ---------------------------------------------------------------------------
+
+describe('rule: heat-stress', () => {
+  const lettuce: Planting = {
+    id: 'l1',
+    plantId: 'lettuce',
+    transplantDate: `${YEAR}-06-01`,
+    endedOn: `${YEAR}-07-31`,
+  }
+  // Lettuce stresses at 24°C.
+  const hotJune = () =>
+    buildWeather({
+      [`${YEAR}-06-10`]: { tempMaxC: 25 },
+      [`${YEAR}-06-11`]: { tempMaxC: 26 },
+      [`${YEAR}-06-12`]: { tempMaxC: 27 },
+      [`${YEAR}-07-02`]: { tempMaxC: 24 },
+    })
+
+  it('flags enough hot days for a heat-sensitive crop', () => {
+    const findings = evaluateSeason(
+      makeInput({ weather: hotJune(), seasonRecord: makeSeasonRecord([lettuce]) })
+    )
+    const [finding] = byRule(findings, 'heat-stress')
+    expect(finding).toBeDefined()
+    expect(finding.severity).toBe('notice')
+    expect(finding.metrics).toMatchObject({ heatStressDays: 4, heatStressTempC: 24 })
+  })
+
+  it('escalates to warning when bolting was logged in the window', () => {
+    const bolted: CareLogEntry = { id: 'b1', type: 'bolted', date: `${YEAR}-07-05`, plantingId: 'l1' }
+    const findings = evaluateSeason(
+      makeInput({ weather: hotJune(), seasonRecord: makeSeasonRecord([lettuce], [bolted]) })
+    )
+    const [finding] = byRule(findings, 'heat-stress')
+    expect(finding.severity).toBe('warning')
+    expect(finding.summary).toContain('bolting on 5 Jul')
+    expect(finding.metrics.boltedOn).toBe(`${YEAR}-07-05`)
+  })
+
+  it('stays silent below the day-count threshold and after the planting ended', () => {
+    // Two hot days in the window; a third scorcher lands after endedOn.
+    const weather = buildWeather({
+      [`${YEAR}-06-10`]: { tempMaxC: 25 },
+      [`${YEAR}-06-11`]: { tempMaxC: 26 },
+      [`${YEAR}-08-10`]: { tempMaxC: 30 },
+    })
+    const findings = evaluateSeason(
+      makeInput({ weather, seasonRecord: makeSeasonRecord([lettuce]) })
+    )
+    expect(byRule(findings, 'heat-stress')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// R5/R6/R10 monthly anomalies vs baseline
+// ---------------------------------------------------------------------------
+
+describe('rules: monthly anomalies vs baseline', () => {
+  it('flags a month markedly colder than the baseline', () => {
+    const weather = buildWeather(overrideRange(`${YEAR}-06-01`, `${YEAR}-06-30`, { tempMeanC: 10.2 }))
+    const findings = evaluateSeason(makeInput({ weather, baseline: makeBaseline() }))
+    const june = byRule(findings, 'temp-anomaly').find((f) => f.metrics.month === 6)
+    expect(june).toBeDefined()
+    expect(june?.summary).toBe(
+      'June averaged 10.2°C — 1.8°C below your 10-year average of 12°C.'
+    )
+    expect(june?.severity).toBe('info')
+  })
+
+  it('flags a much drier month as a notice and a much wetter one as info', () => {
+    const weather = buildWeather({
+      ...overrideRange(`${YEAR}-06-01`, `${YEAR}-06-30`, { precipitationMm: 1 }),
+      ...overrideRange(`${YEAR}-08-01`, `${YEAR}-08-31`, { precipitationMm: 4 }),
+    })
+    const findings = evaluateSeason(makeInput({ weather, baseline: makeBaseline() }))
+    const june = byRule(findings, 'rain-anomaly').find((f) => f.metrics.month === 6)
+    const august = byRule(findings, 'rain-anomaly').find((f) => f.metrics.month === 8)
+    expect(june?.severity).toBe('notice')
+    expect(june?.summary).toContain('drier')
+    expect(june?.metrics).toMatchObject({ actualRainMm: 30, baselineRainMm: 62 })
+    expect(august?.severity).toBe('info')
+    expect(august?.summary).toContain('wetter')
+  })
+
+  it('flags a notably dull summer month', () => {
+    const weather = buildWeather(overrideRange(`${YEAR}-06-01`, `${YEAR}-06-30`, { sunshineHours: 2 }))
+    const findings = evaluateSeason(makeInput({ weather, baseline: makeBaseline() }))
+    const [finding] = byRule(findings, 'dull-month')
+    expect(finding).toBeDefined()
+    expect(finding.metrics).toMatchObject({ month: 6, actualSunshineHours: 60, baselineSunshineHours: 155 })
+    expect(finding.summary).toContain('less sunshine')
+  })
+
+  it('emits no anomaly findings when weather matches the baseline, or without a baseline', () => {
+    expect(
+      evaluateSeason(makeInput({ weather: buildWeather(), baseline: makeBaseline() }))
+    ).toEqual([])
+    expect(
+      evaluateSeason(
+        makeInput({
+          weather: buildWeather(overrideRange(`${YEAR}-06-01`, `${YEAR}-06-30`, { tempMeanC: 2 })),
+        })
+      )
+    ).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// R7 dry-spell
+// ---------------------------------------------------------------------------
+
+describe('rule: dry-spell', () => {
+  const drySummer = () =>
+    buildWeather(overrideRange(`${YEAR}-07-02`, `${YEAR}-07-19`, { precipitationMm: 0.1 }))
+  const water = (id: string, date: string): CareLogEntry => ({ id, type: 'water', date })
+
+  it('reports a growing-season dry spell with the watering logs during it', () => {
+    const logs = [
+      water('w1', `${YEAR}-07-05`),
+      water('w2', `${YEAR}-07-10`),
+      water('w3', `${YEAR}-07-15`),
+      water('w4', `${YEAR}-07-18`),
+    ]
+    const findings = evaluateSeason(
+      makeInput({ weather: drySummer(), seasonRecord: makeSeasonRecord([], logs) })
+    )
+    const [finding] = byRule(findings, 'dry-spell')
+    expect(finding).toBeDefined()
+    expect(finding.severity).toBe('notice')
+    expect(finding.summary).toContain('18-day dry spell')
+    expect(finding.summary).toContain('watering 4 times')
+    expect(finding.metrics).toMatchObject({ lengthDays: 18, totalRainMm: 1.8, wateringsLogged: 4 })
+  })
+
+  it('escalates when the season has watering logs but none during the spell', () => {
+    const logs = [water('w1', `${YEAR}-05-01`)]
+    const findings = evaluateSeason(
+      makeInput({ weather: drySummer(), seasonRecord: makeSeasonRecord([], logs) })
+    )
+    const [finding] = byRule(findings, 'dry-spell')
+    expect(finding.severity).toBe('warning')
+    expect(finding.summary).toContain('No watering was logged')
+  })
+
+  it('never comments on watering when the user logs no watering at all', () => {
+    const findings = evaluateSeason(
+      makeInput({ weather: drySummer(), seasonRecord: makeSeasonRecord([]) })
+    )
+    const [finding] = byRule(findings, 'dry-spell')
+    expect(finding.severity).toBe('notice')
+    expect(finding.summary).not.toContain('watering')
+    expect(finding.metrics.wateringsLogged).toBeUndefined()
+  })
+
+  it('ignores dry spells outside the growing season', () => {
+    const winterDry = buildWeather(
+      overrideRange(`${YEAR}-01-05`, `${YEAR}-01-25`, { precipitationMm: 0 })
+    )
+    const findings = evaluateSeason(makeInput({ weather: winterDry }))
+    expect(byRule(findings, 'dry-spell')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// R8 water-deficit
+// ---------------------------------------------------------------------------
+
+describe('rule: water-deficit', () => {
+  it('flags a summer month where ET0 far outran rainfall', () => {
+    // Rain stays at 2mm/day but never a dry spell; ET0 climbs to 5mm/day.
+    const weather = buildWeather(overrideRange(`${YEAR}-07-01`, `${YEAR}-07-31`, { et0Mm: 5 }))
+    const findings = evaluateSeason(makeInput({ weather }))
+    const [finding] = byRule(findings, 'water-deficit')
+    expect(finding).toBeDefined()
+    expect(finding.metrics).toMatchObject({ month: 7, rainMm: 62, et0Mm: 155, balanceMm: -93 })
+    expect(finding.summary).toContain('93mm deficit')
+  })
+
+  it('stays silent when the balance is mild or coverage is thin', () => {
+    const mild = evaluateSeason(makeInput({ weather: buildWeather() }))
+    expect(byRule(mild, 'water-deficit')).toEqual([])
+    const gappy = buildWeather({
+      ...overrideRange(`${YEAR}-07-01`, `${YEAR}-07-31`, { et0Mm: 5 }),
+      ...overrideRange(`${YEAR}-07-01`, `${YEAR}-07-10`, { et0Mm: null }),
+    })
+    expect(byRule(evaluateSeason(makeInput({ weather: gappy })), 'water-deficit')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// R9 pest-disease-cluster
+// ---------------------------------------------------------------------------
+
+describe('rule: pest-disease-cluster', () => {
+  const pest = (id: string, date: string, severity?: 1 | 2 | 3): CareLogEntry => ({
+    id,
+    type: 'pest',
+    date,
+    ...(severity ? { severity } : {}),
+  })
+
+  it('flags 3+ same-type observations in one bed within 30 days (no weather needed)', () => {
+    const logs = [
+      pest('p1', `${YEAR}-06-03`, 1),
+      pest('p2', `${YEAR}-06-12`, 2),
+      pest('p3', `${YEAR}-06-28`, 2),
+    ]
+    const findings = evaluateSeason(makeInput({ seasonRecord: makeSeasonRecord([], logs) }))
+    const [finding] = byRule(findings, 'pest-disease-cluster')
+    expect(finding).toBeDefined()
+    expect(finding.severity).toBe('notice')
+    expect(finding.summary).toContain('3 pest observations')
+    expect(finding.summary).toContain('Bed A')
+    expect(finding.metrics).toMatchObject({ observationCount: 3, maxSeverity: 2 })
+  })
+
+  it('escalates to warning when any observation was severe', () => {
+    const logs = [
+      pest('p1', `${YEAR}-06-03`, 1),
+      pest('p2', `${YEAR}-06-12`, 3),
+      pest('p3', `${YEAR}-06-20`, 1),
+    ]
+    const findings = evaluateSeason(makeInput({ seasonRecord: makeSeasonRecord([], logs) }))
+    expect(byRule(findings, 'pest-disease-cluster')[0]?.severity).toBe('warning')
+  })
+
+  it('does not mix types or count logs spread beyond the window', () => {
+    const logs = [
+      pest('p1', `${YEAR}-04-01`),
+      pest('p2', `${YEAR}-06-01`),
+      pest('p3', `${YEAR}-08-01`),
+      { id: 'd1', type: 'disease', date: `${YEAR}-06-02` } as CareLogEntry,
+      { id: 'd2', type: 'disease', date: `${YEAR}-06-03` } as CareLogEntry,
+    ]
+    const findings = evaluateSeason(makeInput({ seasonRecord: makeSeasonRecord([], logs) }))
+    expect(byRule(findings, 'pest-disease-cluster')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Engine behaviour
+// ---------------------------------------------------------------------------
+
+describe('evaluateSeason', () => {
+  it('emits nothing for a sparse season: plantings without dates, no logs, no weather, no baseline', () => {
+    const undated: Planting = { id: 'u1', plantId: 'peas' }
+    const findings = evaluateSeason(makeInput({ seasonRecord: makeSeasonRecord([undated]) }))
+    expect(findings).toEqual([])
+  })
+
+  it('emits nothing when there is no data at all', () => {
+    expect(evaluateSeason(makeInput())).toEqual([])
+  })
+
+  it('orders findings most severe first', () => {
+    const findings: Finding[] = [
+      { id: 'a', ruleId: 'r', severity: 'info', summary: '', metrics: {}, entities: [] },
+      { id: 'b', ruleId: 'r', severity: 'warning', summary: '', metrics: {}, entities: [] },
+      { id: 'c', ruleId: 'r', severity: 'notice', summary: '', metrics: {}, entities: [] },
+    ]
+    expect(sortFindings(findings).map((f) => f.severity)).toEqual(['warning', 'notice', 'info'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Per-planting metrics for the review page
+// ---------------------------------------------------------------------------
+
+describe('computePlantingMetrics', () => {
+  it('computes soil-at-sow, GDD and germination for a dated planting', () => {
+    const peas: Planting = {
+      id: 'p1',
+      plantId: 'peas',
+      sowDate: `${YEAR}-04-01`,
+      sowMethod: 'outdoor',
+      endedOn: `${YEAR}-04-30`,
+    }
+    const log: CareLogEntry = { id: 'g1', type: 'germinated', date: `${YEAR}-04-11`, plantingId: 'p1' }
+    const [metrics] = computePlantingMetrics(
+      makeInput({ weather: buildWeather(), seasonRecord: makeSeasonRecord([peas], [log]) })
+    )
+    expect(metrics).toMatchObject({
+      plantingId: 'p1',
+      areaName: 'Bed A',
+      soilTempAtSowC: 10,
+      gddBaseTempC: 5,
+      typicalDaysToGerminate: 10,
+    })
+    // 30 days (1–30 Apr inclusive) × (12 − 5).
+    expect(metrics.gdd).toEqual({ gdd: 210, daysWithData: 30, windowDays: 30 })
+    expect(metrics.germination?.days).toBe(10)
+  })
+
+  it('skips plantings with no dates this year and degrades without weather', () => {
+    const undated: Planting = { id: 'u1', plantId: 'peas' }
+    const dated: Planting = { id: 'd1', plantId: 'carrot', sowDate: `${YEAR}-04-01`, sowMethod: 'outdoor' }
+    const results = computePlantingMetrics(
+      makeInput({ seasonRecord: makeSeasonRecord([undated, dated]) })
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({ plantingId: 'd1', soilTempAtSowC: null, gdd: null })
+  })
+})

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -27,6 +27,7 @@ import {
   AlertTriangle,
   StickyNote,
   Flower2,
+  BookOpenCheck,
   Camera,
   Check,
   ChevronLeft,
@@ -475,13 +476,21 @@ export default function QuickLogPage() {
         )}
 
         {/* Retroactive capture: rebuild the season from camera-roll photos */}
-        <div className="mt-6">
+        <div className="mt-6 flex flex-col gap-2">
           <Link
             href="/log/import"
             className="inline-flex items-center gap-2 text-sm text-zen-moss-700 hover:text-zen-moss-800 font-medium"
           >
             <Camera className="w-4 h-4" />
             Import observations from photos
+          </Link>
+          {/* The learn half of the loop: what those logs add up to. */}
+          <Link
+            href="/season-review"
+            className="inline-flex items-center gap-2 text-sm text-zen-moss-700 hover:text-zen-moss-800 font-medium"
+          >
+            <BookOpenCheck className="w-4 h-4" />
+            See what this season&apos;s logs show
           </Link>
         </div>
 

--- a/src/app/season-review/page.tsx
+++ b/src/app/season-review/page.tsx
@@ -1,0 +1,426 @@
+'use client'
+
+/**
+ * Season Review — the Season Observer's Phase 2b report page.
+ *
+ * Deterministic rendering only: pick a year, see the season's monthly weather
+ * against the plot's 10-year baseline, the rules-engine findings, and the
+ * per-planting derived metrics. Everything on screen comes from tested pure
+ * functions (src/lib/season-review/) over logs + cached archive weather — no
+ * narration, no LLM (that's the still-open Phase 2c decision), and nothing is
+ * persisted: the review is recomputed on demand.
+ *
+ * Degrades gracefully: no coordinates → log-only findings plus a pointer to
+ * set a location; no cached weather and offline → same; sparse logs → an
+ * honest "nothing confidently worth flagging" empty state.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  AlertTriangle,
+  BookOpenCheck,
+  ChevronLeft,
+  CloudOff,
+  Info,
+  MapPin,
+  Sprout,
+} from 'lucide-react'
+import { useAllotment } from '@/hooks/useAllotment'
+import {
+  fetchSeasonWeather,
+  isValidPlotCoordinates,
+  type PlotCoordinates,
+  type SeasonWeather,
+} from '@/lib/weather/open-meteo-archive'
+import { getBaseline, type WeatherBaseline } from '@/lib/weather/weather-baseline'
+import {
+  computeMonthlyActuals,
+  computeMonthlyAnomalies,
+  type MonthlyAnomaly,
+} from '@/lib/season-review/metrics'
+import {
+  computePlantingMetrics,
+  evaluateSeason,
+  type SeasonReviewInput,
+} from '@/lib/season-review/rules'
+import type { Finding, FindingSeverity } from '@/lib/season-review/findings'
+import { todayLocalISO } from '@/lib/log-date'
+
+const MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
+const SEVERITY_STYLES: Record<FindingSeverity, { card: string; label: string; badge: string }> = {
+  warning: {
+    card: 'border-zen-kitsune-200 bg-zen-kitsune-50',
+    label: 'Worth acting on',
+    badge: 'bg-zen-kitsune-600 text-white',
+  },
+  notice: {
+    card: 'border-zen-stone-200 bg-white',
+    label: 'Worth knowing',
+    badge: 'bg-zen-ink-700 text-white',
+  },
+  info: {
+    card: 'border-zen-stone-200 bg-zen-stone-50',
+    label: 'Context',
+    badge: 'bg-zen-stone-400 text-white',
+  },
+}
+
+type WeatherStatus = 'no-coordinates' | 'loading' | 'ready' | 'unavailable'
+
+function FindingCard({ finding }: { finding: Finding }) {
+  const style = SEVERITY_STYLES[finding.severity]
+  const entityLabels = finding.entities
+    .map((e) => [e.plantName, e.varietyName, e.areaName].filter(Boolean).join(' · '))
+    .filter(Boolean)
+  return (
+    <li className={`rounded-zen border p-4 ${style.card}`}>
+      <div className="flex items-center gap-2 mb-1.5">
+        <span className={`text-[11px] font-medium uppercase tracking-wide px-2 py-0.5 rounded-full ${style.badge}`}>
+          {style.label}
+        </span>
+        {entityLabels.map((label) => (
+          <span key={label} className="text-xs text-zen-stone-500 truncate">
+            {label}
+          </span>
+        ))}
+      </div>
+      <p className="text-sm text-zen-ink-800">{finding.summary}</p>
+    </li>
+  )
+}
+
+function formatDelta(delta: number | null, unit: string): string {
+  if (delta === null) return '—'
+  const sign = delta > 0 ? '+' : ''
+  return `${sign}${delta}${unit}`
+}
+
+function MonthlyWeatherTable({ anomalies }: { anomalies: MonthlyAnomaly[] }) {
+  const rows = anomalies.filter(
+    (m) => m.actualTempC !== null || m.actualRainMm !== null || m.actualSunshineHours !== null
+  )
+  if (rows.length === 0) return null
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs text-zen-stone-500 border-b border-zen-stone-200">
+            <th className="py-2 pr-3 font-medium">Month</th>
+            <th className="py-2 pr-3 font-medium">Mean temp</th>
+            <th className="py-2 pr-3 font-medium">vs 10-yr</th>
+            <th className="py-2 pr-3 font-medium">Rain</th>
+            <th className="py-2 pr-3 font-medium">vs 10-yr</th>
+            <th className="py-2 font-medium">Sunshine</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((m) => (
+            <tr key={m.month} className="border-b border-zen-stone-100 last:border-0">
+              <td className="py-2 pr-3 font-medium text-zen-ink-700">{MONTH_NAMES[m.month - 1]}</td>
+              <td className="py-2 pr-3 text-zen-ink-800">
+                {m.actualTempC !== null ? `${m.actualTempC}°C` : '—'}
+              </td>
+              <td className="py-2 pr-3 text-zen-stone-600">{formatDelta(m.tempDeltaC, '°C')}</td>
+              <td className="py-2 pr-3 text-zen-ink-800">
+                {m.actualRainMm !== null ? `${m.actualRainMm}mm` : '—'}
+              </td>
+              <td className="py-2 pr-3 text-zen-stone-600">
+                {m.rainRatio !== null ? `${Math.round(m.rainRatio * 100)}%` : '—'}
+              </td>
+              <td className="py-2 text-zen-ink-800">
+                {m.actualSunshineHours !== null ? `${Math.round(m.actualSunshineHours)}h` : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default function SeasonReviewPage() {
+  const { data, isLoading, getYears, getAllAreas } = useAllotment()
+
+  const currentCalendarYear = Number(todayLocalISO().slice(0, 4))
+  // Reviewable years: seasons that exist and aren't in the future.
+  const years = useMemo(
+    () => getYears().filter((y) => y <= currentCalendarYear).sort((a, b) => b - a),
+    [getYears, currentCalendarYear]
+  )
+  const [year, setYear] = useState<number | null>(null)
+  const selectedReviewYear = year ?? years[0] ?? null
+
+  const coordinates: PlotCoordinates | null = useMemo(() => {
+    const coords = data?.meta.coordinates
+    return isValidPlotCoordinates(coords) ? coords : null
+  }, [data?.meta.coordinates])
+
+  const [weatherStatus, setWeatherStatus] = useState<WeatherStatus>('loading')
+  const [weather, setWeather] = useState<SeasonWeather | null>(null)
+  const [baseline, setBaseline] = useState<WeatherBaseline | null>(null)
+
+  useEffect(() => {
+    if (isLoading || selectedReviewYear === null) return
+    if (!coordinates) {
+      setWeatherStatus('no-coordinates')
+      setWeather(null)
+      setBaseline(null)
+      return
+    }
+    let cancelled = false
+    setWeatherStatus('loading')
+    // Both are cache-first: a previously-reviewed season costs no network.
+    Promise.all([
+      fetchSeasonWeather(coordinates, selectedReviewYear),
+      getBaseline(coordinates),
+    ]).then(([season, base]) => {
+      if (cancelled) return
+      setWeather(season)
+      setBaseline(base)
+      setWeatherStatus(season ? 'ready' : 'unavailable')
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isLoading, coordinates, selectedReviewYear])
+
+  const input: SeasonReviewInput | null = useMemo(() => {
+    if (!data || selectedReviewYear === null) return null
+    return {
+      year: selectedReviewYear,
+      areas: getAllAreas(),
+      seasonRecord: data.seasons.find((s) => s.year === selectedReviewYear) ?? null,
+      weather,
+      baseline,
+    }
+  }, [data, selectedReviewYear, getAllAreas, weather, baseline])
+
+  const findings = useMemo(() => (input ? evaluateSeason(input) : []), [input])
+  const plantingMetrics = useMemo(() => (input ? computePlantingMetrics(input) : []), [input])
+  const anomalies = useMemo(() => {
+    if (!weather) return []
+    const actuals = computeMonthlyActuals(weather)
+    if (baseline) return computeMonthlyAnomalies(actuals, baseline)
+    // No baseline: show the season's own numbers with empty comparisons.
+    return actuals.map((a) => ({
+      month: a.month,
+      tempDeltaC: null,
+      actualTempC: a.meanTempC,
+      baselineTempC: null,
+      rainRatio: null,
+      actualRainMm: a.rainfallMm,
+      baselineRainMm: null,
+      sunshineRatio: null,
+      actualSunshineHours: a.sunshineHours,
+      baselineSunshineHours: null,
+    }))
+  }, [weather, baseline])
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-zen-stone-50 flex items-center justify-center">
+        <p className="text-zen-stone-500">Loading…</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-zen-stone-50 zen-texture">
+      <div className="container mx-auto px-4 py-8 max-w-3xl">
+        <header className="mb-6">
+          <div className="flex items-center gap-3 mb-1">
+            <BookOpenCheck className="w-6 h-6 text-zen-moss-600" />
+            <h1 className="text-zen-ink-900">Season Review</h1>
+          </div>
+          <p className="text-zen-stone-500">
+            What your logs and the weather say about the season. Every number is computed —
+            nothing is guessed.
+          </p>
+        </header>
+
+        {years.length === 0 ? (
+          <div className="zen-card p-6 text-center">
+            <Sprout className="w-8 h-8 text-zen-moss-400 mx-auto mb-3" />
+            <p className="text-zen-stone-600 mb-4">
+              There&apos;s no season to review yet. Start planning a year and logging what happens
+              on the plot.
+            </p>
+            <Link href="/allotment" className="zen-btn-primary">
+              Go to Allotment
+            </Link>
+          </div>
+        ) : (
+          <>
+            {/* Year picker */}
+            <section className="mb-6" aria-label="Choose a year">
+              <div className="flex flex-wrap gap-2">
+                {years.map((y) => (
+                  <button
+                    key={y}
+                    onClick={() => setYear(y)}
+                    aria-pressed={y === selectedReviewYear}
+                    className={`min-h-[44px] px-4 rounded-zen text-sm font-medium border transition ${
+                      y === selectedReviewYear
+                        ? 'bg-zen-moss-600 text-white border-zen-moss-600'
+                        : 'bg-white text-zen-ink-700 border-zen-stone-200 hover:bg-zen-stone-50'
+                    }`}
+                  >
+                    {y}
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            {/* Weather availability notes */}
+            {weatherStatus === 'no-coordinates' && (
+              <div
+                role="note"
+                className="mb-6 flex items-start gap-2 rounded-zen bg-zen-water-50 border border-zen-water-200 px-4 py-3 text-sm text-zen-ink-700"
+              >
+                <MapPin className="w-4 h-4 shrink-0 mt-0.5 text-zen-water-600" />
+                <span>
+                  Your allotment has no location set, so this review only uses what you logged.
+                  Allow location on the <Link href="/" className="underline">Today</Link> page to
+                  compare the season against local weather. Your coordinates stay on this device.
+                </span>
+              </div>
+            )}
+            {weatherStatus === 'unavailable' && (
+              <div
+                role="note"
+                className="mb-6 flex items-start gap-2 rounded-zen bg-zen-stone-100 border border-zen-stone-200 px-4 py-3 text-sm text-zen-ink-700"
+              >
+                <CloudOff className="w-4 h-4 shrink-0 mt-0.5 text-zen-stone-500" />
+                <span>
+                  Weather for {selectedReviewYear} isn&apos;t available right now (offline, or not
+                  fetched yet). Findings below use your logs only — reload when online to add
+                  weather.
+                </span>
+              </div>
+            )}
+            {weatherStatus === 'loading' && (
+              <p className="mb-6 text-sm text-zen-stone-500">Fetching the season&apos;s weather…</p>
+            )}
+
+            {/* Findings */}
+            <section className="mb-8" aria-label="Findings">
+              <h2 className="text-sm font-medium text-zen-ink-700 mb-2">
+                Findings {weatherStatus === 'loading' ? '(so far)' : ''}
+              </h2>
+              {findings.length === 0 ? (
+                <div className="zen-card p-5 flex items-start gap-3">
+                  <Info className="w-5 h-5 text-zen-stone-400 shrink-0 mt-0.5" />
+                  <p className="text-sm text-zen-stone-600">
+                    Nothing confidently worth flagging for {selectedReviewYear}. That usually means
+                    a smooth season — or not enough logged sowings, observations and dates for the
+                    rules to work with. The more you <Link href="/log" className="underline">log</Link>,
+                    the more this page can tell you.
+                  </p>
+                </div>
+              ) : (
+                <ul className="space-y-3">
+                  {findings.map((finding) => (
+                    <FindingCard key={finding.id} finding={finding} />
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            {/* Monthly weather vs baseline */}
+            {weather && anomalies.length > 0 && (
+              <section className="zen-card p-4 mb-8" aria-label="Monthly weather">
+                <h2 className="text-sm font-medium text-zen-ink-700 mb-1">
+                  {selectedReviewYear} weather, month by month
+                </h2>
+                <p className="text-xs text-zen-stone-500 mb-3">
+                  {baseline
+                    ? `Compared against your ${baseline.startYear}–${baseline.endYear} averages. Rain shows this year as a percentage of normal.`
+                    : 'A 10-year baseline isn’t available yet, so only this season’s numbers are shown.'}
+                </p>
+                <MonthlyWeatherTable anomalies={anomalies} />
+              </section>
+            )}
+
+            {/* Per-planting metrics */}
+            {plantingMetrics.length > 0 && (
+              <section className="zen-card p-4 mb-8" aria-label="Planting metrics">
+                <h2 className="text-sm font-medium text-zen-ink-700 mb-3">Your plantings</h2>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-xs text-zen-stone-500 border-b border-zen-stone-200">
+                        <th className="py-2 pr-3 font-medium">Crop</th>
+                        <th className="py-2 pr-3 font-medium">Bed</th>
+                        <th className="py-2 pr-3 font-medium">Soil at sowing</th>
+                        <th className="py-2 pr-3 font-medium">Germination</th>
+                        <th className="py-2 font-medium">Growing degree days</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {plantingMetrics.map((p) => (
+                        <tr key={p.plantingId} className="border-b border-zen-stone-100 last:border-0">
+                          <td className="py-2 pr-3 font-medium text-zen-ink-700">
+                            {p.plantName}
+                            {p.varietyName && (
+                              <span className="text-zen-stone-500 font-normal"> · {p.varietyName}</span>
+                            )}
+                          </td>
+                          <td className="py-2 pr-3 text-zen-ink-800">{p.areaName ?? '—'}</td>
+                          <td className="py-2 pr-3 text-zen-ink-800">
+                            {p.soilTempAtSowC !== null ? `${p.soilTempAtSowC}°C` : '—'}
+                          </td>
+                          <td className="py-2 pr-3 text-zen-ink-800">
+                            {p.germination
+                              ? `${p.germination.days} days (typ. ~${p.typicalDaysToGerminate})`
+                              : '—'}
+                          </td>
+                          <td className="py-2 text-zen-ink-800">
+                            {p.gdd ? `${p.gdd.gdd} (base ${p.gddBaseTempC}°C)` : '—'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <p className="text-xs text-zen-stone-400 mt-2 flex items-start gap-1.5">
+                  <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+                  Soil and degree-day figures need a sow or transplant date; germination needs a
+                  &ldquo;Germinated&rdquo; entry in the log. Dashes mean there wasn&apos;t enough
+                  data to compute a number.
+                </p>
+              </section>
+            )}
+          </>
+        )}
+
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <Link
+            href="/log"
+            className="inline-flex items-center gap-1 text-zen-stone-500 hover:text-zen-moss-700"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Back to Quick Log
+          </Link>
+          {/* Open-Meteo data is CC BY 4.0 — attribution with a link is required. */}
+          <span className="text-zen-stone-400">
+            Weather{' '}
+            <a
+              href="https://open-meteo.com/"
+              target="_blank"
+              rel="noreferrer"
+              className="underline hover:text-zen-stone-500"
+            >
+              by Open-Meteo
+            </a>{' '}
+            (CC BY 4.0)
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/season-review/page.tsx
+++ b/src/app/season-review/page.tsx
@@ -83,8 +83,9 @@ function FindingCard({ finding }: { finding: Finding }) {
         <span className={`text-[11px] font-medium uppercase tracking-wide px-2 py-0.5 rounded-full ${style.badge}`}>
           {style.label}
         </span>
-        {entityLabels.map((label) => (
-          <span key={label} className="text-xs text-zen-stone-500 truncate">
+        {entityLabels.map((label, i) => (
+          // Labels can repeat (same crop in two beds) — key by position.
+          <span key={`${finding.id}-entity-${i}`} className="text-xs text-zen-stone-500 truncate">
             {label}
           </span>
         ))}
@@ -176,6 +177,10 @@ export default function SeasonReviewPage() {
     }
     let cancelled = false
     setWeatherStatus('loading')
+    // Drop the previous year's data immediately so findings/anomalies never
+    // render the new season record against stale weather while fetching.
+    setWeather(null)
+    setBaseline(null)
     // Both are cache-first: a previously-reviewed season costs no network.
     Promise.all([
       fetchSeasonWeather(coordinates, selectedReviewYear),
@@ -423,7 +428,7 @@ export default function SeasonReviewPage() {
             <a
               href="https://open-meteo.com/"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="underline hover:text-zen-stone-500"
             >
               by Open-Meteo

--- a/src/app/season-review/page.tsx
+++ b/src/app/season-review/page.tsx
@@ -153,7 +153,9 @@ export default function SeasonReviewPage() {
     [getYears, currentCalendarYear]
   )
   const [year, setYear] = useState<number | null>(null)
-  const selectedReviewYear = year ?? years[0] ?? null
+  // Clamp to the available list so a stale pick (e.g. after the season was
+  // deleted or the data was replaced) falls back to the newest year.
+  const selectedReviewYear = year !== null && years.includes(year) ? year : years[0] ?? null
 
   const coordinates: PlotCoordinates | null = useMemo(() => {
     const coords = data?.meta.coordinates
@@ -178,12 +180,21 @@ export default function SeasonReviewPage() {
     Promise.all([
       fetchSeasonWeather(coordinates, selectedReviewYear),
       getBaseline(coordinates),
-    ]).then(([season, base]) => {
-      if (cancelled) return
-      setWeather(season)
-      setBaseline(base)
-      setWeatherStatus(season ? 'ready' : 'unavailable')
-    })
+    ])
+      .then(([season, base]) => {
+        if (cancelled) return
+        setWeather(season)
+        setBaseline(base)
+        setWeatherStatus(season ? 'ready' : 'unavailable')
+      })
+      // Both services resolve null on failure, but never let a surprise
+      // rejection escape the effect — degrade to the log-only view instead.
+      .catch(() => {
+        if (cancelled) return
+        setWeather(null)
+        setBaseline(null)
+        setWeatherStatus('unavailable')
+      })
     return () => {
       cancelled = true
     }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -53,6 +53,7 @@ const primaryNavLinks = [
 
 // Secondary links shown in "More" dropdown
 export const secondaryLinks = [
+  { href: '/season-review', label: 'Season Review', description: 'What the season’s logs & weather show' },
   { href: '/seeds', label: 'Seeds', description: 'Inventory & varieties' },
   { href: '/preserving', label: 'Preserving', description: 'Store & preserve your harvest' },
   { href: '/settings', label: 'Settings', description: 'Sync & preferences' },

--- a/src/lib/season-review/findings.ts
+++ b/src/lib/season-review/findings.ts
@@ -1,0 +1,68 @@
+/**
+ * Season Observer findings (Phase 2b).
+ *
+ * A finding is one deterministic, plain-English observation about the
+ * reviewed season, emitted by the rules engine. Findings are computed on
+ * demand from logs + cached weather — never persisted in the Yjs doc — and
+ * carry the numbers behind them (`metrics`) plus the entities they refer to,
+ * so any future narration layer (Phase 2c) can be checked against them
+ * number-for-number. Coordinates are never part of a finding.
+ */
+
+/**
+ * How much attention a finding deserves.
+ * - info: context worth knowing ("June was warmer than your average").
+ * - notice: probably affected an outcome; worth a different plan next year.
+ * - warning: strong evidence something went wrong for a specific planting/bed.
+ */
+export type FindingSeverity = 'info' | 'notice' | 'warning'
+
+/** What a finding is about. All fields optional — a weather-only finding names no bed. */
+export interface FindingEntity {
+  areaId?: string
+  /** Display name resolved at evaluation time so the UI never re-joins. */
+  areaName?: string
+  plantingId?: string
+  plantId?: string
+  plantName?: string
+  varietyName?: string
+}
+
+/** The date range a finding refers to (ISO dates), when it has one. */
+export interface FindingDates {
+  start?: string
+  end?: string
+}
+
+export interface Finding {
+  /** Stable within a season: `${ruleId}:${year}:${discriminator}`. */
+  id: string
+  /** Which rule produced this finding. */
+  ruleId: string
+  severity: FindingSeverity
+  /** One plain-English sentence, every number sourced from `metrics`. */
+  summary: string
+  /** The tested metric values the summary was built from. */
+  metrics: Record<string, number | string>
+  /** Beds/plantings the finding refers to; empty for plot-wide weather findings. */
+  entities: FindingEntity[]
+  dates?: FindingDates
+}
+
+const SEVERITY_ORDER: Record<FindingSeverity, number> = {
+  warning: 0,
+  notice: 1,
+  info: 2,
+}
+
+/** Sort findings for display: most severe first, then by start date, then id. */
+export function sortFindings(findings: Finding[]): Finding[] {
+  return [...findings].sort((a, b) => {
+    const severity = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]
+    if (severity !== 0) return severity
+    const dateA = a.dates?.start ?? ''
+    const dateB = b.dates?.start ?? ''
+    if (dateA !== dateB) return dateA.localeCompare(dateB)
+    return a.id.localeCompare(b.id)
+  })
+}

--- a/src/lib/season-review/metrics.ts
+++ b/src/lib/season-review/metrics.ts
@@ -36,8 +36,9 @@ function round(value: number, decimals: number): number {
 
 /** Inclusive day count between two ISO dates (same date = 1). */
 export function daySpan(startDate: string, endDate: string): number {
-  const start = Date.parse(`${startDate}T00:00:00Z`)
-  const end = Date.parse(`${endDate}T00:00:00Z`)
+  // Tolerate a full ISO datetime by keeping only the date part.
+  const start = Date.parse(`${startDate.slice(0, 10)}T00:00:00Z`)
+  const end = Date.parse(`${endDate.slice(0, 10)}T00:00:00Z`)
   if (Number.isNaN(start) || Number.isNaN(end)) return 0
   return Math.floor((end - start) / 86_400_000) + 1
 }

--- a/src/lib/season-review/metrics.ts
+++ b/src/lib/season-review/metrics.ts
@@ -1,0 +1,410 @@
+/**
+ * Season Observer derived metrics (Phase 2b).
+ *
+ * Pure functions over a season's daily weather (`SeasonWeather` from the
+ * Open-Meteo archive), the plot's monthly baseline (`WeatherBaseline`), and
+ * the season's logged plantings/care-logs. The rules engine builds every
+ * number in a finding from these functions — nothing in a finding may be
+ * computed anywhere else, so each metric is unit-tested in isolation.
+ *
+ * Missing-data policy (false positives are the failure mode): every metric
+ * returns null — or excludes the day — rather than guessing when coverage is
+ * too thin. Rules then stay silent instead of reporting a number built on a
+ * gap. Coverage thresholds mirror weather-baseline.ts so "this June" and
+ * "your average June" are computed to the same standard.
+ */
+
+import type { SeasonDailyRecord, SeasonWeather } from '@/lib/weather/open-meteo-archive'
+import type { WeatherBaseline } from '@/lib/weather/weather-baseline'
+import type { CareLogEntry, Planting } from '@/types/unified-allotment'
+
+/** Minimum fraction of a window's days with data before a sum/count is trusted. */
+const MIN_WINDOW_COVERAGE = 0.8
+/** Minimum valid days before a month's mean is included (as weather-baseline.ts). */
+const MIN_DAYS_FOR_MEAN = 20
+/** Minimum fraction of a month's days before a monthly total is included (as weather-baseline.ts). */
+const MIN_COVERAGE_FOR_TOTAL = 0.9
+/** A day with at most this much rain (mm) counts as dry for dry-spell detection. */
+const DRY_DAY_MAX_MM = 1
+/** Consecutive days at/above a soil threshold before it counts as "reliably reached". */
+const SOIL_THRESHOLD_RUN_DAYS = 3
+
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals
+  return Math.round(value * factor) / factor
+}
+
+/** Inclusive day count between two ISO dates (same date = 1). */
+export function daySpan(startDate: string, endDate: string): number {
+  const start = Date.parse(`${startDate}T00:00:00Z`)
+  const end = Date.parse(`${endDate}T00:00:00Z`)
+  if (Number.isNaN(start) || Number.isNaN(end)) return 0
+  return Math.floor((end - start) / 86_400_000) + 1
+}
+
+/** Days in `[startDate, endDate]` (inclusive, lexical compare on ISO dates). */
+export function daysInWindow(
+  days: SeasonDailyRecord[],
+  startDate: string,
+  endDate: string
+): SeasonDailyRecord[] {
+  return days.filter((d) => d.date >= startDate && d.date <= endDate)
+}
+
+/**
+ * Daily mean temperature for GDD: prefer the archive's daily mean, fall back
+ * to (max+min)/2 when only the extremes are present.
+ */
+function dailyMeanTemp(day: SeasonDailyRecord): number | null {
+  if (day.tempMeanC !== null) return day.tempMeanC
+  if (day.tempMaxC !== null && day.tempMinC !== null) {
+    return (day.tempMaxC + day.tempMinC) / 2
+  }
+  return null
+}
+
+/** Growing-degree-day accumulation over a window. */
+export interface GddAccumulation {
+  /** Accumulated GDD (°C·days) above the base temperature. */
+  gdd: number
+  /** Days in the window that had usable temperature data. */
+  daysWithData: number
+  /** Total days in the window (inclusive). */
+  windowDays: number
+}
+
+/**
+ * Accumulate GDD (simple average method: max(0, dailyMean − base)) from
+ * startDate to endDate inclusive. Returns null when the window is invalid or
+ * fewer than MIN_WINDOW_COVERAGE of its days carry temperature data — a GDD
+ * total over a gappy window would silently understate growth.
+ */
+export function accumulateGdd(
+  days: SeasonDailyRecord[],
+  baseTempC: number,
+  startDate: string,
+  endDate: string
+): GddAccumulation | null {
+  const windowDays = daySpan(startDate, endDate)
+  if (windowDays <= 0) return null
+  let gdd = 0
+  let daysWithData = 0
+  for (const day of daysInWindow(days, startDate, endDate)) {
+    const mean = dailyMeanTemp(day)
+    if (mean === null) continue
+    daysWithData++
+    gdd += Math.max(0, mean - baseTempC)
+  }
+  if (daysWithData < windowDays * MIN_WINDOW_COVERAGE) return null
+  return { gdd: round(gdd, 0), daysWithData, windowDays }
+}
+
+/** Mean 0–7cm soil temperature on the given date, or null when not recorded. */
+export function soilTempOn(days: SeasonDailyRecord[], date: string): number | null {
+  return days.find((d) => d.date === date)?.soilTempMean0to7C ?? null
+}
+
+/**
+ * First date at/after `fromDate` where the 0–7cm soil temperature stayed at or
+ * above `thresholdC` for SOIL_THRESHOLD_RUN_DAYS consecutive recorded days —
+ * a single warm day doesn't count as the soil "reaching" a germination
+ * threshold. A missing reading breaks the run (conservative: when in doubt,
+ * the threshold was not reached). Returns null when no such run exists.
+ */
+export function firstSoilTempAtOrAbove(
+  days: SeasonDailyRecord[],
+  thresholdC: number,
+  fromDate: string
+): string | null {
+  const window = days.filter((d) => d.date >= fromDate)
+  let runStart: string | null = null
+  let runLength = 0
+  for (const day of window) {
+    if (day.soilTempMean0to7C !== null && day.soilTempMean0to7C >= thresholdC) {
+      if (runLength === 0) runStart = day.date
+      runLength++
+      if (runLength >= SOIL_THRESHOLD_RUN_DAYS) return runStart
+    } else {
+      runStart = null
+      runLength = 0
+    }
+  }
+  return null
+}
+
+/** A run of consecutive dry days (each ≤ DRY_DAY_MAX_MM of rain). */
+export interface DrySpell {
+  start: string
+  end: string
+  lengthDays: number
+  totalRainMm: number
+}
+
+/**
+ * Find dry spells of at least `minLengthDays` consecutive dry days. A day
+ * with no precipitation reading breaks the spell rather than extending it —
+ * a "20-day dry spell" spanning a data gap would be a guess.
+ */
+export function findDrySpells(days: SeasonDailyRecord[], minLengthDays: number): DrySpell[] {
+  const spells: DrySpell[] = []
+  let current: { start: string; end: string; days: number; rain: number } | null = null
+
+  const flush = () => {
+    if (current && current.days >= minLengthDays) {
+      spells.push({
+        start: current.start,
+        end: current.end,
+        lengthDays: current.days,
+        totalRainMm: round(current.rain, 1),
+      })
+    }
+    current = null
+  }
+
+  for (const day of days) {
+    const rain = day.precipitationMm
+    if (rain !== null && rain <= DRY_DAY_MAX_MM) {
+      if (current) {
+        current.end = day.date
+        current.days++
+        current.rain += rain
+      } else {
+        current = { start: day.date, end: day.date, days: 1, rain }
+      }
+    } else {
+      flush()
+    }
+  }
+  flush()
+  return spells
+}
+
+/** Rain vs reference evapotranspiration for one calendar month. */
+export interface MonthlyWaterBalance {
+  month: number
+  rainMm: number
+  et0Mm: number
+  /** rain − ET0; negative means the month lost more water than it received. */
+  balanceMm: number
+}
+
+/**
+ * Simple monthly water balance: total rain minus total FAO ET₀. Returns null
+ * unless both series cover ≥ MIN_COVERAGE_FOR_TOTAL of the month — a partial
+ * total would understate one side of the balance.
+ */
+export function monthlyWaterBalance(
+  season: SeasonWeather,
+  month: number
+): MonthlyWaterBalance | null {
+  const prefix = `${season.year}-${String(month).padStart(2, '0')}-`
+  const monthDays = season.days.filter((d) => d.date.startsWith(prefix))
+  const totalDays = new Date(season.year, month, 0).getDate()
+  const needed = totalDays * MIN_COVERAGE_FOR_TOTAL
+
+  const rain = monthDays.map((d) => d.precipitationMm).filter((v): v is number => v !== null)
+  const et0 = monthDays.map((d) => d.et0Mm).filter((v): v is number => v !== null)
+  if (rain.length < needed || et0.length < needed) return null
+
+  const rainMm = round(rain.reduce((a, b) => a + b, 0), 1)
+  const et0Mm = round(et0.reduce((a, b) => a + b, 0), 1)
+  return { month, rainMm, et0Mm, balanceMm: round(rainMm - et0Mm, 1) }
+}
+
+/** Days at/above a heat threshold inside a window. */
+export interface HeatStressDays {
+  count: number
+  /** Dates that hit the threshold, in order. */
+  dates: string[]
+  daysWithData: number
+  windowDays: number
+}
+
+/**
+ * Count days whose max temperature reached `thresholdC` between startDate and
+ * endDate. Returns null when fewer than MIN_WINDOW_COVERAGE of the window's
+ * days have a max-temperature reading, so a count over a gappy window can't
+ * masquerade as a complete one.
+ */
+export function countHeatStressDays(
+  days: SeasonDailyRecord[],
+  thresholdC: number,
+  startDate: string,
+  endDate: string
+): HeatStressDays | null {
+  const windowDays = daySpan(startDate, endDate)
+  if (windowDays <= 0) return null
+  const dates: string[] = []
+  let daysWithData = 0
+  for (const day of daysInWindow(days, startDate, endDate)) {
+    if (day.tempMaxC === null) continue
+    daysWithData++
+    if (day.tempMaxC >= thresholdC) dates.push(day.date)
+  }
+  if (daysWithData < windowDays * MIN_WINDOW_COVERAGE) return null
+  return { count: dates.length, dates, daysWithData, windowDays }
+}
+
+/** Dates with an air frost (Tmin ≤ 0°C) inside a window, with the coldest. */
+export interface FrostInWindow {
+  dates: string[]
+  /** Coldest Tmin among the frost dates. */
+  minTempC: number
+}
+
+/**
+ * Frost days (Tmin ≤ 0°C) between startDate and endDate inclusive. Missing
+ * Tmin days simply can't contribute a frost — an absence of data never
+ * asserts "no frost", and callers only act when frosts were found.
+ */
+export function frostDaysInWindow(
+  days: SeasonDailyRecord[],
+  startDate: string,
+  endDate: string
+): FrostInWindow | null {
+  const dates: string[] = []
+  let minTempC = Infinity
+  for (const day of daysInWindow(days, startDate, endDate)) {
+    if (day.tempMinC === null) continue
+    if (day.tempMinC <= 0) {
+      dates.push(day.date)
+      minTempC = Math.min(minTempC, day.tempMinC)
+    }
+  }
+  if (dates.length === 0) return null
+  return { dates, minTempC }
+}
+
+/** Actual sow → germination interval for one planting, from the care log. */
+export interface GerminationInterval {
+  sowDate: string
+  germinatedDate: string
+  days: number
+}
+
+/**
+ * Days from a planting's sow date to its earliest `germinated` care-log entry
+ * (matched by plantingId). Returns null when the planting has no sow date or
+ * no germination was logged — never inferred from other entry types.
+ */
+export function daysToGermination(
+  planting: Planting,
+  careLogs: CareLogEntry[]
+): GerminationInterval | null {
+  if (!planting.sowDate) return null
+  const germinated = careLogs
+    .filter(
+      (log) =>
+        log.type === 'germinated' && log.plantingId === planting.id && log.date >= planting.sowDate!
+    )
+    .sort((a, b) => a.date.localeCompare(b.date))[0]
+  if (!germinated) return null
+  return {
+    sowDate: planting.sowDate,
+    germinatedDate: germinated.date,
+    // daySpan is inclusive; sow→germination is the elapsed interval.
+    days: daySpan(planting.sowDate, germinated.date) - 1,
+  }
+}
+
+/** One month of the reviewed season, aggregated to the baseline's standard. */
+export interface MonthlyActual {
+  month: number
+  meanTempC: number | null
+  rainfallMm: number | null
+  sunshineHours: number | null
+}
+
+/**
+ * Aggregate a season's days into monthly actuals using the same coverage
+ * rules as computeBaseline (means need MIN_DAYS_FOR_MEAN days, totals need
+ * MIN_COVERAGE_FOR_TOTAL of the month), so actual-vs-normal comparisons are
+ * like-for-like. Always returns 12 entries; a month without coverage has
+ * null metrics.
+ */
+export function computeMonthlyActuals(season: SeasonWeather): MonthlyActual[] {
+  const actuals: MonthlyActual[] = []
+  for (let month = 1; month <= 12; month++) {
+    const prefix = `${season.year}-${String(month).padStart(2, '0')}-`
+    const monthDays = season.days.filter((d) => d.date.startsWith(prefix))
+    const totalDays = new Date(season.year, month, 0).getDate()
+
+    const temps = monthDays.map((d) => d.tempMeanC).filter((v): v is number => v !== null)
+    const rain = monthDays.map((d) => d.precipitationMm).filter((v): v is number => v !== null)
+    const sun = monthDays.map((d) => d.sunshineHours).filter((v): v is number => v !== null)
+
+    actuals.push({
+      month,
+      meanTempC:
+        temps.length >= MIN_DAYS_FOR_MEAN
+          ? round(temps.reduce((a, b) => a + b, 0) / temps.length, 1)
+          : null,
+      rainfallMm:
+        rain.length >= totalDays * MIN_COVERAGE_FOR_TOTAL
+          ? round(rain.reduce((a, b) => a + b, 0), 1)
+          : null,
+      sunshineHours:
+        sun.length >= totalDays * MIN_COVERAGE_FOR_TOTAL
+          ? round(sun.reduce((a, b) => a + b, 0), 1)
+          : null,
+    })
+  }
+  return actuals
+}
+
+/** One month's deviation from the 10-year baseline. Null = not comparable. */
+export interface MonthlyAnomaly {
+  month: number
+  /** Actual − baseline mean temperature (°C). */
+  tempDeltaC: number | null
+  actualTempC: number | null
+  baselineTempC: number | null
+  /** Actual ÷ baseline rainfall (1 = normal). */
+  rainRatio: number | null
+  actualRainMm: number | null
+  baselineRainMm: number | null
+  /** Actual ÷ baseline sunshine (1 = normal). */
+  sunshineRatio: number | null
+  actualSunshineHours: number | null
+  baselineSunshineHours: number | null
+}
+
+/**
+ * Compare a season's monthly actuals against the baseline normals. Each
+ * metric is only compared when both sides have a value (and, for ratios, the
+ * baseline is meaningfully non-zero); otherwise that metric is null.
+ */
+export function computeMonthlyAnomalies(
+  actuals: MonthlyActual[],
+  baseline: WeatherBaseline
+): MonthlyAnomaly[] {
+  return actuals.map((actual) => {
+    const normal = baseline.months.find((m) => m.month === actual.month)
+    const baselineTempC = normal?.meanTempC ?? null
+    const baselineRainMm = normal?.totalRainfallMm ?? null
+    const baselineSunshineHours = normal?.sunshineHours ?? null
+    return {
+      month: actual.month,
+      tempDeltaC:
+        actual.meanTempC !== null && baselineTempC !== null
+          ? round(actual.meanTempC - baselineTempC, 1)
+          : null,
+      actualTempC: actual.meanTempC,
+      baselineTempC,
+      // A tiny baseline (near-rainless normal month) makes ratios explode;
+      // require at least 5mm of normal rain before publishing a ratio.
+      rainRatio:
+        actual.rainfallMm !== null && baselineRainMm !== null && baselineRainMm >= 5
+          ? round(actual.rainfallMm / baselineRainMm, 2)
+          : null,
+      actualRainMm: actual.rainfallMm,
+      baselineRainMm,
+      sunshineRatio:
+        actual.sunshineHours !== null && baselineSunshineHours !== null && baselineSunshineHours >= 10
+          ? round(actual.sunshineHours / baselineSunshineHours, 2)
+          : null,
+      actualSunshineHours: actual.sunshineHours,
+      baselineSunshineHours,
+    }
+  })
+}

--- a/src/lib/season-review/metrics.ts
+++ b/src/lib/season-review/metrics.ts
@@ -300,11 +300,14 @@ export function daysToGermination(
     )
     .sort((a, b) => a.date.localeCompare(b.date))[0]
   if (!germinated) return null
+  // daySpan is inclusive; sow→germination is the elapsed interval. A span of
+  // 0 means one of the dates was unparseable — missing data, not "-1 days".
+  const span = daySpan(planting.sowDate, germinated.date)
+  if (span <= 0) return null
   return {
     sowDate: planting.sowDate,
     germinatedDate: germinated.date,
-    // daySpan is inclusive; sow→germination is the elapsed interval.
-    days: daySpan(planting.sowDate, germinated.date) - 1,
+    days: span - 1,
   }
 }
 

--- a/src/lib/season-review/rules.ts
+++ b/src/lib/season-review/rules.ts
@@ -114,7 +114,9 @@ function collectPlantings(input: SeasonReviewInput): PlantingContext[] {
   for (const areaSeason of input.seasonRecord.areas) {
     const area = input.areas.find((a) => a.id === areaSeason.areaId)
     const careLogs = areaSeason.careLogs ?? []
-    for (const planting of areaSeason.plantings) {
+    // plantings is required by the type, but season records travel through
+    // migration/CRDT merges — guard like careLogs rather than crash.
+    for (const planting of areaSeason.plantings ?? []) {
       contexts.push({
         planting,
         area,
@@ -487,9 +489,11 @@ function ruleDrySpell(input: SeasonReviewInput): Finding[] {
   )
   if (spells.length === 0) return []
 
+  // Only this year's watering logs count — an out-of-year entry (backdated
+  // mistake, copied log) must not make "no watering was logged" fire falsely.
   const waterLogs = (input.seasonRecord?.areas ?? [])
     .flatMap((areaSeason) => areaSeason.careLogs ?? [])
-    .filter((log) => log.type === 'water')
+    .filter((log) => log.type === 'water' && isInYear(log.date, input.year))
 
   return spells.map((spell) => {
     const waterings = waterLogs.filter((log) => log.date >= spell.start && log.date <= spell.end)
@@ -570,12 +574,13 @@ function rulePestDiseaseCluster(input: SeasonReviewInput): Finding[] {
         .sort((a, b) => a.date.localeCompare(b.date))
       if (logs.length < CLUSTER_MIN_LOGS) continue
 
-      // Find the largest run of logs that fits a CLUSTER_WINDOW_DAYS window.
+      // Find the largest run of logs that fits a CLUSTER_WINDOW_DAYS window —
+      // a sliding window over the date-sorted logs.
       let best: CareLogEntry[] = []
-      for (let i = 0; i < logs.length; i++) {
-        const windowLimit = addDaysISO(logs[i].date, CLUSTER_WINDOW_DAYS - 1)
-        const run = logs.filter((log) => log.date >= logs[i].date && log.date <= windowLimit)
-        if (run.length > best.length) best = run
+      let lo = 0
+      for (let hi = 0; hi < logs.length; hi++) {
+        while (daySpan(logs[lo].date, logs[hi].date) > CLUSTER_WINDOW_DAYS) lo++
+        if (hi - lo + 1 > best.length) best = logs.slice(lo, hi + 1)
       }
       if (best.length < CLUSTER_MIN_LOGS) continue
 

--- a/src/lib/season-review/rules.ts
+++ b/src/lib/season-review/rules.ts
@@ -1,0 +1,732 @@
+/**
+ * Season Observer rules engine (Phase 2b).
+ *
+ * Deterministic rules over the derived metrics (metrics.ts), the crop
+ * agronomy reference (agronomy.ts), and the season's logged plantings and
+ * care logs. `evaluateSeason` emits a structured findings[] array — no LLM,
+ * no heuristics beyond the documented thresholds.
+ *
+ * The failure mode is a false positive: a wrong "your peas struggled" erodes
+ * trust in every other finding. So every rule stays silent unless its inputs
+ * are complete — missing weather, a planting without dates, a metric that
+ * returned null for thin coverage, all mean "no finding", never a guess.
+ * Every number in a summary comes from a tested metric function or the
+ * agronomy table.
+ */
+
+import { getCropAgronomy, type CropAgronomy } from '@/lib/agronomy'
+import { getVegetableById } from '@/lib/vegetable-database'
+import type { SeasonWeather } from '@/lib/weather/open-meteo-archive'
+import type { WeatherBaseline } from '@/lib/weather/weather-baseline'
+import type {
+  Area,
+  CareLogEntry,
+  Planting,
+  SeasonRecord,
+} from '@/types/unified-allotment'
+import type { Finding, FindingEntity } from './findings'
+import { sortFindings } from './findings'
+import {
+  accumulateGdd,
+  computeMonthlyActuals,
+  computeMonthlyAnomalies,
+  countHeatStressDays,
+  daySpan,
+  daysToGermination,
+  findDrySpells,
+  firstSoilTempAtOrAbove,
+  frostDaysInWindow,
+  monthlyWaterBalance,
+  soilTempOn,
+  type GddAccumulation,
+  type GerminationInterval,
+} from './metrics'
+
+// ---------------------------------------------------------------------------
+// Thresholds. Each is the line between "normal season noise" and "worth a
+// finding" — deliberately conservative, and in one place so they're easy to
+// tune as real seasons calibrate them.
+// ---------------------------------------------------------------------------
+
+/** Soil must be at least this far (°C) below the crop's minimum to flag a sowing. */
+const COLD_SOIL_MARGIN_C = 1
+/** Germination must take ≥ typical × this AND ≥ typical + 5 days to flag. */
+const SLOW_GERMINATION_RATIO = 1.5
+const SLOW_GERMINATION_MIN_EXTRA_DAYS = 5
+/** Days after planting-out during which a frost counts as "caught the young plant". */
+const TENDER_FROST_WINDOW_DAYS = 45
+/** Heat-stress days within a planting's window before it's worth reporting. */
+const MIN_HEAT_STRESS_DAYS = 3
+/** Monthly mean temperature must deviate ≥ this (°C) from baseline to flag. */
+const TEMP_ANOMALY_C = 1.5
+/** Month rainfall ≤ this fraction of baseline = notably dry. */
+const DRY_MONTH_RATIO = 0.5
+/** Month rainfall ≥ this multiple of baseline = notably wet. */
+const WET_MONTH_RATIO = 1.8
+/** Month sunshine ≤ this fraction of baseline = notably dull. */
+const DULL_MONTH_RATIO = 0.7
+/** Consecutive dry days before a spell is reported. */
+const DRY_SPELL_MIN_DAYS = 14
+/** Monthly rain − ET0 at or below this (mm) = notable water deficit. */
+const WATER_DEFICIT_MM = -60
+/** Pest/disease logs of one type in one bed within this window = a cluster. */
+const CLUSTER_WINDOW_DAYS = 30
+const CLUSTER_MIN_LOGS = 3
+/** Growing-season months (inclusive) for plot-wide monthly findings. */
+const GROWING_SEASON_START_MONTH = 3
+const GROWING_SEASON_END_MONTH = 10
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+
+// ---------------------------------------------------------------------------
+// Input assembly
+// ---------------------------------------------------------------------------
+
+/** Everything the engine reasons over. Any piece may be missing. */
+export interface SeasonReviewInput {
+  /** The calendar year under review. */
+  year: number
+  /** All areas, for resolving bed names. */
+  areas: Area[]
+  /** The season record for `year` (plantings + care logs), if one exists. */
+  seasonRecord: SeasonRecord | null
+  /** Archived daily weather for `year`, if cached/fetchable. */
+  weather: SeasonWeather | null
+  /** The plot's 10-year monthly baseline, if computable. */
+  baseline: WeatherBaseline | null
+}
+
+/** One planting joined with its bed and the bed's care logs for the year. */
+interface PlantingContext {
+  planting: Planting
+  area: Area | undefined
+  areaId: string
+  careLogs: CareLogEntry[]
+  agronomy: CropAgronomy
+}
+
+function collectPlantings(input: SeasonReviewInput): PlantingContext[] {
+  if (!input.seasonRecord) return []
+  const contexts: PlantingContext[] = []
+  for (const areaSeason of input.seasonRecord.areas) {
+    const area = input.areas.find((a) => a.id === areaSeason.areaId)
+    const careLogs = areaSeason.careLogs ?? []
+    for (const planting of areaSeason.plantings) {
+      contexts.push({
+        planting,
+        area,
+        areaId: areaSeason.areaId,
+        careLogs,
+        agronomy: getCropAgronomy(planting.plantId),
+      })
+    }
+  }
+  return contexts
+}
+
+function plantingEntity(ctx: PlantingContext): FindingEntity {
+  return {
+    areaId: ctx.areaId,
+    areaName: ctx.area?.name,
+    plantingId: ctx.planting.id,
+    plantId: ctx.planting.plantId,
+    plantName: plantName(ctx.planting.plantId),
+    varietyName: ctx.planting.varietyName,
+  }
+}
+
+function plantName(plantId: string): string {
+  return getVegetableById(plantId)?.name ?? plantId
+}
+
+/** "2026-05-12" → "12 May". Fixed English month names — no locale surprises. */
+function formatDay(isoDate: string): string {
+  const month = Number(isoDate.slice(5, 7))
+  const day = Number(isoDate.slice(8, 10))
+  return `${day} ${MONTH_NAMES[month - 1]?.slice(0, 3) ?? '?'}`
+}
+
+function addDaysISO(isoDate: string, days: number): string {
+  const ms = Date.parse(`${isoDate}T00:00:00Z`) + days * 86_400_000
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
+function isInYear(date: string | undefined, year: number): date is string {
+  return typeof date === 'string' && date.startsWith(`${year}-`)
+}
+
+/**
+ * The date a planting first faced outdoor weather this year: its sow date
+ * when direct-sown, otherwise its transplant date. Null when neither applies
+ * to the reviewed year — weather rules then stay silent for the planting.
+ */
+function outdoorExposureDate(planting: Planting, year: number): string | null {
+  if (planting.sowMethod === 'outdoor' && isInYear(planting.sowDate, year)) {
+    return planting.sowDate
+  }
+  if (isInYear(planting.transplantDate, year)) {
+    return planting.transplantDate
+  }
+  return null
+}
+
+/** When a planting stopped facing the weather: ended, last harvest, or last weather day. */
+function windowEnd(planting: Planting, weather: SeasonWeather): string | null {
+  const lastWeatherDay = weather.days[weather.days.length - 1]?.date
+  if (!lastWeatherDay) return null
+  const end = planting.endedOn ?? planting.actualHarvestEnd ?? lastWeatherDay
+  return end < lastWeatherDay ? end : lastWeatherDay
+}
+
+// ---------------------------------------------------------------------------
+// Rules — each takes the input plus shared context and returns findings.
+// ---------------------------------------------------------------------------
+
+/**
+ * R1 cold-soil-sowing (warning): a crop was direct-sown outdoors while the
+ * 0–7cm soil was more than COLD_SOIL_MARGIN_C below its minimum germination
+ * temperature. Reports when the soil actually reached the threshold and, if
+ * germination was logged, actual vs typical days.
+ */
+function ruleColdSoilSowing(
+  input: SeasonReviewInput,
+  plantings: PlantingContext[],
+  flaggedPlantings: Set<string>
+): Finding[] {
+  if (!input.weather) return []
+  const days = input.weather.days
+  const findings: Finding[] = []
+
+  for (const ctx of plantings) {
+    const { planting, agronomy } = ctx
+    if (planting.sowMethod !== 'outdoor' || !isInYear(planting.sowDate, input.year)) continue
+    const soilAtSow = soilTempOn(days, planting.sowDate)
+    if (soilAtSow === null) continue
+    const minTemp = agronomy.minSoilTempGerminationC
+    if (soilAtSow > minTemp - COLD_SOIL_MARGIN_C) continue
+
+    const reached = firstSoilTempAtOrAbove(days, minTemp, planting.sowDate)
+    const daysLate = reached ? daySpan(planting.sowDate, reached) - 1 : null
+    const germination = daysToGermination(planting, ctx.careLogs)
+
+    const metrics: Record<string, number | string> = {
+      sowDate: planting.sowDate,
+      soilTempAtSowC: soilAtSow,
+      minSoilTempGerminationC: minTemp,
+    }
+    let summary =
+      `${plantName(planting.plantId)} was sown outdoors on ${formatDay(planting.sowDate)} ` +
+      `when the soil was ${soilAtSow}°C — below the ~${minTemp}°C it needs to germinate.`
+    if (reached && daysLate !== null && daysLate > 0) {
+      metrics.soilReachedThresholdOn = reached
+      metrics.daysUntilSoilReached = daysLate
+      summary += ` The soil didn't reliably reach ${minTemp}°C until ${formatDay(reached)} (${daysLate} days later).`
+    }
+    if (germination) {
+      metrics.actualDaysToGerminate = germination.days
+      metrics.typicalDaysToGerminate = agronomy.typicalDaysToGerminate
+      summary += ` Germination took ${germination.days} days (typically ~${agronomy.typicalDaysToGerminate}).`
+    }
+
+    flaggedPlantings.add(planting.id)
+    findings.push({
+      id: `cold-soil-sowing:${input.year}:${planting.id}`,
+      ruleId: 'cold-soil-sowing',
+      severity: 'warning',
+      summary,
+      metrics,
+      entities: [plantingEntity(ctx)],
+      dates: { start: planting.sowDate, end: reached ?? undefined },
+    })
+  }
+  return findings
+}
+
+/**
+ * R2 slow-germination (notice): germination was logged and took markedly
+ * longer than typical for the crop. Skipped when R1 already explained the
+ * same planting — one story per planting.
+ */
+function ruleSlowGermination(
+  input: SeasonReviewInput,
+  plantings: PlantingContext[],
+  flaggedPlantings: Set<string>
+): Finding[] {
+  const findings: Finding[] = []
+  for (const ctx of plantings) {
+    const { planting, agronomy } = ctx
+    if (flaggedPlantings.has(planting.id)) continue
+    if (!isInYear(planting.sowDate, input.year)) continue
+    const germination = daysToGermination(planting, ctx.careLogs)
+    if (!germination) continue
+    const typical = agronomy.typicalDaysToGerminate
+    if (
+      germination.days < typical * SLOW_GERMINATION_RATIO ||
+      germination.days < typical + SLOW_GERMINATION_MIN_EXTRA_DAYS
+    ) {
+      continue
+    }
+    findings.push({
+      id: `slow-germination:${input.year}:${planting.id}`,
+      ruleId: 'slow-germination',
+      severity: 'notice',
+      summary:
+        `${plantName(planting.plantId)} took ${germination.days} days to germinate ` +
+        `(sown ${formatDay(germination.sowDate)}, germinated ${formatDay(germination.germinatedDate)}) — ` +
+        `typically ~${typical} days.`,
+      metrics: {
+        sowDate: germination.sowDate,
+        germinatedDate: germination.germinatedDate,
+        actualDaysToGerminate: germination.days,
+        typicalDaysToGerminate: typical,
+      },
+      entities: [plantingEntity(ctx)],
+      dates: { start: germination.sowDate, end: germination.germinatedDate },
+    })
+  }
+  return findings
+}
+
+/**
+ * R3 frost-after-tender-planting (warning): a frost-tender crop went outside
+ * and an air frost (Tmin ≤ 0°C) hit within TENDER_FROST_WINDOW_DAYS.
+ */
+function ruleFrostAfterTenderPlanting(
+  input: SeasonReviewInput,
+  plantings: PlantingContext[]
+): Finding[] {
+  if (!input.weather) return []
+  const findings: Finding[] = []
+  for (const ctx of plantings) {
+    const { planting, agronomy } = ctx
+    if (agronomy.frostTolerant) continue
+    const exposure = outdoorExposureDate(planting, input.year)
+    if (!exposure) continue
+    const end = windowEnd(planting, input.weather)
+    if (!end || end < exposure) continue
+    const frostWindowEnd = addDaysISO(exposure, TENDER_FROST_WINDOW_DAYS)
+    const frost = frostDaysInWindow(
+      input.weather.days,
+      exposure,
+      frostWindowEnd < end ? frostWindowEnd : end
+    )
+    if (!frost) continue
+    const firstFrost = frost.dates[0]
+    findings.push({
+      id: `frost-after-tender-planting:${input.year}:${planting.id}`,
+      ruleId: 'frost-after-tender-planting',
+      severity: 'warning',
+      summary:
+        `${plantName(planting.plantId)} is frost-tender and went outside on ${formatDay(exposure)}, ` +
+        `but there was an air frost on ${formatDay(firstFrost)}` +
+        `${frost.dates.length > 1 ? ` (${frost.dates.length} frosts in total)` : ''} ` +
+        `with a low of ${frost.minTempC}°C.`,
+      metrics: {
+        outdoorFrom: exposure,
+        firstFrostDate: firstFrost,
+        frostDays: frost.dates.length,
+        minTempC: frost.minTempC,
+      },
+      entities: [plantingEntity(ctx)],
+      dates: { start: exposure, end: frost.dates[frost.dates.length - 1] },
+    })
+  }
+  return findings
+}
+
+/**
+ * R4 heat-stress (notice; warning when bolting was logged): a heat-sensitive
+ * crop faced ≥ MIN_HEAT_STRESS_DAYS days at/above its stress temperature
+ * while in the ground.
+ */
+function ruleHeatStress(input: SeasonReviewInput, plantings: PlantingContext[]): Finding[] {
+  if (!input.weather) return []
+  const findings: Finding[] = []
+  for (const ctx of plantings) {
+    const { planting, agronomy } = ctx
+    const threshold = agronomy.heatStressTempC
+    if (threshold === undefined) continue
+    const start =
+      isInYear(planting.transplantDate, input.year)
+        ? planting.transplantDate
+        : planting.sowMethod === 'outdoor' && isInYear(planting.sowDate, input.year)
+          ? planting.sowDate
+          : null
+    if (!start) continue
+    const end = windowEnd(planting, input.weather)
+    if (!end || end < start) continue
+    const heat = countHeatStressDays(input.weather.days, threshold, start, end)
+    if (!heat || heat.count < MIN_HEAT_STRESS_DAYS) continue
+
+    const bolted = ctx.careLogs
+      .filter(
+        (log) =>
+          log.type === 'bolted' &&
+          log.plantingId === planting.id &&
+          log.date >= start &&
+          log.date <= end
+      )
+      .sort((a, b) => a.date.localeCompare(b.date))[0]
+
+    const metrics: Record<string, number | string> = {
+      heatStressDays: heat.count,
+      heatStressTempC: threshold,
+      windowStart: start,
+      windowEnd: end,
+    }
+    let summary =
+      `${plantName(planting.plantId)} faced ${heat.count} days at or above ${threshold}°C ` +
+      `between ${formatDay(heat.dates[0])} and ${formatDay(heat.dates[heat.dates.length - 1])}.`
+    if (bolted) {
+      metrics.boltedOn = bolted.date
+      summary += ` You logged it bolting on ${formatDay(bolted.date)}.`
+    }
+    findings.push({
+      id: `heat-stress:${input.year}:${planting.id}`,
+      ruleId: 'heat-stress',
+      severity: bolted ? 'warning' : 'notice',
+      summary,
+      metrics,
+      entities: [plantingEntity(ctx)],
+      dates: { start: heat.dates[0], end: heat.dates[heat.dates.length - 1] },
+    })
+  }
+  return findings
+}
+
+/**
+ * R5 temp-anomaly (info): a growing-season month's mean temperature deviated
+ * ≥ TEMP_ANOMALY_C from the 10-year baseline.
+ */
+function ruleTempAnomaly(input: SeasonReviewInput): Finding[] {
+  if (!input.weather || !input.baseline) return []
+  const anomalies = computeMonthlyAnomalies(computeMonthlyActuals(input.weather), input.baseline)
+  const findings: Finding[] = []
+  for (const anomaly of anomalies) {
+    if (anomaly.month < GROWING_SEASON_START_MONTH || anomaly.month > GROWING_SEASON_END_MONTH) continue
+    if (
+      anomaly.tempDeltaC === null ||
+      anomaly.actualTempC === null ||
+      anomaly.baselineTempC === null ||
+      Math.abs(anomaly.tempDeltaC) < TEMP_ANOMALY_C
+    ) {
+      continue
+    }
+    const direction = anomaly.tempDeltaC > 0 ? 'above' : 'below'
+    findings.push({
+      id: `temp-anomaly:${input.year}:${anomaly.month}`,
+      ruleId: 'temp-anomaly',
+      severity: 'info',
+      summary:
+        `${MONTH_NAMES[anomaly.month - 1]} averaged ${anomaly.actualTempC}°C — ` +
+        `${Math.abs(anomaly.tempDeltaC)}°C ${direction} your 10-year average of ${anomaly.baselineTempC}°C.`,
+      metrics: {
+        month: anomaly.month,
+        actualMeanTempC: anomaly.actualTempC,
+        baselineMeanTempC: anomaly.baselineTempC,
+        tempDeltaC: anomaly.tempDeltaC,
+      },
+      entities: [],
+      dates: { start: `${input.year}-${String(anomaly.month).padStart(2, '0')}-01` },
+    })
+  }
+  return findings
+}
+
+/**
+ * R6 rain-anomaly (notice when dry, info when wet): a growing-season month's
+ * rainfall was ≤ DRY_MONTH_RATIO or ≥ WET_MONTH_RATIO of the baseline.
+ */
+function ruleRainAnomaly(input: SeasonReviewInput): Finding[] {
+  if (!input.weather || !input.baseline) return []
+  const anomalies = computeMonthlyAnomalies(computeMonthlyActuals(input.weather), input.baseline)
+  const findings: Finding[] = []
+  for (const anomaly of anomalies) {
+    if (anomaly.month < GROWING_SEASON_START_MONTH || anomaly.month > GROWING_SEASON_END_MONTH) continue
+    if (anomaly.rainRatio === null || anomaly.actualRainMm === null || anomaly.baselineRainMm === null) continue
+    const dry = anomaly.rainRatio <= DRY_MONTH_RATIO
+    const wet = anomaly.rainRatio >= WET_MONTH_RATIO
+    if (!dry && !wet) continue
+    const monthName = MONTH_NAMES[anomaly.month - 1]
+    findings.push({
+      id: `rain-anomaly:${input.year}:${anomaly.month}`,
+      ruleId: 'rain-anomaly',
+      severity: dry ? 'notice' : 'info',
+      summary: dry
+        ? `${monthName} was much drier than usual: ${anomaly.actualRainMm}mm of rain against ` +
+          `your 10-year average of ${anomaly.baselineRainMm}mm (${Math.round(anomaly.rainRatio * 100)}%).`
+        : `${monthName} was much wetter than usual: ${anomaly.actualRainMm}mm of rain against ` +
+          `your 10-year average of ${anomaly.baselineRainMm}mm (${Math.round(anomaly.rainRatio * 100)}%).`,
+      metrics: {
+        month: anomaly.month,
+        actualRainMm: anomaly.actualRainMm,
+        baselineRainMm: anomaly.baselineRainMm,
+        rainRatio: anomaly.rainRatio,
+      },
+      entities: [],
+      dates: { start: `${input.year}-${String(anomaly.month).padStart(2, '0')}-01` },
+    })
+  }
+  return findings
+}
+
+/**
+ * R7 dry-spell (notice; warning when no watering was logged): a run of
+ * ≥ DRY_SPELL_MIN_DAYS dry days overlapping the April–September growing
+ * season, cross-referenced with the season's watering logs.
+ */
+function ruleDrySpell(input: SeasonReviewInput): Finding[] {
+  if (!input.weather) return []
+  const growingStart = `${input.year}-04-01`
+  const growingEnd = `${input.year}-09-30`
+  const spells = findDrySpells(input.weather.days, DRY_SPELL_MIN_DAYS).filter(
+    (spell) => spell.end >= growingStart && spell.start <= growingEnd
+  )
+  if (spells.length === 0) return []
+
+  const waterLogs = (input.seasonRecord?.areas ?? [])
+    .flatMap((areaSeason) => areaSeason.careLogs ?? [])
+    .filter((log) => log.type === 'water')
+
+  return spells.map((spell) => {
+    const waterings = waterLogs.filter((log) => log.date >= spell.start && log.date <= spell.end)
+    const hasLogs = waterLogs.length > 0
+    const summaryBase =
+      `A ${spell.lengthDays}-day dry spell ran from ${formatDay(spell.start)} to ${formatDay(spell.end)} ` +
+      `(${spell.totalRainMm}mm of rain in total).`
+    // Only comment on watering when the season has watering logs at all —
+    // "you never watered" is unfair to someone who just doesn't log it.
+    const summary = !hasLogs
+      ? summaryBase
+      : waterings.length === 0
+        ? `${summaryBase} No watering was logged during it.`
+        : `${summaryBase} You logged watering ${waterings.length} time${waterings.length === 1 ? '' : 's'} during it.`
+    const metrics: Record<string, number | string> = {
+      startDate: spell.start,
+      endDate: spell.end,
+      lengthDays: spell.lengthDays,
+      totalRainMm: spell.totalRainMm,
+    }
+    if (hasLogs) metrics.wateringsLogged = waterings.length
+    return {
+      id: `dry-spell:${input.year}:${spell.start}`,
+      ruleId: 'dry-spell',
+      severity: hasLogs && waterings.length === 0 ? 'warning' : 'notice',
+      summary,
+      metrics,
+      entities: [],
+      dates: { start: spell.start, end: spell.end },
+    } satisfies Finding
+  })
+}
+
+/**
+ * R8 water-deficit (info): a summer month where reference evapotranspiration
+ * outran rainfall by ≥ |WATER_DEFICIT_MM| — the plot lost more water than the
+ * sky supplied, even without a headline dry spell.
+ */
+function ruleWaterDeficit(input: SeasonReviewInput): Finding[] {
+  if (!input.weather) return []
+  const findings: Finding[] = []
+  for (let month = 4; month <= 9; month++) {
+    const balance = monthlyWaterBalance(input.weather, month)
+    if (!balance || balance.balanceMm > WATER_DEFICIT_MM) continue
+    findings.push({
+      id: `water-deficit:${input.year}:${month}`,
+      ruleId: 'water-deficit',
+      severity: 'info',
+      summary:
+        `In ${MONTH_NAMES[month - 1]} the plot lost ${balance.et0Mm}mm to evapotranspiration ` +
+        `but only received ${balance.rainMm}mm of rain — a ${Math.abs(balance.balanceMm)}mm deficit.`,
+      metrics: {
+        month,
+        rainMm: balance.rainMm,
+        et0Mm: balance.et0Mm,
+        balanceMm: balance.balanceMm,
+      },
+      entities: [],
+      dates: { start: `${input.year}-${String(month).padStart(2, '0')}-01` },
+    })
+  }
+  return findings
+}
+
+/**
+ * R9 pest-disease-cluster (notice; warning when any log was severity 3):
+ * ≥ CLUSTER_MIN_LOGS pest or disease observations of the same type in one
+ * bed within CLUSTER_WINDOW_DAYS. Works from logs alone — no weather needed.
+ */
+function rulePestDiseaseCluster(input: SeasonReviewInput): Finding[] {
+  if (!input.seasonRecord) return []
+  const findings: Finding[] = []
+  for (const areaSeason of input.seasonRecord.areas) {
+    const area = input.areas.find((a) => a.id === areaSeason.areaId)
+    for (const type of ['pest', 'disease'] as const) {
+      const logs = (areaSeason.careLogs ?? [])
+        .filter((log) => log.type === type && isInYear(log.date, input.year))
+        .sort((a, b) => a.date.localeCompare(b.date))
+      if (logs.length < CLUSTER_MIN_LOGS) continue
+
+      // Find the largest run of logs that fits a CLUSTER_WINDOW_DAYS window.
+      let best: CareLogEntry[] = []
+      for (let i = 0; i < logs.length; i++) {
+        const windowLimit = addDaysISO(logs[i].date, CLUSTER_WINDOW_DAYS - 1)
+        const run = logs.filter((log) => log.date >= logs[i].date && log.date <= windowLimit)
+        if (run.length > best.length) best = run
+      }
+      if (best.length < CLUSTER_MIN_LOGS) continue
+
+      const maxSeverity = Math.max(...best.map((log) => log.severity ?? 0))
+      const first = best[0].date
+      const last = best[best.length - 1].date
+      const bedName = area?.name ?? areaSeason.areaId
+      findings.push({
+        id: `pest-disease-cluster:${input.year}:${areaSeason.areaId}:${type}`,
+        ruleId: 'pest-disease-cluster',
+        severity: maxSeverity >= 3 ? 'warning' : 'notice',
+        summary:
+          `${best.length} ${type} observations were logged in ${bedName} ` +
+          `between ${formatDay(first)} and ${formatDay(last)}` +
+          `${maxSeverity >= 3 ? ', including at least one rated severe' : ''}.`,
+        metrics: {
+          observationCount: best.length,
+          type,
+          firstDate: first,
+          lastDate: last,
+          ...(maxSeverity > 0 ? { maxSeverity } : {}),
+        },
+        entities: [{ areaId: areaSeason.areaId, areaName: area?.name }],
+        dates: { start: first, end: last },
+      })
+    }
+  }
+  return findings
+}
+
+/**
+ * R10 dull-month (info): a summer month with ≤ DULL_MONTH_RATIO of the
+ * baseline's sunshine hours — slow, leggy growth without an obvious culprit.
+ */
+function ruleDullMonth(input: SeasonReviewInput): Finding[] {
+  if (!input.weather || !input.baseline) return []
+  const anomalies = computeMonthlyAnomalies(computeMonthlyActuals(input.weather), input.baseline)
+  const findings: Finding[] = []
+  for (const anomaly of anomalies) {
+    if (anomaly.month < 4 || anomaly.month > 9) continue
+    if (
+      anomaly.sunshineRatio === null ||
+      anomaly.actualSunshineHours === null ||
+      anomaly.baselineSunshineHours === null ||
+      anomaly.sunshineRatio > DULL_MONTH_RATIO
+    ) {
+      continue
+    }
+    findings.push({
+      id: `dull-month:${input.year}:${anomaly.month}`,
+      ruleId: 'dull-month',
+      severity: 'info',
+      summary:
+        `${MONTH_NAMES[anomaly.month - 1]} had ${Math.round((1 - anomaly.sunshineRatio) * 100)}% less sunshine ` +
+        `than your 10-year average (${Math.round(anomaly.actualSunshineHours)}h vs ` +
+        `${Math.round(anomaly.baselineSunshineHours)}h).`,
+      metrics: {
+        month: anomaly.month,
+        actualSunshineHours: anomaly.actualSunshineHours,
+        baselineSunshineHours: anomaly.baselineSunshineHours,
+        sunshineRatio: anomaly.sunshineRatio,
+      },
+      entities: [],
+      dates: { start: `${input.year}-${String(anomaly.month).padStart(2, '0')}-01` },
+    })
+  }
+  return findings
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate every rule against a season and return the findings, most severe
+ * first. Missing inputs (no weather, no baseline, no season record, sparse
+ * logs) silently disable the rules that need them — an empty array means
+ * "nothing confidently worth saying", which is a valid, common result.
+ */
+export function evaluateSeason(input: SeasonReviewInput): Finding[] {
+  const plantings = collectPlantings(input)
+  // Plantings already explained by the cold-soil rule skip slow-germination.
+  const flaggedPlantings = new Set<string>()
+
+  const findings = [
+    ...ruleColdSoilSowing(input, plantings, flaggedPlantings),
+    ...ruleSlowGermination(input, plantings, flaggedPlantings),
+    ...ruleFrostAfterTenderPlanting(input, plantings),
+    ...ruleHeatStress(input, plantings),
+    ...ruleTempAnomaly(input),
+    ...ruleRainAnomaly(input),
+    ...ruleDrySpell(input),
+    ...ruleWaterDeficit(input),
+    ...rulePestDiseaseCluster(input),
+    ...ruleDullMonth(input),
+  ]
+  return sortFindings(findings)
+}
+
+/** Per-planting derived metrics for the review page's plantings table. */
+export interface PlantingSeasonMetrics {
+  plantingId: string
+  plantId: string
+  plantName: string
+  varietyName?: string
+  areaId: string
+  areaName?: string
+  sowDate?: string
+  /** 0–7cm soil temperature on the sow date (outdoor sowings only). */
+  soilTempAtSowC: number | null
+  /** GDD accumulated from first outdoor exposure to the planting's window end. */
+  gdd: GddAccumulation | null
+  gddBaseTempC: number
+  germination: GerminationInterval | null
+  typicalDaysToGerminate: number
+}
+
+/**
+ * Derived metrics for each planting with any date logged this year — the
+ * deterministic numbers the review page shows alongside the findings. Pure
+ * presentation data; emits nothing that isn't computable.
+ */
+export function computePlantingMetrics(input: SeasonReviewInput): PlantingSeasonMetrics[] {
+  const results: PlantingSeasonMetrics[] = []
+  for (const ctx of collectPlantings(input)) {
+    const { planting, agronomy } = ctx
+    const exposure = input.weather ? outdoorExposureDate(planting, input.year) : null
+    const end = input.weather ? windowEnd(planting, input.weather) : null
+    const hasAnyDate =
+      isInYear(planting.sowDate, input.year) || isInYear(planting.transplantDate, input.year)
+    if (!hasAnyDate) continue
+    results.push({
+      plantingId: planting.id,
+      plantId: planting.plantId,
+      plantName: plantName(planting.plantId),
+      varietyName: planting.varietyName,
+      areaId: ctx.areaId,
+      areaName: ctx.area?.name,
+      sowDate: planting.sowDate,
+      soilTempAtSowC:
+        input.weather && planting.sowMethod === 'outdoor' && isInYear(planting.sowDate, input.year)
+          ? soilTempOn(input.weather.days, planting.sowDate)
+          : null,
+      gdd:
+        input.weather && exposure && end && end >= exposure
+          ? accumulateGdd(input.weather.days, agronomy.gddBaseTempC, exposure, end)
+          : null,
+      gddBaseTempC: agronomy.gddBaseTempC,
+      germination: daysToGermination(planting, ctx.careLogs),
+      typicalDaysToGerminate: agronomy.typicalDaysToGerminate,
+    })
+  }
+  return results
+}

--- a/src/lib/season-review/rules.ts
+++ b/src/lib/season-review/rules.ts
@@ -151,9 +151,11 @@ function formatDay(isoDate: string): string {
   return `${day} ${MONTH_NAMES[month - 1]?.slice(0, 3) ?? '?'}`
 }
 
-function addDaysISO(isoDate: string, days: number): string {
-  const ms = Date.parse(`${isoDate}T00:00:00Z`) + days * 86_400_000
-  return new Date(ms).toISOString().slice(0, 10)
+/** Null on an unparseable date — callers skip, per the stay-silent policy. */
+function addDaysISO(isoDate: string, days: number): string | null {
+  const parsed = Date.parse(`${isoDate.slice(0, 10)}T00:00:00Z`)
+  if (Number.isNaN(parsed)) return null
+  return new Date(parsed + days * 86_400_000).toISOString().slice(0, 10)
 }
 
 function isInYear(date: string | undefined, year: number): date is string {
@@ -310,6 +312,7 @@ function ruleFrostAfterTenderPlanting(
     const end = windowEnd(planting, input.weather)
     if (!end || end < exposure) continue
     const frostWindowEnd = addDaysISO(exposure, TENDER_FROST_WINDOW_DAYS)
+    if (!frostWindowEnd) continue
     const frost = frostDaysInWindow(
       input.weather.days,
       exposure,

--- a/src/lib/season-review/rules.ts
+++ b/src/lib/season-review/rules.ts
@@ -191,7 +191,7 @@ function windowEnd(planting: Planting, weather: SeasonWeather): string | null {
 
 /**
  * R1 cold-soil-sowing (warning): a crop was direct-sown outdoors while the
- * 0–7cm soil was more than COLD_SOIL_MARGIN_C below its minimum germination
+ * 0–7cm soil was at least COLD_SOIL_MARGIN_C below its minimum germination
  * temperature. Reports when the soil actually reached the threshold and, if
  * germination was logged, actual vs typical days.
  */
@@ -702,9 +702,9 @@ export interface PlantingSeasonMetrics {
 }
 
 /**
- * Derived metrics for each planting with any date logged this year — the
- * deterministic numbers the review page shows alongside the findings. Pure
- * presentation data; emits nothing that isn't computable.
+ * Derived metrics for each planting sown or transplanted in the reviewed
+ * year — the deterministic numbers the review page shows alongside the
+ * findings. Pure presentation data; emits nothing that isn't computable.
  */
 export function computePlantingMetrics(input: SeasonReviewInput): PlantingSeasonMetrics[] {
   const results: PlantingSeasonMetrics[] = []


### PR DESCRIPTION
## Summary

The learn half of the Season Observer's plan → observe → learn loop, built on the merged Phase 2a weather foundation (#475) and the Phase 1 log capture (#467). Fully deterministic — no LLM anywhere; that remains the open Phase 2c decision.

- **Derived metrics** (`src/lib/season-review/metrics.ts`): pure functions over a season's archived daily weather (`SeasonWeather`), the plot's 10-year baseline (`WeatherBaseline`), and the season's plantings/care-logs — GDD accumulation (from `agronomy.ts` base temps), soil temperature at each sow date, sustained soil-threshold detection (3-day run, single warm blips don't count), dry spells, monthly water balance (rain vs ET₀), heat-stress day counts, frost-in-window, actual days-to-germinate (sow → `germinated` care log) vs typical, and monthly actuals/anomalies computed with the same coverage floors as `computeBaseline` so the comparison is like-for-like. Every metric returns `null` on thin coverage instead of guessing.
- **Rules engine** (`rules.ts` + `findings.ts`): `evaluateSeason()` runs 10 conservative rules and emits a structured `findings[]` array — stable id, severity (info/notice/warning), a plain-English summary, the metric values behind every number, and the bed/planting entities. Rules: cold-soil sowing (with soil-recovery date + germination interval, e.g. "sown at 3.5°C, soil didn't reach 5°C for 22 days, germination took 24 days vs ~10"), slow germination, frost after a tender crop went out, heat-stress days (escalates when bolting was logged), monthly temp/rain/sunshine anomalies vs the 10-yr baseline, dry spells cross-referenced with watering logs (never scolds a user who doesn't log watering at all), monthly water deficit, and pest/disease clusters (log-only — works with no weather). Missing weather/baseline/logs silently disable the rules that need them; false positives are treated as the failure mode.
- **`/season-review` page**: deterministic rendering only — year picker, findings list, monthly weather-vs-baseline table, and a per-planting metrics table (soil at sowing, germination vs typical, GDD), with graceful empty states for no coordinates, no cached weather/offline, and sparse logs. Linked from the More menu and from `/log`. Findings are computed on demand — nothing new is persisted in the Yjs doc, coordinates never appear in findings, and Open-Meteo attribution is shown (CC BY 4.0).
- Docs: `docs/plans/season-observer.md` marks Phase 2b shipped; `current-plan.md` updated.

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes
- [x] I have updated documentation if needed

**Testing:** 59 new unit tests covering every metric function and every rule (fire + stay-silent fixtures over synthetic weather/logs, including a sparse-data fixture asserting the engine emits nothing). `npm run type-check`, `lint`, `test:unit` (1291 passed), and `build` all pass; full Playwright chromium suite green (136 passed, 9 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171tevuBwwcW7SEcxSTyPt3

---
_Generated by [Claude Code](https://claude.ai/code/session_0171tevuBwwcW7SEcxSTyPt3)_