### PR TITLE
Season Observer Phase 2c: opt-in, number-verified season narration

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,23 @@
 # Current Plan
 
-Last updated: 2026-07-13 (Season Observer Phase 2b rules engine shipped)
+Last updated: 2026-07-14 (Season Observer Phase 2c report narration shipped)
+
+## Season Observer — Phase 2c: report narration (shipped)
+
+The open Phase 2c decision is resolved and built: a **provider-agnostic
+narration client** (`src/lib/season-review/narration.ts`) — configurable
+OpenAI-compatible endpoint + model, local Ollama
+(`http://localhost:11434/v1`) as the default preset, optional bearer key for
+hosted endpoints. Strictly opt-in and OFF by default: a collapsed panel on
+`/season-review` (`NarrationPanel.tsx`) that does nothing until the user
+presses Generate, calling the endpoint directly from the browser. The
+findings[] from the Phase 2b rules engine are the only season data sent
+(plus allotment name + year — never coordinates). The real guarantee is
+deterministic: `narration-verify.ts` rejects any draft containing a number
+the findings don't vouch for, falling back to the plain findings list.
+Narration is ephemeral — never persisted, dropped when the year or findings
+change. CSP `connect-src` now allows the two localhost Ollama origins. Full
+detail in `docs/plans/season-observer.md`.
 
 ## Season Observer — Phase 2b: derived metrics + rules engine (shipped)
 
@@ -15,8 +32,8 @@ missing/thin data (false positives are the failure mode). The new
 `/season-review` page (More menu + linked from `/log`) renders the findings,
 a monthly weather-vs-baseline table, and per-planting metrics, degrading
 gracefully with no coordinates / no cached weather / sparse logs. Findings
-are computed on demand, never persisted. Phase 2c (report narration) remains
-an open decision — see `docs/plans/season-observer.md`.
+are computed on demand, never persisted. Phase 2c (report narration) shipped
+next — see above and `docs/plans/season-observer.md`.
 
 ## Season Observer — camera-roll photo import (shipped)
 

--- a/docs/plans/season-observer.md
+++ b/docs/plans/season-observer.md
@@ -147,14 +147,46 @@ Deterministic code over logs + weather, all in `src/lib/season-review/`:
   demand — nothing new is persisted in the Yjs doc, and coordinates never
   appear in findings.
 
-### Report narration (Phase 2c) — **open decision**
-The brief mandates local Ollama only (privacy-first). The repo's only LLM path
-is a cloud OpenAI proxy (`/api/ai-advisor`, hidden behind `SHOW_AI_ADVISOR`).
-A deployed web app cannot reach a user's `localhost:11434`, so Ollama-only means
-"self-hosted / local machine," not the public deploy. **Recommendation:** a
-provider-agnostic narration client (configurable base URL, Ollama default),
-with the deterministic `findings` JSON + a "no number absent from findings"
-automated check as the real guarantee. Confirm before building.
+### Report narration (Phase 2c) — **shipped**
+
+**Decision (resolving the open question):** a provider-agnostic narration
+client — configurable base URL + model, OpenAI-compatible chat-completions
+API, local Ollama (`http://localhost:11434/v1`) as the default preset. No new
+required cloud service; narration is strictly opt-in and OFF by default, and
+the deterministic `/season-review` page stays fully useful without it. The
+brief's Ollama-only mandate is honoured as the default (nothing leaves the
+machine), while the configurable endpoint covers the deployed-web-app reality
+that a server can never reach a user's `localhost`.
+
+- `src/lib/season-review/narration.ts` — the client. Browser → configured
+  endpoint directly (no app server in the path), `temperature: 0.2`, optional
+  bearer key for hosted endpoints (sessionStorage, mirroring the AI-advisor
+  BYO-key pattern; endpoint + model persist in localStorage). The findings[]
+  from `rules.ts` are the ONLY season data sent, plus allotment name + year —
+  never coordinates, never internal ids. The system prompt forbids numbers
+  not present in the findings.
+- `src/lib/season-review/narration-verify.ts` — the real guarantee,
+  deterministic code: every numeric token in the draft must be vouched for by
+  the findings (summaries, metric values, ISO date parts) or a small derived
+  allowance (season year, year+1, finding counts). Tokens are canonicalized
+  (`21.50` ≡ `21.5`, thousands separators joined, sign treated as grammar);
+  model-side rounding/conversions/arithmetic all fail. A failing draft is
+  discarded and the UI says so — the findings list is the fallback report.
+- `src/components/season-review/NarrationPanel.tsx` — collapsed
+  `<details>` on `/season-review`, inert until the user presses Generate.
+  Narration is ephemeral: rendered on demand, never persisted (not in the
+  Yjs doc, not anywhere), dropped when the year or findings change. Friendly
+  guidance on unreachable endpoints (Ollama not running / `OLLAMA_ORIGINS`).
+- CSP: `connect-src` gained `http://localhost:11434` + `http://127.0.0.1:11434`
+  (browsers exempt localhost from mixed-content blocking, but CSP still needs
+  the origin). Custom remote endpoints need their origin added to
+  `src/middleware.ts`.
+- No release-visibility flag: the collapsed opt-in panel that does nothing
+  until configured-and-clicked *is* the gate, and a flag would be sprawl.
+- Tests: `narration-verify.test.ts` (the checker, tested hard — rounding,
+  conversions, thousands separators, dedupe, zero-findings) and
+  `narration.test.ts` (mocked fetch: request shape, auth header only with a
+  key, prompt contract, error paths, verified/rejected orchestration).
 
 ### Not building (per brief non-goals)
 Bed-layout designer, sensors/hardware, cloud accounts/telemetry for this

--- a/src/__tests__/components/NarrationPanel.test.tsx
+++ b/src/__tests__/components/NarrationPanel.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * NarrationPanel — the ephemerality guarantee. The panel must never show
+ * prose about inputs that have since changed: an in-flight request whose year
+ * or findings were swapped out from under it is orphaned, not rendered.
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import NarrationPanel from '@/components/season-review/NarrationPanel'
+import type { Finding } from '@/lib/season-review/findings'
+import { narrateSeason, type NarrationResult } from '@/lib/season-review/narration'
+
+vi.mock('@/lib/season-review/narration', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/season-review/narration')>()),
+  narrateSeason: vi.fn(),
+}))
+
+const narrateSeasonMock = vi.mocked(narrateSeason)
+
+const FINDINGS: Finding[] = [
+  {
+    id: 'rule:2024:x',
+    ruleId: 'rule',
+    severity: 'notice',
+    summary: 'June was warm.',
+    metrics: {},
+    entities: [],
+  },
+]
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+describe('NarrationPanel', () => {
+  beforeEach(() => {
+    narrateSeasonMock.mockReset()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('shows verified narration after Generate', async () => {
+    narrateSeasonMock.mockResolvedValue({ status: 'ok', text: 'A warm June.' })
+    render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+
+    expect(await screen.findByText('A warm June.')).toBeInTheDocument()
+    expect(screen.getByText(/every number above appears in the findings/i)).toBeInTheDocument()
+  })
+
+  it('shows the fallback note when the draft is rejected', async () => {
+    narrateSeasonMock.mockResolvedValue({
+      status: 'rejected',
+      text: 'It hit 99°C.',
+      unverifiedNumbers: ['99'],
+    })
+    render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+
+    expect(await screen.findByText(/numbers that aren't in the findings/i)).toBeInTheDocument()
+    expect(screen.getByText(/\(99\)/)).toBeInTheDocument()
+    expect(screen.queryByText('It hit 99°C.')).not.toBeInTheDocument()
+  })
+
+  it('discards an in-flight result when the year changes mid-request', async () => {
+    const pending = deferred<NarrationResult>()
+    narrateSeasonMock.mockReturnValue(pending.promise)
+    const { rerender } = render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+    expect(screen.getByRole('button', { name: /writing/i })).toBeInTheDocument()
+
+    // The user flips to another season while the model is still writing.
+    rerender(<NarrationPanel findings={FINDINGS} year={2023} />)
+
+    pending.resolve({ status: 'ok', text: 'Stale prose about 2024.' })
+    // The orphaned resolution must not repopulate the panel.
+    await waitFor(() => {
+      expect(narrateSeasonMock).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.queryByText('Stale prose about 2024.')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /generate narration/i })).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/lib/season-review/narration-verify.test.ts
+++ b/src/__tests__/lib/season-review/narration-verify.test.ts
@@ -104,6 +104,21 @@ describe('collectAllowedNumbers', () => {
     expect(allowed.has('0')).toBe(true) // notice count — zero is still a count
   })
 
+  it('vouches for numbers inside entity display names', () => {
+    const allowed = collectAllowedNumbers(
+      [
+        finding({
+          entities: [
+            { areaName: 'Raised Bed 1', plantName: 'Sweetcorn F1', varietyName: 'Earlibird 2' },
+          ],
+        }),
+      ],
+      META
+    )
+    expect(allowed.has('1')).toBe(true)
+    expect(allowed.has('2')).toBe(true)
+  })
+
   it('vouches zero counts for severities with no findings at all', () => {
     const allowed = collectAllowedNumbers([finding({ severity: 'notice' })], META)
     expect(allowed.has('0')).toBe(true) // no warnings, no info
@@ -189,6 +204,17 @@ describe('verifyNarration', () => {
     const result = verifyNarration('Rainfall ran at .4 of normal.', findings, META)
     expect(result.ok).toBe(false)
     expect(result.unverifiedNumbers).toEqual(['0.4'])
+  })
+
+  it('accepts a draft naming a numbered bed', () => {
+    const numberedBed = [
+      finding({
+        summary: 'Slugs clustered in one bed.',
+        entities: [{ areaName: 'Raised Bed 3' }],
+      }),
+    ]
+    const result = verifyNarration('Raised Bed 3 had a slug problem.', numberedBed, META)
+    expect(result.ok).toBe(true)
   })
 
   it('allows counting the findings and mentioning the season and next year', () => {

--- a/src/__tests__/lib/season-review/narration-verify.test.ts
+++ b/src/__tests__/lib/season-review/narration-verify.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The number-verification checker is the real guarantee behind Phase 2c
+ * narration — the LLM is untrusted, this is not. Test it hard.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Finding } from '@/lib/season-review/findings'
+import {
+  collectAllowedNumbers,
+  extractNumericTokens,
+  verifyNarration,
+} from '@/lib/season-review/narration-verify'
+
+function finding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: 'rule:2025:x',
+    ruleId: 'rule',
+    severity: 'notice',
+    summary: 'Something happened.',
+    metrics: {},
+    entities: [],
+    ...overrides,
+  }
+}
+
+const META = { year: 2025 }
+
+describe('extractNumericTokens', () => {
+  it('extracts integers and decimals', () => {
+    expect(extractNumericTokens('Soil was 6.5°C, 3 days later 12°C')).toEqual([
+      '6.5', '3', '12',
+    ])
+  })
+
+  it('canonicalizes formatting variants', () => {
+    expect(extractNumericTokens('21.50')).toEqual(['21.5'])
+    expect(extractNumericTokens('07 of July')).toEqual(['7'])
+    expect(extractNumericTokens('0.50')).toEqual(['0.5'])
+  })
+
+  it('joins thousands separators but not list commas', () => {
+    expect(extractNumericTokens('1,200mm')).toEqual(['1200'])
+    expect(extractNumericTokens('beds 3, 14 and 9')).toEqual(['3', '14', '9'])
+    // Four digits after the comma is not a thousands group.
+    expect(extractNumericTokens('3,1415')).toEqual(['3', '1415'])
+  })
+
+  it('splits ISO dates into their parts', () => {
+    expect(extractNumericTokens('2025-06-14')).toEqual(['2025', '6', '14'])
+  })
+
+  it('handles ordinals and percentages', () => {
+    expect(extractNumericTokens('the 14th, at 40%')).toEqual(['14', '40'])
+  })
+
+  it('returns empty for prose without numbers', () => {
+    expect(extractNumericTokens('A kind season with gentle rain.')).toEqual([])
+  })
+})
+
+describe('collectAllowedNumbers', () => {
+  it('vouches for numbers in summaries, metrics, and dates', () => {
+    const allowed = collectAllowedNumbers(
+      [
+        finding({
+          summary: 'June was 2.1°C warmer than your 10-year average.',
+          metrics: { deltaC: 2.1, baselineC: 14.3, month: 6 },
+          dates: { start: '2025-06-01', end: '2025-06-30' },
+        }),
+      ],
+      META
+    )
+    for (const token of ['2.1', '10', '14.3', '6', '2025', '1', '30']) {
+      expect(allowed.has(token), token).toBe(true)
+    }
+  })
+
+  it('vouches for numeric fragments inside string metrics', () => {
+    const allowed = collectAllowedNumbers(
+      [finding({ metrics: { window: '14 days from 2025-07-02' } })],
+      META
+    )
+    expect(allowed.has('14')).toBe(true)
+    expect(allowed.has('7')).toBe(true)
+    expect(allowed.has('2')).toBe(true)
+  })
+
+  it('allows the year, next year, and finding counts', () => {
+    const findings = [
+      finding({ severity: 'warning' }),
+      finding({ severity: 'info' }),
+      finding({ severity: 'info' }),
+    ]
+    const allowed = collectAllowedNumbers(findings, META)
+    expect(allowed.has('2025')).toBe(true) // season year
+    expect(allowed.has('2026')).toBe(true) // "next year"
+    expect(allowed.has('3')).toBe(true) // total findings
+    expect(allowed.has('1')).toBe(true) // warning count
+    expect(allowed.has('2')).toBe(true) // info count
+  })
+})
+
+describe('verifyNarration', () => {
+  const findings = [
+    finding({
+      summary: 'Peas sown 2025-03-12 into 6.5°C soil, below their 7°C minimum.',
+      metrics: { soilTempC: 6.5, minSoilTempC: 7 },
+      dates: { start: '2025-03-12' },
+    }),
+    finding({
+      summary: 'A 21-day dry spell from 2025-06-14; only 4mm of rain fell.',
+      metrics: { days: 21, rainMm: 4 },
+      dates: { start: '2025-06-14', end: '2025-07-04' },
+    }),
+  ]
+
+  it('accepts prose that only reuses findings numbers', () => {
+    const result = verifyNarration(
+      'Your peas went in on 12 March into 6.5°C soil — just under the 7°C they want. ' +
+        'Later, from 14 June, a 21-day dry spell brought only 4mm of rain.',
+      findings,
+      META
+    )
+    expect(result).toEqual({ ok: true, unverifiedNumbers: [] })
+  })
+
+  it('rejects an invented number and names it', () => {
+    const result = verifyNarration(
+      'A 21-day dry spell with 4mm of rain — beds lost roughly 85mm of moisture.',
+      findings,
+      META
+    )
+    expect(result.ok).toBe(false)
+    expect(result.unverifiedNumbers).toEqual(['85'])
+  })
+
+  it('rejects arithmetic the model did itself', () => {
+    // 21 days restated as "roughly 22": 22 appears nowhere in the findings.
+    const result = verifyNarration('The dry spell ran roughly 22 days.', findings, META)
+    expect(result.ok).toBe(false)
+    expect(result.unverifiedNumbers).toEqual(['22'])
+  })
+
+  it('rejects unit conversions the model did itself', () => {
+    // 4mm restated as 0.4cm: 0.4 appears nowhere in the findings.
+    const result = verifyNarration('Only 0.4cm of rain fell.', findings, META)
+    expect(result.ok).toBe(false)
+    expect(result.unverifiedNumbers).toEqual(['0.4'])
+  })
+
+  it('accepts reformatted-but-equal numbers', () => {
+    const result = verifyNarration('Soil sat at 6.50°C on the 12th.', findings, META)
+    expect(result.ok).toBe(true)
+  })
+
+  it('treats sign as grammar, not a new number', () => {
+    const deficit = [
+      finding({
+        summary: 'July ran a -60mm water deficit.',
+        metrics: { balanceMm: -60 },
+      }),
+    ]
+    const result = verifyNarration('July came up 60mm short on water.', deficit, META)
+    expect(result.ok).toBe(true)
+  })
+
+  it('allows counting the findings and mentioning the season and next year', () => {
+    const result = verifyNarration(
+      'Two things stood out in 2025 — worth planning around in 2026.',
+      findings,
+      META
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts prose with no numbers at all', () => {
+    expect(verifyNarration('A gentle, kind season.', findings, META).ok).toBe(true)
+  })
+
+  it('accepts an empty draft (emptiness is handled upstream)', () => {
+    expect(verifyNarration('', findings, META).ok).toBe(true)
+  })
+
+  it('dedupes repeated unverified numbers', () => {
+    const result = verifyNarration('It hit 33°C, then 33°C again, then 99°C.', findings, META)
+    expect(result.ok).toBe(false)
+    expect(result.unverifiedNumbers.sort()).toEqual(['33', '99'])
+  })
+
+  it('with zero findings, only the derived allowance survives', () => {
+    const ok = verifyNarration('Nothing to report for 2025.', [], META)
+    expect(ok.ok).toBe(true)
+    const bad = verifyNarration('Rain totalled 400mm in 2025.', [], META)
+    expect(bad.ok).toBe(false)
+    expect(bad.unverifiedNumbers).toEqual(['400'])
+  })
+
+  it('rejects thousands-separated variants of unvouched numbers', () => {
+    const result = verifyNarration('That is 1,200 slugs.', findings, META)
+    expect(result.ok).toBe(false)
+    expect(result.unverifiedNumbers).toEqual(['1200'])
+  })
+})

--- a/src/__tests__/lib/season-review/narration-verify.test.ts
+++ b/src/__tests__/lib/season-review/narration-verify.test.ts
@@ -119,6 +119,11 @@ describe('collectAllowedNumbers', () => {
     expect(allowed.has('2')).toBe(true)
   })
 
+  it('vouches for digits in the allotment name', () => {
+    const allowed = collectAllowedNumbers([], { year: 2025, allotmentName: 'Plot 2' })
+    expect(allowed.has('2')).toBe(true)
+  })
+
   it('vouches zero counts for severities with no findings at all', () => {
     const allowed = collectAllowedNumbers([finding({ severity: 'notice' })], META)
     expect(allowed.has('0')).toBe(true) // no warnings, no info
@@ -204,6 +209,15 @@ describe('verifyNarration', () => {
     const result = verifyNarration('Rainfall ran at .4 of normal.', findings, META)
     expect(result.ok).toBe(false)
     expect(result.unverifiedNumbers).toEqual(['0.4'])
+  })
+
+  it('accepts a draft repeating a numeric allotment name', () => {
+    const result = verifyNarration(
+      'Plot 7 had a season to remember.',
+      findings,
+      { year: 2025, allotmentName: 'Plot 7' }
+    )
+    expect(result.ok).toBe(true)
   })
 
   it('accepts a draft naming a numbered bed', () => {

--- a/src/__tests__/lib/season-review/narration-verify.test.ts
+++ b/src/__tests__/lib/season-review/narration-verify.test.ts
@@ -52,6 +52,11 @@ describe('extractNumericTokens', () => {
     expect(extractNumericTokens('the 14th, at 40%')).toEqual(['14', '40'])
   })
 
+  it('reads bare-dot decimals whole rather than as their fraction digits', () => {
+    expect(extractNumericTokens('about .5mm')).toEqual(['0.5'])
+    expect(extractNumericTokens('.50 of normal')).toEqual(['0.5'])
+  })
+
   it('returns empty for prose without numbers', () => {
     expect(extractNumericTokens('A kind season with gentle rain.')).toEqual([])
   })
@@ -96,6 +101,12 @@ describe('collectAllowedNumbers', () => {
     expect(allowed.has('3')).toBe(true) // total findings
     expect(allowed.has('1')).toBe(true) // warning count
     expect(allowed.has('2')).toBe(true) // info count
+    expect(allowed.has('0')).toBe(true) // notice count — zero is still a count
+  })
+
+  it('vouches zero counts for severities with no findings at all', () => {
+    const allowed = collectAllowedNumbers([finding({ severity: 'notice' })], META)
+    expect(allowed.has('0')).toBe(true) // no warnings, no info
   })
 })
 
@@ -161,6 +172,23 @@ describe('verifyNarration', () => {
     ]
     const result = verifyNarration('July came up 60mm short on water.', deficit, META)
     expect(result.ok).toBe(true)
+  })
+
+  it('accepts "0 warnings"-style phrasing when a severity has no findings', () => {
+    const noticesOnly = [finding({ severity: 'notice' }), finding({ severity: 'notice' })]
+    const result = verifyNarration(
+      'Two notices and 0 warnings this season.',
+      noticesOnly,
+      META
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects a bare-dot decimal even when its fraction digits are vouched', () => {
+    // findings vouch for 4 (rainMm) — ".4" must not ride on it.
+    const result = verifyNarration('Rainfall ran at .4 of normal.', findings, META)
+    expect(result.ok).toBe(false)
+    expect(result.unverifiedNumbers).toEqual(['0.4'])
   })
 
   it('allows counting the findings and mentioning the season and next year', () => {

--- a/src/__tests__/lib/season-review/narration-verify.test.ts
+++ b/src/__tests__/lib/season-review/narration-verify.test.ts
@@ -57,6 +57,11 @@ describe('extractNumericTokens', () => {
     expect(extractNumericTokens('.50 of normal')).toEqual(['0.5'])
   })
 
+  it('reads scientific notation whole rather than as its digits', () => {
+    expect(extractNumericTokens('roughly 1e6 slugs')).toEqual(['1000000'])
+    expect(extractNumericTokens('2.5e-2 of normal')).toEqual(['0.025'])
+  })
+
   it('returns empty for prose without numbers', () => {
     expect(extractNumericTokens('A kind season with gentle rain.')).toEqual([])
   })
@@ -202,6 +207,13 @@ describe('verifyNarration', () => {
       META
     )
     expect(result.ok).toBe(true)
+  })
+
+  it('rejects scientific notation even when its digits are individually vouched', () => {
+    // findings vouch 7 (minSoilTempC) and 4 (rainMm) — "7e4" must not ride on them.
+    const result = verifyNarration('That is 7e4 raindrops.', findings, META)
+    expect(result.ok).toBe(false)
+    expect(result.unverifiedNumbers).toEqual(['70000'])
   })
 
   it('rejects a bare-dot decimal even when its fraction digits are vouched', () => {

--- a/src/__tests__/lib/season-review/narration.test.ts
+++ b/src/__tests__/lib/season-review/narration.test.ts
@@ -103,6 +103,30 @@ describe('requestNarration', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('refuses a scheme-less base URL — it would resolve relative to this origin', async () => {
+    const fetchMock = vi.fn()
+    await expect(
+      requestNarration(FINDINGS, META, { ...SETTINGS, baseUrl: 'api.example.com/v1' }, fetchMock)
+    ).rejects.toThrow('must be absolute')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses non-http(s) schemes', async () => {
+    const fetchMock = vi.fn()
+    await expect(
+      requestNarration(FINDINGS, META, { ...SETTINGS, baseUrl: 'ftp://llm.example/v1' }, fetchMock)
+    ).rejects.toThrow('must use http or https')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses an empty model up front', async () => {
+    const fetchMock = vi.fn()
+    await expect(
+      requestNarration(FINDINGS, META, { ...SETTINGS, model: '  ' }, fetchMock)
+    ).rejects.toThrow('model is required')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('trims the model name in the request body', async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse('ok'))
     await requestNarration(FINDINGS, META, { ...SETTINGS, model: ' llama3.2 ' }, fetchMock)
@@ -179,6 +203,38 @@ describe('requestNarration', () => {
       const assertion = expect(pending).rejects.toMatchObject({ name: 'AbortError' })
       await vi.advanceTimersByTimeAsync(60_000)
       await assertion
+    })
+
+    it('cancels the in-flight fetch when the caller aborts', async () => {
+      const fetchMock = vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () =>
+              reject(new DOMException('The operation was aborted.', 'AbortError'))
+            )
+          })
+      )
+      const controller = new AbortController()
+      const pending = requestNarration(
+        FINDINGS,
+        META,
+        SETTINGS,
+        fetchMock as unknown as typeof fetch,
+        { signal: controller.signal }
+      )
+      const assertion = expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+      controller.abort()
+      await assertion
+    })
+
+    it('rejects immediately when called with an already-aborted signal', async () => {
+      const fetchMock = vi.fn()
+      const controller = new AbortController()
+      controller.abort()
+      await expect(
+        requestNarration(FINDINGS, META, SETTINGS, fetchMock, { signal: controller.signal })
+      ).rejects.toMatchObject({ name: 'AbortError' })
+      expect(fetchMock).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/__tests__/lib/season-review/narration.test.ts
+++ b/src/__tests__/lib/season-review/narration.test.ts
@@ -3,7 +3,7 @@
  * request shape, the prompt contract, error handling, and the verified /
  * rejected orchestration in narrateSeason.
  */
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Finding } from '@/lib/season-review/findings'
 import {
   buildNarrationMessages,
@@ -131,6 +131,41 @@ describe('requestNarration', () => {
     await expect(requestNarration(FINDINGS, META, SETTINGS, fetchMock)).rejects.toThrow(
       'Failed to fetch'
     )
+  })
+
+  describe('timeout', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('passes an abort signal to fetch', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okResponse('ok'))
+      await requestNarration(FINDINGS, META, SETTINGS, fetchMock)
+      expect(fetchMock.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+      expect(fetchMock.mock.calls[0][1].signal.aborted).toBe(false)
+    })
+
+    it('aborts a hung request after the timeout instead of loading forever', async () => {
+      vi.useFakeTimers()
+      // A fetch that never resolves — it only rejects when its signal aborts.
+      const fetchMock = vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () =>
+              reject(new DOMException('The operation was aborted.', 'AbortError'))
+            )
+          })
+      )
+      const pending = requestNarration(
+        FINDINGS,
+        META,
+        SETTINGS,
+        fetchMock as unknown as typeof fetch
+      )
+      const assertion = expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+      await vi.advanceTimersByTimeAsync(60_000)
+      await assertion
+    })
   })
 })
 

--- a/src/__tests__/lib/season-review/narration.test.ts
+++ b/src/__tests__/lib/season-review/narration.test.ts
@@ -83,9 +83,9 @@ describe('requestNarration', () => {
     expect(body.messages).toHaveLength(2)
   })
 
-  it('tolerates trailing slashes on the base URL', async () => {
+  it('tolerates trailing slashes and whitespace on the base URL', async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse('ok'))
-    await requestNarration(FINDINGS, META, { ...SETTINGS, baseUrl: 'https://llm.example/v1/' }, fetchMock)
+    await requestNarration(FINDINGS, META, { ...SETTINGS, baseUrl: ' https://llm.example/v1/ ' }, fetchMock)
     expect(fetchMock.mock.calls[0][0]).toBe('https://llm.example/v1/chat/completions')
   })
 

--- a/src/__tests__/lib/season-review/narration.test.ts
+++ b/src/__tests__/lib/season-review/narration.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Narration client (Phase 2c) — mocked-fetch tests for the OpenAI-compatible
+ * request shape, the prompt contract, error handling, and the verified /
+ * rejected orchestration in narrateSeason.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { Finding } from '@/lib/season-review/findings'
+import {
+  buildNarrationMessages,
+  narrateSeason,
+  OLLAMA_PRESET,
+  requestNarration,
+  type NarrationSettings,
+} from '@/lib/season-review/narration'
+
+const FINDINGS: Finding[] = [
+  {
+    id: 'cold-soil:2025:p1',
+    ruleId: 'cold-soil',
+    severity: 'warning',
+    summary: 'Peas sown 2025-03-12 into 6.5°C soil, below their 7°C minimum.',
+    metrics: { soilTempC: 6.5, minSoilTempC: 7 },
+    entities: [{ areaId: 'a1', areaName: 'Bed A', plantId: 'peas', plantName: 'Peas' }],
+    dates: { start: '2025-03-12' },
+  },
+]
+
+const META = { year: 2025, allotmentName: 'Bonnie Wee Plot' }
+const SETTINGS: NarrationSettings = { baseUrl: 'http://localhost:11434/v1', model: 'llama3.2' }
+
+function okResponse(content: string | null) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ choices: [{ message: { content } }] }),
+  } as Response
+}
+
+describe('buildNarrationMessages', () => {
+  it('sends the findings, allotment name and year — and only that', () => {
+    const [system, user] = buildNarrationMessages(FINDINGS, META)
+    expect(system.role).toBe('system')
+    expect(user.role).toBe('user')
+    expect(user.content).toContain('Allotment: Bonnie Wee Plot')
+    expect(user.content).toContain('Season: 2025')
+    expect(user.content).toContain('Peas sown 2025-03-12')
+    expect(user.content).toContain('"soilTempC": 6.5')
+    expect(user.content).toContain('Bed A')
+    // Internal ids are payload noise the model has no use for.
+    expect(user.content).not.toContain('cold-soil:2025:p1')
+    expect(user.content).not.toContain('"areaId"')
+  })
+
+  it('omits the allotment line when no name is set', () => {
+    const [, user] = buildNarrationMessages(FINDINGS, { year: 2025 })
+    expect(user.content).not.toContain('Allotment:')
+  })
+
+  it('forbids invented numbers and mentioning locations in the system prompt', () => {
+    const [system] = buildNarrationMessages(FINDINGS, META)
+    expect(system.content).toContain('Never write a number that does not appear in the findings')
+    expect(system.content).toContain('coordinates')
+  })
+})
+
+describe('requestNarration', () => {
+  it('POSTs an OpenAI-compatible body to <baseUrl>/chat/completions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse('A fine season.'))
+    const text = await requestNarration(FINDINGS, META, SETTINGS, fetchMock)
+
+    expect(text).toBe('A fine season.')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:11434/v1/chat/completions')
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/json')
+    expect(init.headers['Authorization']).toBeUndefined()
+
+    const body = JSON.parse(init.body)
+    expect(body.model).toBe('llama3.2')
+    expect(body.temperature).toBe(0.2)
+    expect(body.stream).toBe(false)
+    expect(body.messages).toHaveLength(2)
+  })
+
+  it('tolerates trailing slashes on the base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse('ok'))
+    await requestNarration(FINDINGS, META, { ...SETTINGS, baseUrl: 'https://llm.example/v1/' }, fetchMock)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://llm.example/v1/chat/completions')
+  })
+
+  it('sends a bearer token only when an API key is configured', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse('ok'))
+    await requestNarration(FINDINGS, META, { ...SETTINGS, apiKey: 'sk-test' }, fetchMock)
+    expect(fetchMock.mock.calls[0][1].headers['Authorization']).toBe('Bearer sk-test')
+  })
+
+  it('throws with status and detail on a non-OK response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: { message: 'model "nope" not found' } }),
+    } as Response)
+    await expect(requestNarration(FINDINGS, META, SETTINGS, fetchMock)).rejects.toThrow(
+      'Narration endpoint returned 404: model "nope" not found'
+    )
+  })
+
+  it('throws with just the status when the error body is not JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error('not json')
+      },
+    } as unknown as Response)
+    await expect(requestNarration(FINDINGS, META, SETTINGS, fetchMock)).rejects.toThrow(
+      'Narration endpoint returned 502'
+    )
+  })
+
+  it('throws on an empty completion', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse('   '))
+    await expect(requestNarration(FINDINGS, META, SETTINGS, fetchMock)).rejects.toThrow(
+      'empty completion'
+    )
+  })
+
+  it('propagates network failures', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    await expect(requestNarration(FINDINGS, META, SETTINGS, fetchMock)).rejects.toThrow(
+      'Failed to fetch'
+    )
+  })
+})
+
+describe('narrateSeason', () => {
+  it('returns ok for a draft whose numbers the findings vouch for', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse('Your peas went into 6.5°C soil on 12 March — under the 7°C they prefer.')
+    )
+    const result = await narrateSeason(FINDINGS, META, SETTINGS, fetchMock)
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.text).toContain('6.5°C')
+    }
+  })
+
+  it('rejects a draft with an invented number — the fallback path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse('Soil hit 6.5°C, and you lost around 40% of the crop.')
+    )
+    const result = await narrateSeason(FINDINGS, META, SETTINGS, fetchMock)
+    expect(result.status).toBe('rejected')
+    if (result.status === 'rejected') {
+      expect(result.unverifiedNumbers).toEqual(['40'])
+      expect(result.text).toContain('40%')
+    }
+  })
+
+  it('lets endpoint errors escape as exceptions rather than fake rejections', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    await expect(narrateSeason(FINDINGS, META, SETTINGS, fetchMock)).rejects.toThrow()
+  })
+})
+
+describe('OLLAMA_PRESET', () => {
+  it('defaults to a local Ollama with no API key', () => {
+    expect(OLLAMA_PRESET.baseUrl).toBe('http://localhost:11434/v1')
+    expect(OLLAMA_PRESET.apiKey).toBeUndefined()
+  })
+})

--- a/src/__tests__/lib/season-review/narration.test.ts
+++ b/src/__tests__/lib/season-review/narration.test.ts
@@ -181,6 +181,17 @@ describe('narrateSeason', () => {
     }
   })
 
+  it('lets a draft repeat digits from the allotment name', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse('A fine year on Plot 9.'))
+    const result = await narrateSeason(
+      FINDINGS,
+      { year: 2025, allotmentName: 'Plot 9' },
+      SETTINGS,
+      fetchMock
+    )
+    expect(result.status).toBe('ok')
+  })
+
   it('rejects a draft with an invented number — the fallback path', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       okResponse('Soil hit 6.5°C, and you lost around 40% of the crop.')

--- a/src/__tests__/lib/season-review/narration.test.ts
+++ b/src/__tests__/lib/season-review/narration.test.ts
@@ -44,7 +44,7 @@ describe('buildNarrationMessages', () => {
     expect(user.content).toContain('Allotment: Bonnie Wee Plot')
     expect(user.content).toContain('Season: 2025')
     expect(user.content).toContain('Peas sown 2025-03-12')
-    expect(user.content).toContain('"soilTempC": 6.5')
+    expect(user.content).toContain('"soilTempC":6.5')
     expect(user.content).toContain('Bed A')
     // Internal ids are payload noise the model has no use for.
     expect(user.content).not.toContain('cold-soil:2025:p1')
@@ -89,10 +89,24 @@ describe('requestNarration', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('https://llm.example/v1/chat/completions')
   })
 
-  it('sends a bearer token only when an API key is configured', async () => {
+  it('sends a bearer token only when an API key is configured, trimmed', async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse('ok'))
-    await requestNarration(FINDINGS, META, { ...SETTINGS, apiKey: 'sk-test' }, fetchMock)
+    await requestNarration(FINDINGS, META, { ...SETTINGS, apiKey: ' sk-test\n' }, fetchMock)
     expect(fetchMock.mock.calls[0][1].headers['Authorization']).toBe('Bearer sk-test')
+  })
+
+  it('refuses an empty base URL instead of posting to a same-origin relative path', async () => {
+    const fetchMock = vi.fn()
+    await expect(
+      requestNarration(FINDINGS, META, { ...SETTINGS, baseUrl: '  ' }, fetchMock)
+    ).rejects.toThrow('base URL is required')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('trims the model name in the request body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse('ok'))
+    await requestNarration(FINDINGS, META, { ...SETTINGS, model: ' llama3.2 ' }, fetchMock)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).model).toBe('llama3.2')
   })
 
   it('throws with status and detail on a non-OK response', async () => {

--- a/src/app/season-review/page.tsx
+++ b/src/app/season-review/page.tsx
@@ -3,12 +3,14 @@
 /**
  * Season Review — the Season Observer's Phase 2b report page.
  *
- * Deterministic rendering only: pick a year, see the season's monthly weather
+ * Deterministic rendering first: pick a year, see the season's monthly weather
  * against the plot's 10-year baseline, the rules-engine findings, and the
  * per-planting derived metrics. Everything on screen comes from tested pure
- * functions (src/lib/season-review/) over logs + cached archive weather — no
- * narration, no LLM (that's the still-open Phase 2c decision), and nothing is
- * persisted: the review is recomputed on demand.
+ * functions (src/lib/season-review/) over logs + cached archive weather, and
+ * nothing is persisted: the review is recomputed on demand. The only LLM
+ * surface is the strictly opt-in NarrationPanel (Phase 2c) — collapsed, off
+ * until clicked, number-verified against the findings, and ephemeral. The
+ * page is fully useful without ever touching it.
  *
  * Degrades gracefully: no coordinates → log-only findings plus a pointer to
  * set a location; no cached weather and offline → same; sparse logs → an
@@ -45,6 +47,7 @@ import {
   type SeasonReviewInput,
 } from '@/lib/season-review/rules'
 import type { Finding, FindingSeverity } from '@/lib/season-review/findings'
+import NarrationPanel from '@/components/season-review/NarrationPanel'
 import { todayLocalISO } from '@/lib/log-date'
 
 const MONTH_NAMES = [
@@ -346,6 +349,17 @@ export default function SeasonReviewPage() {
                 </ul>
               )}
             </section>
+
+            {/* Opt-in AI narration — only once the findings it narrates are final */}
+            {findings.length > 0 && weatherStatus !== 'loading' && selectedReviewYear !== null && (
+              <section className="mb-8" aria-label="Season narration">
+                <NarrationPanel
+                  findings={findings}
+                  year={selectedReviewYear}
+                  allotmentName={data?.meta.name}
+                />
+              </section>
+            )}
 
             {/* Monthly weather vs baseline */}
             {weather && anomalies.length > 0 && (

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -43,8 +43,10 @@ type PanelStatus =
 
 function friendlyRequestError(error: unknown, baseUrl: string): string {
   const message = error instanceof Error ? error.message : String(error)
-  // The client aborts a hung request after its timeout.
-  if (error instanceof Error && error.name === 'AbortError') {
+  // The client aborts a hung request after its timeout. Duck-type on name —
+  // abort rejections are DOMExceptions, which older engines didn't parent
+  // under Error.
+  if ((error as { name?: unknown } | null)?.name === 'AbortError') {
     return (
       `The request to ${baseUrl} timed out. A local model may just be slow to ` +
       `load or generate on your machine — try again.`

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -22,7 +22,7 @@ import {
   OLLAMA_PRESET,
   type NarrationSettings,
 } from '@/lib/season-review/narration'
-import { getStorageItem, setStorageItem } from '@/services/allotment-storage'
+import { getStorageItem, setStorageItem } from '@/services/generic-storage'
 import { useSessionStorage } from '@/hooks/useSessionStorage'
 
 /** Endpoint + model persist across sessions; the optional key is session-only. */
@@ -43,6 +43,13 @@ type PanelStatus =
 
 function friendlyRequestError(error: unknown, baseUrl: string): string {
   const message = error instanceof Error ? error.message : String(error)
+  // The client aborts a hung request after its timeout.
+  if (error instanceof Error && error.name === 'AbortError') {
+    return (
+      `The request to ${baseUrl} timed out. A local model may just be slow to ` +
+      `load or generate on your machine — try again.`
+    )
+  }
   // fetch() network failures surface as TypeError with an opaque message —
   // translate to the causes a gardener can actually act on.
   if (error instanceof TypeError) {

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+/**
+ * Opt-in AI narration for the Season Review page (Phase 2c).
+ *
+ * Collapsed by default and completely inert until the user opens it and
+ * presses Generate — the deterministic findings above are the report, this
+ * is optional prose over them. The request goes straight from the browser to
+ * whatever OpenAI-compatible endpoint the user configures (local Ollama by
+ * default), and the result is ephemeral: shown once, never persisted.
+ *
+ * Every generated draft is number-checked against the findings
+ * (narration-verify.ts); a draft that mentions any number the findings don't
+ * vouch for is discarded and the panel says so.
+ */
+
+import { useEffect, useState } from 'react'
+import { CheckCircle2, Sparkles } from 'lucide-react'
+import type { Finding } from '@/lib/season-review/findings'
+import {
+  narrateSeason,
+  OLLAMA_PRESET,
+  type NarrationSettings,
+} from '@/lib/season-review/narration'
+import { getStorageItem, setStorageItem } from '@/services/allotment-storage'
+import { useSessionStorage } from '@/hooks/useSessionStorage'
+
+/** Endpoint + model persist across sessions; the optional key is session-only. */
+const NARRATION_CONFIG_KEY = 'bwp-narration-config'
+const NARRATION_API_KEY_KEY = 'bwp-narration-key'
+
+interface StoredNarrationConfig {
+  baseUrl: string
+  model: string
+}
+
+type PanelStatus =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ok'; text: string }
+  | { kind: 'rejected'; unverifiedNumbers: string[] }
+  | { kind: 'error'; message: string }
+
+function friendlyRequestError(error: unknown, baseUrl: string): string {
+  const message = error instanceof Error ? error.message : String(error)
+  // fetch() network failures surface as TypeError with an opaque message —
+  // translate to the causes a gardener can actually act on.
+  if (error instanceof TypeError) {
+    return (
+      `Couldn't reach ${baseUrl}. If you're using Ollama, check it's running ` +
+      `(ollama serve) and allows this site: set OLLAMA_ORIGINS to this app's ` +
+      `address. Custom endpoints must also be allowed by the deployment's ` +
+      `security policy.`
+    )
+  }
+  return message
+}
+
+export default function NarrationPanel({
+  findings,
+  year,
+  allotmentName,
+}: {
+  findings: Finding[]
+  year: number
+  allotmentName?: string
+}) {
+  const [baseUrl, setBaseUrl] = useState(OLLAMA_PRESET.baseUrl)
+  const [model, setModel] = useState(OLLAMA_PRESET.model)
+  const [apiKey, setApiKey] = useSessionStorage<string>(NARRATION_API_KEY_KEY, '')
+  const [status, setStatus] = useState<PanelStatus>({ kind: 'idle' })
+
+  useEffect(() => {
+    const stored = getStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY)
+    if (stored?.baseUrl) setBaseUrl(stored.baseUrl)
+    if (stored?.model) setModel(stored.model)
+  }, [])
+
+  // A new year (or freshly recomputed findings) makes old prose stale —
+  // narration is ephemeral by design, so simply drop it.
+  useEffect(() => {
+    setStatus({ kind: 'idle' })
+  }, [year, findings])
+
+  const handleGenerate = async () => {
+    const settings: NarrationSettings = {
+      baseUrl: baseUrl.trim() || OLLAMA_PRESET.baseUrl,
+      model: model.trim() || OLLAMA_PRESET.model,
+      ...(apiKey ? { apiKey } : {}),
+    }
+    setStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY, {
+      baseUrl: settings.baseUrl,
+      model: settings.model,
+    })
+    setStatus({ kind: 'loading' })
+    try {
+      const result = await narrateSeason(findings, { year, allotmentName }, settings)
+      if (result.status === 'ok') {
+        setStatus({ kind: 'ok', text: result.text })
+      } else {
+        setStatus({ kind: 'rejected', unverifiedNumbers: result.unverifiedNumbers })
+      }
+    } catch (error) {
+      setStatus({ kind: 'error', message: friendlyRequestError(error, settings.baseUrl) })
+    }
+  }
+
+  return (
+    <details className="zen-card group">
+      <summary className="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden p-4 text-sm text-zen-ink-700 hover:bg-zen-stone-50 rounded-zen">
+        <Sparkles className="w-4 h-4 text-zen-moss-600" aria-hidden="true" />
+        <span className="font-medium">Narrate this season</span>
+        <span className="text-zen-stone-400 font-normal">optional — bring your own AI</span>
+      </summary>
+
+      <div className="px-4 pb-4 space-y-4">
+        <p className="text-xs text-zen-stone-500">
+          Turns the findings above into a few paragraphs of prose using an AI model you run or
+          choose — by default a local Ollama, so nothing leaves your machine. Only the findings
+          and your allotment&apos;s name are sent (never your coordinates), directly from this
+          browser to the address below. Every number in the result is checked against the
+          findings; a draft that invents numbers is discarded. Nothing is saved.
+        </p>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <label htmlFor="narration-base-url" className="block text-xs font-medium text-zen-ink-700 mb-1">
+              Endpoint (OpenAI-compatible)
+            </label>
+            <input
+              id="narration-base-url"
+              type="text"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder={OLLAMA_PRESET.baseUrl}
+              className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
+              autoComplete="off"
+            />
+          </div>
+          <div>
+            <label htmlFor="narration-model" className="block text-xs font-medium text-zen-ink-700 mb-1">
+              Model
+            </label>
+            <input
+              id="narration-model"
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder={OLLAMA_PRESET.model}
+              className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
+              autoComplete="off"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="narration-api-key" className="block text-xs font-medium text-zen-ink-700 mb-1">
+            API key <span className="text-zen-stone-400 font-normal">(optional — Ollama needs none; kept for this session only)</span>
+          </label>
+          <input
+            id="narration-api-key"
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder="sk-…"
+            className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
+            autoComplete="off"
+          />
+        </div>
+
+        <button
+          onClick={handleGenerate}
+          disabled={status.kind === 'loading'}
+          className="zen-btn-primary min-h-[44px] disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {status.kind === 'loading' ? 'Writing…' : 'Generate narration'}
+        </button>
+
+        {status.kind === 'ok' && (
+          <div className="rounded-zen border border-zen-moss-200 bg-zen-moss-50 p-4">
+            <p className="text-sm text-zen-ink-800 whitespace-pre-line">{status.text}</p>
+            <p className="mt-3 text-xs text-zen-moss-700 flex items-center gap-1.5">
+              <CheckCircle2 className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+              Verified: every number above appears in the findings.
+            </p>
+          </div>
+        )}
+
+        {status.kind === 'rejected' && (
+          <div role="note" className="rounded-zen border border-zen-stone-200 bg-zen-stone-50 p-4 text-sm text-zen-ink-700">
+            The model&apos;s draft mentioned numbers that aren&apos;t in the findings
+            ({status.unverifiedNumbers.join(', ')}), so it was discarded. The findings above
+            are the verified report — you can try generating again.
+          </div>
+        )}
+
+        {status.kind === 'error' && (
+          <div role="alert" className="rounded-zen border border-zen-kitsune-200 bg-zen-kitsune-50 p-4 text-sm text-zen-ink-700">
+            {status.message}
+          </div>
+        )}
+      </div>
+    </details>
+  )
+}

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -95,10 +95,13 @@ export default function NarrationPanel({
 
   const handleGenerate = async () => {
     const generation = ++requestGeneration.current
+    // Pasted keys often carry stray whitespace, which would corrupt the
+    // Authorization header into a confusing auth failure.
+    const trimmedKey = apiKey.trim()
     const settings: NarrationSettings = {
       baseUrl: baseUrl.trim() || OLLAMA_PRESET.baseUrl,
       model: model.trim() || OLLAMA_PRESET.model,
-      ...(apiKey ? { apiKey } : {}),
+      ...(trimmedKey ? { apiKey: trimmedKey } : {}),
     }
     setStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY, {
       baseUrl: settings.baseUrl,

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -14,7 +14,7 @@
  * vouch for is discarded and the panel says so.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { CheckCircle2, Sparkles } from 'lucide-react'
 import type { Finding } from '@/lib/season-review/findings'
 import {
@@ -84,12 +84,17 @@ export default function NarrationPanel({
   }, [])
 
   // A new year (or freshly recomputed findings) makes old prose stale —
-  // narration is ephemeral by design, so simply drop it.
+  // narration is ephemeral by design, so simply drop it. Bumping the request
+  // generation also orphans any in-flight request so its late resolution
+  // can't repopulate the panel with prose about the previous inputs.
+  const requestGeneration = useRef(0)
   useEffect(() => {
+    requestGeneration.current += 1
     setStatus({ kind: 'idle' })
   }, [year, findings])
 
   const handleGenerate = async () => {
+    const generation = ++requestGeneration.current
     const settings: NarrationSettings = {
       baseUrl: baseUrl.trim() || OLLAMA_PRESET.baseUrl,
       model: model.trim() || OLLAMA_PRESET.model,
@@ -102,12 +107,14 @@ export default function NarrationPanel({
     setStatus({ kind: 'loading' })
     try {
       const result = await narrateSeason(findings, { year, allotmentName }, settings)
+      if (generation !== requestGeneration.current) return
       if (result.status === 'ok') {
         setStatus({ kind: 'ok', text: result.text })
       } else {
         setStatus({ kind: 'rejected', unverifiedNumbers: result.unverifiedNumbers })
       }
     } catch (error) {
+      if (generation !== requestGeneration.current) return
       setStatus({ kind: 'error', message: friendlyRequestError(error, settings.baseUrl) })
     }
   }

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -85,16 +85,24 @@ export default function NarrationPanel({
 
   // A new year (or freshly recomputed findings) makes old prose stale —
   // narration is ephemeral by design, so simply drop it. Bumping the request
-  // generation also orphans any in-flight request so its late resolution
-  // can't repopulate the panel with prose about the previous inputs.
+  // generation orphans any in-flight request so its late resolution can't
+  // repopulate the panel with prose about the previous inputs, and the abort
+  // actively cancels it — no point letting a local model keep generating a
+  // draft nobody will see.
   const requestGeneration = useRef(0)
+  const abortRef = useRef<AbortController | null>(null)
   useEffect(() => {
     requestGeneration.current += 1
     setStatus({ kind: 'idle' })
+    // Cleanup covers both a year/findings change and unmount.
+    return () => abortRef.current?.abort()
   }, [year, findings])
 
   const handleGenerate = async () => {
     const generation = ++requestGeneration.current
+    abortRef.current?.abort()
+    const abortController = new AbortController()
+    abortRef.current = abortController
     // Pasted keys often carry stray whitespace, which would corrupt the
     // Authorization header into a confusing auth failure.
     const trimmedKey = apiKey.trim()
@@ -109,7 +117,13 @@ export default function NarrationPanel({
     })
     setStatus({ kind: 'loading' })
     try {
-      const result = await narrateSeason(findings, { year, allotmentName }, settings)
+      const result = await narrateSeason(
+        findings,
+        { year, allotmentName },
+        settings,
+        undefined,
+        { signal: abortController.signal }
+      )
       if (generation !== requestGeneration.current) return
       if (result.status === 'ok') {
         setStatus({ kind: 'ok', text: result.text })

--- a/src/lib/season-review/narration-verify.ts
+++ b/src/lib/season-review/narration-verify.ts
@@ -39,17 +39,21 @@ function stripThousandsSeparators(text: string): string {
 
 /**
  * Canonical form of a numeric token so formatting differences never matter:
- * "21.50" and "21.5" compare equal, "07" reads as "7". Sign is not captured —
- * verification compares magnitudes ("-60mm" and "a 60mm deficit" are the same
- * fact wearing different grammar).
+ * "21.50" and "21.5" compare equal, "07" reads as "7", ".5" reads as "0.5".
+ * Sign is not captured — verification compares magnitudes ("-60mm" and "a
+ * 60mm deficit" are the same fact wearing different grammar).
  */
 function canonicalize(token: string): string {
   return String(Number.parseFloat(token))
 }
 
-/** Extract every numeric token from free text, canonicalized. */
+/**
+ * Extract every numeric token from free text, canonicalized. Bare-dot
+ * decimals (".5") are matched whole — splitting one into "5" would let a
+ * draft's ".5" ride on an unrelated vouched-for 5.
+ */
 export function extractNumericTokens(text: string): string[] {
-  const matches = stripThousandsSeparators(text).match(/\d+(?:\.\d+)?/g) ?? []
+  const matches = stripThousandsSeparators(text).match(/\d+(?:\.\d+)?|\.\d+/g) ?? []
   return matches.map(canonicalize)
 }
 
@@ -81,11 +85,11 @@ export function collectAllowedNumbers(
   allowed.add(canonicalize(String(meta.year)))
   allowed.add(canonicalize(String(meta.year + 1)))
   allowed.add(canonicalize(String(findings.length)))
-  const severityCounts = new Map<string, number>()
-  for (const finding of findings) {
-    severityCounts.set(finding.severity, (severityCounts.get(finding.severity) ?? 0) + 1)
-  }
-  for (const count of severityCounts.values()) {
+  // Count every severity, present or not, so "you had 2 notices and 0
+  // warnings" isn't rejected over the 0.
+  const severities: Finding['severity'][] = ['warning', 'notice', 'info']
+  for (const severity of severities) {
+    const count = findings.filter((f) => f.severity === severity).length
     allowed.add(canonicalize(String(count)))
   }
 

--- a/src/lib/season-review/narration-verify.ts
+++ b/src/lib/season-review/narration-verify.ts
@@ -26,6 +26,8 @@ export interface NarrationVerification {
 export interface VerificationMeta {
   /** The season year under review (also allows year + 1 for "next year"). */
   year: number
+  /** Allotment display name — it's sent to the model, so its digits are too. */
+  allotmentName?: string
 }
 
 /**
@@ -89,6 +91,7 @@ export function collectAllowedNumbers(
     }
   }
 
+  addFromText(meta.allotmentName)
   allowed.add(canonicalize(String(meta.year)))
   allowed.add(canonicalize(String(meta.year + 1)))
   allowed.add(canonicalize(String(findings.length)))

--- a/src/lib/season-review/narration-verify.ts
+++ b/src/lib/season-review/narration-verify.ts
@@ -60,8 +60,10 @@ export function extractNumericTokens(text: string): string[] {
 /**
  * Every number the findings can vouch for: numeric tokens in each summary,
  * each metrics value (numbers and numeric fragments of strings), each date
- * (ISO parts, so "2025-06-14" vouches for 2025, 6 and 14), plus the derived
- * allowance (year, year + 1, total and per-severity finding counts).
+ * (ISO parts, so "2025-06-14" vouches for 2025, 6 and 14), each entity
+ * display name (a draft naming "Raised Bed 1" isn't inventing the 1), plus
+ * the derived allowance (year, year + 1, total and per-severity finding
+ * counts).
  */
 export function collectAllowedNumbers(
   findings: Finding[],
@@ -80,6 +82,11 @@ export function collectAllowedNumbers(
     }
     addFromText(finding.dates?.start)
     addFromText(finding.dates?.end)
+    for (const entity of finding.entities) {
+      addFromText(entity.areaName)
+      addFromText(entity.plantName)
+      addFromText(entity.varietyName)
+    }
   }
 
   allowed.add(canonicalize(String(meta.year)))

--- a/src/lib/season-review/narration-verify.ts
+++ b/src/lib/season-review/narration-verify.ts
@@ -1,0 +1,111 @@
+/**
+ * Narration number verification (Phase 2c).
+ *
+ * The LLM narration layer is only trustworthy because of this module: after a
+ * model drafts a season narrative, every numeric token in the draft must be
+ * vouched for by the deterministic findings (their summaries, metric values,
+ * or dates) or by a small derived allowance (the season year, the year after
+ * it for "next year" phrasing, and the finding counts). A draft containing
+ * any number the findings can't account for is rejected outright and the UI
+ * falls back to the plain findings list.
+ *
+ * Deliberately conservative: rounding, unit conversion, and arithmetic the
+ * model performs itself all fail verification. A false rejection costs a
+ * paragraph of prose; a false acceptance costs trust in the whole report.
+ */
+
+import type { Finding } from './findings'
+
+export interface NarrationVerification {
+  ok: boolean
+  /** Numeric tokens in the narration no finding vouches for (canonical, deduped). */
+  unverifiedNumbers: string[]
+}
+
+/** Context numbers that are fair game even though no finding contains them. */
+export interface VerificationMeta {
+  /** The season year under review (also allows year + 1 for "next year"). */
+  year: number
+}
+
+/**
+ * Join digit groups split by thousands separators ("1,200" → "1200") without
+ * touching list commas ("3, 14" stays two tokens: the comma is only removed
+ * when exactly three digits follow).
+ */
+function stripThousandsSeparators(text: string): string {
+  return text.replace(/(\d),(?=\d{3}(?!\d))/g, '$1')
+}
+
+/**
+ * Canonical form of a numeric token so formatting differences never matter:
+ * "21.50" and "21.5" compare equal, "07" reads as "7". Sign is not captured —
+ * verification compares magnitudes ("-60mm" and "a 60mm deficit" are the same
+ * fact wearing different grammar).
+ */
+function canonicalize(token: string): string {
+  return String(Number.parseFloat(token))
+}
+
+/** Extract every numeric token from free text, canonicalized. */
+export function extractNumericTokens(text: string): string[] {
+  const matches = stripThousandsSeparators(text).match(/\d+(?:\.\d+)?/g) ?? []
+  return matches.map(canonicalize)
+}
+
+/**
+ * Every number the findings can vouch for: numeric tokens in each summary,
+ * each metrics value (numbers and numeric fragments of strings), each date
+ * (ISO parts, so "2025-06-14" vouches for 2025, 6 and 14), plus the derived
+ * allowance (year, year + 1, total and per-severity finding counts).
+ */
+export function collectAllowedNumbers(
+  findings: Finding[],
+  meta: VerificationMeta
+): Set<string> {
+  const allowed = new Set<string>()
+  const addFromText = (text: string | undefined) => {
+    if (!text) return
+    for (const token of extractNumericTokens(text)) allowed.add(token)
+  }
+
+  for (const finding of findings) {
+    addFromText(finding.summary)
+    for (const value of Object.values(finding.metrics)) {
+      addFromText(String(value))
+    }
+    addFromText(finding.dates?.start)
+    addFromText(finding.dates?.end)
+  }
+
+  allowed.add(canonicalize(String(meta.year)))
+  allowed.add(canonicalize(String(meta.year + 1)))
+  allowed.add(canonicalize(String(findings.length)))
+  const severityCounts = new Map<string, number>()
+  for (const finding of findings) {
+    severityCounts.set(finding.severity, (severityCounts.get(finding.severity) ?? 0) + 1)
+  }
+  for (const count of severityCounts.values()) {
+    allowed.add(canonicalize(String(count)))
+  }
+
+  return allowed
+}
+
+/**
+ * Check a narration draft against the findings. `ok` is true only when every
+ * numeric token in the draft is vouched for. Prose with no numbers passes —
+ * the checker guards against invented quantities, not dullness.
+ */
+export function verifyNarration(
+  narration: string,
+  findings: Finding[],
+  meta: VerificationMeta
+): NarrationVerification {
+  const allowed = collectAllowedNumbers(findings, meta)
+  const unverified = new Set<string>()
+  for (const token of extractNumericTokens(narration)) {
+    if (!allowed.has(token)) unverified.add(token)
+  }
+  return { ok: unverified.size === 0, unverifiedNumbers: [...unverified] }
+}

--- a/src/lib/season-review/narration-verify.ts
+++ b/src/lib/season-review/narration-verify.ts
@@ -51,11 +51,15 @@ function canonicalize(token: string): string {
 
 /**
  * Extract every numeric token from free text, canonicalized. Bare-dot
- * decimals (".5") are matched whole — splitting one into "5" would let a
- * draft's ".5" ride on an unrelated vouched-for 5.
+ * decimals (".5") and scientific notation ("1e6") are matched whole —
+ * splitting either into its digits would let a draft's invented value ride
+ * on unrelated vouched-for numbers.
  */
 export function extractNumericTokens(text: string): string[] {
-  const matches = stripThousandsSeparators(text).match(/\d+(?:\.\d+)?|\.\d+/g) ?? []
+  const matches =
+    stripThousandsSeparators(text).match(
+      /(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?/g
+    ) ?? []
   return matches.map(canonicalize)
 }
 

--- a/src/lib/season-review/narration.ts
+++ b/src/lib/season-review/narration.ts
@@ -45,6 +45,8 @@ export type NarrationResult =
 /** Low temperature: the job is faithful restatement, not creativity. */
 const NARRATION_TEMPERATURE = 0.2
 const NARRATION_MAX_TOKENS = 700
+/** Generous — a cold local model may need to load first — but never infinite. */
+const NARRATION_TIMEOUT_MS = 60_000
 
 const SYSTEM_PROMPT = `You write a short season summary for an allotment gardener's journal.
 
@@ -113,40 +115,50 @@ export async function requestNarration(
     headers['Authorization'] = `Bearer ${settings.apiKey}`
   }
 
-  const response = await fetchImpl(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      model: settings.model,
-      messages: buildNarrationMessages(findings, meta),
-      temperature: NARRATION_TEMPERATURE,
-      max_tokens: NARRATION_MAX_TOKENS,
-      stream: false,
-    }),
-  })
+  // A hung endpoint must fail predictably rather than pin the UI on
+  // "Writing…" forever.
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), NARRATION_TIMEOUT_MS)
 
-  if (!response.ok) {
-    let detail = ''
-    try {
-      const body = (await response.json()) as { error?: { message?: string } | string }
-      detail =
-        typeof body.error === 'string' ? body.error : body.error?.message ?? ''
-    } catch {
-      // Non-JSON error body — the status alone will have to do.
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: settings.model,
+        messages: buildNarrationMessages(findings, meta),
+        temperature: NARRATION_TEMPERATURE,
+        max_tokens: NARRATION_MAX_TOKENS,
+        stream: false,
+      }),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      let detail = ''
+      try {
+        const body = (await response.json()) as { error?: { message?: string } | string }
+        detail =
+          typeof body.error === 'string' ? body.error : body.error?.message ?? ''
+      } catch {
+        // Non-JSON error body — the status alone will have to do.
+      }
+      throw new Error(
+        `Narration endpoint returned ${response.status}${detail ? `: ${detail}` : ''}`
+      )
     }
-    throw new Error(
-      `Narration endpoint returned ${response.status}${detail ? `: ${detail}` : ''}`
-    )
-  }
 
-  const data = (await response.json()) as {
-    choices?: Array<{ message?: { content?: string | null } }>
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string | null } }>
+    }
+    const content = data.choices?.[0]?.message?.content
+    if (!content || !content.trim()) {
+      throw new Error('Narration endpoint returned an empty completion')
+    }
+    return content.trim()
+  } finally {
+    clearTimeout(timeoutId)
   }
-  const content = data.choices?.[0]?.message?.content
-  if (!content || !content.trim()) {
-    throw new Error('Narration endpoint returned an empty completion')
-  }
-  return content.trim()
 }
 
 /**

--- a/src/lib/season-review/narration.ts
+++ b/src/lib/season-review/narration.ts
@@ -176,7 +176,10 @@ export async function narrateSeason(
   fetchImpl: typeof fetch = fetch
 ): Promise<NarrationResult> {
   const text = await requestNarration(findings, meta, settings, fetchImpl)
-  const verification = verifyNarration(text, findings, { year: meta.year })
+  const verification = verifyNarration(text, findings, {
+    year: meta.year,
+    allotmentName: meta.allotmentName,
+  })
   if (!verification.ok) {
     return { status: 'rejected', text, unverifiedNumbers: verification.unverifiedNumbers }
   }

--- a/src/lib/season-review/narration.ts
+++ b/src/lib/season-review/narration.ts
@@ -109,7 +109,9 @@ export async function requestNarration(
   settings: NarrationSettings,
   fetchImpl: typeof fetch = fetch
 ): Promise<string> {
-  const url = `${settings.baseUrl.replace(/\/+$/, '')}/chat/completions`
+  // Trim defensively — the UI trims too, but this function is exported and a
+  // stray trailing space would otherwise fail as a cryptic invalid URL.
+  const url = `${settings.baseUrl.trim().replace(/\/+$/, '')}/chat/completions`
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (settings.apiKey) {
     headers['Authorization'] = `Bearer ${settings.apiKey}`

--- a/src/lib/season-review/narration.ts
+++ b/src/lib/season-review/narration.ts
@@ -101,6 +101,11 @@ export function buildNarrationMessages(
   ]
 }
 
+export interface NarrationRequestOptions {
+  /** External cancellation (e.g. the inputs changed and the draft is moot). */
+  signal?: AbortSignal
+}
+
 /**
  * Call the configured chat-completions endpoint and return the raw draft.
  * Throws on network failure, non-OK status, or an empty completion.
@@ -109,19 +114,36 @@ export async function requestNarration(
   findings: Finding[],
   meta: NarrationMeta,
   settings: NarrationSettings,
-  fetchImpl: typeof fetch = fetch
+  fetchImpl: typeof fetch = fetch,
+  options: NarrationRequestOptions = {}
 ): Promise<string> {
-  // Trim defensively — the UI trims too, but this function is exported and a
-  // stray trailing space would otherwise fail as a cryptic invalid URL. An
-  // empty base URL is refused outright: it would resolve to a *relative*
-  // "/chat/completions" and silently post the findings to this app's own
-  // origin, breaking the no-app-server-in-the-path contract.
+  // Trim and validate defensively — the UI does too, but this function is
+  // exported. A missing or non-absolute base URL is refused outright: it
+  // would resolve to a *relative* "/chat/completions" and silently post the
+  // findings to this app's own origin, breaking the no-app-server-in-the-path
+  // contract.
   const baseUrl = settings.baseUrl.trim().replace(/\/+$/, '')
   if (!baseUrl) {
     throw new Error('Narration endpoint base URL is required')
   }
+  let parsedBase: URL
+  try {
+    parsedBase = new URL(baseUrl)
+  } catch {
+    throw new Error(
+      `Narration endpoint base URL must be absolute (e.g. "${OLLAMA_PRESET.baseUrl}"), got "${baseUrl}"`
+    )
+  }
+  if (parsedBase.protocol !== 'http:' && parsedBase.protocol !== 'https:') {
+    throw new Error(
+      `Narration endpoint base URL must use http or https, got "${parsedBase.protocol}"`
+    )
+  }
   const url = `${baseUrl}/chat/completions`
   const model = settings.model.trim()
+  if (!model) {
+    throw new Error('Narration model is required')
+  }
   const apiKey = settings.apiKey?.trim()
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (apiKey) {
@@ -129,9 +151,16 @@ export async function requestNarration(
   }
 
   // A hung endpoint must fail predictably rather than pin the UI on
-  // "Writing…" forever.
+  // "Writing…" forever. The caller's signal chains into the same controller
+  // so a superseded request is actively cancelled, not just ignored.
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), NARRATION_TIMEOUT_MS)
+  const abortFromCaller = () => controller.abort()
+  if (options.signal?.aborted) {
+    clearTimeout(timeoutId)
+    throw new DOMException('The operation was aborted.', 'AbortError')
+  }
+  options.signal?.addEventListener('abort', abortFromCaller)
 
   try {
     const response = await fetchImpl(url, {
@@ -171,6 +200,7 @@ export async function requestNarration(
     return content.trim()
   } finally {
     clearTimeout(timeoutId)
+    options.signal?.removeEventListener('abort', abortFromCaller)
   }
 }
 
@@ -184,9 +214,10 @@ export async function narrateSeason(
   findings: Finding[],
   meta: NarrationMeta,
   settings: NarrationSettings,
-  fetchImpl: typeof fetch = fetch
+  fetchImpl: typeof fetch = fetch,
+  options: NarrationRequestOptions = {}
 ): Promise<NarrationResult> {
-  const text = await requestNarration(findings, meta, settings, fetchImpl)
+  const text = await requestNarration(findings, meta, settings, fetchImpl, options)
   const verification = verifyNarration(text, findings, {
     year: meta.year,
     allotmentName: meta.allotmentName,

--- a/src/lib/season-review/narration.ts
+++ b/src/lib/season-review/narration.ts
@@ -91,7 +91,9 @@ export function buildNarrationMessages(
     meta.allotmentName ? `Allotment: ${meta.allotmentName}` : null,
     `Season: ${meta.year}`,
     'Findings (JSON):',
-    JSON.stringify(findingsPayload(findings), null, 2),
+    // Compact — pretty-printing only spends context window, which is scarce
+    // on small local models.
+    JSON.stringify(findingsPayload(findings)),
   ].filter((line): line is string => line !== null)
   return [
     { role: 'system', content: SYSTEM_PROMPT },
@@ -110,11 +112,20 @@ export async function requestNarration(
   fetchImpl: typeof fetch = fetch
 ): Promise<string> {
   // Trim defensively — the UI trims too, but this function is exported and a
-  // stray trailing space would otherwise fail as a cryptic invalid URL.
-  const url = `${settings.baseUrl.trim().replace(/\/+$/, '')}/chat/completions`
+  // stray trailing space would otherwise fail as a cryptic invalid URL. An
+  // empty base URL is refused outright: it would resolve to a *relative*
+  // "/chat/completions" and silently post the findings to this app's own
+  // origin, breaking the no-app-server-in-the-path contract.
+  const baseUrl = settings.baseUrl.trim().replace(/\/+$/, '')
+  if (!baseUrl) {
+    throw new Error('Narration endpoint base URL is required')
+  }
+  const url = `${baseUrl}/chat/completions`
+  const model = settings.model.trim()
+  const apiKey = settings.apiKey?.trim()
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-  if (settings.apiKey) {
-    headers['Authorization'] = `Bearer ${settings.apiKey}`
+  if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`
   }
 
   // A hung endpoint must fail predictably rather than pin the UI on
@@ -127,7 +138,7 @@ export async function requestNarration(
       method: 'POST',
       headers,
       body: JSON.stringify({
-        model: settings.model,
+        model,
         messages: buildNarrationMessages(findings, meta),
         temperature: NARRATION_TEMPERATURE,
         max_tokens: NARRATION_MAX_TOKENS,

--- a/src/lib/season-review/narration.ts
+++ b/src/lib/season-review/narration.ts
@@ -1,0 +1,170 @@
+/**
+ * Season narration client (Phase 2c).
+ *
+ * Turns the deterministic findings[] into a few paragraphs of prose via a
+ * user-configured, OpenAI-compatible chat endpoint — local Ollama by default.
+ * Strictly opt-in and ephemeral: nothing here runs unless the user presses
+ * Generate on /season-review, the request goes straight from the browser to
+ * the endpoint the user configured (no app server in the path), and the
+ * result is never persisted anywhere.
+ *
+ * The findings are the ONLY season data the model sees — plus the allotment
+ * name and year. Coordinates never appear in findings and are never sent.
+ * The prose is decoration, not information: every draft is checked by
+ * `verifyNarration` (narration-verify.ts) and discarded if it contains any
+ * number the findings don't vouch for.
+ */
+
+import type { Finding } from './findings'
+import { verifyNarration } from './narration-verify'
+
+export interface NarrationSettings {
+  /** OpenAI-compatible base URL, e.g. "http://localhost:11434/v1". */
+  baseUrl: string
+  /** Model name as the endpoint knows it, e.g. "llama3.2". */
+  model: string
+  /** Optional bearer token for hosted OpenAI-compatible endpoints. */
+  apiKey?: string
+}
+
+/** The default preset: a local Ollama server. No key, nothing leaves the machine. */
+export const OLLAMA_PRESET: NarrationSettings = {
+  baseUrl: 'http://localhost:11434/v1',
+  model: 'llama3.2',
+}
+
+export interface NarrationMeta {
+  year: number
+  allotmentName?: string
+}
+
+export type NarrationResult =
+  | { status: 'ok'; text: string }
+  | { status: 'rejected'; text: string; unverifiedNumbers: string[] }
+
+/** Low temperature: the job is faithful restatement, not creativity. */
+const NARRATION_TEMPERATURE = 0.2
+const NARRATION_MAX_TOKENS = 700
+
+const SYSTEM_PROMPT = `You write a short season summary for an allotment gardener's journal.
+
+You will be given a JSON array of verified findings about one growing season. The findings are your only source of truth.
+
+Rules — follow every one:
+- Use only what the findings state. Do not add advice, causes, events or observations of your own.
+- Never write a number that does not appear in the findings. Copy numbers exactly as written — no rounding, no converting units, no arithmetic of your own.
+- Do not mention coordinates or any location.
+- Write 2 to 4 short paragraphs of plain prose addressed to the gardener. No headings, no bullet points, no markdown.`
+
+/**
+ * The exact findings payload sent to the model: severity, summary, metrics,
+ * entity display names and dates — nothing else from the season, and never
+ * coordinates (findings can't contain them by construction).
+ */
+function findingsPayload(findings: Finding[]): unknown[] {
+  return findings.map((f) => ({
+    severity: f.severity,
+    summary: f.summary,
+    metrics: f.metrics,
+    entities: f.entities.map((e) => ({
+      areaName: e.areaName,
+      plantName: e.plantName,
+      varietyName: e.varietyName,
+    })),
+    dates: f.dates,
+  }))
+}
+
+export interface ChatMessage {
+  role: 'system' | 'user'
+  content: string
+}
+
+/** Build the chat messages. Exported for tests. */
+export function buildNarrationMessages(
+  findings: Finding[],
+  meta: NarrationMeta
+): ChatMessage[] {
+  const lines = [
+    meta.allotmentName ? `Allotment: ${meta.allotmentName}` : null,
+    `Season: ${meta.year}`,
+    'Findings (JSON):',
+    JSON.stringify(findingsPayload(findings), null, 2),
+  ].filter((line): line is string => line !== null)
+  return [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: lines.join('\n') },
+  ]
+}
+
+/**
+ * Call the configured chat-completions endpoint and return the raw draft.
+ * Throws on network failure, non-OK status, or an empty completion.
+ */
+export async function requestNarration(
+  findings: Finding[],
+  meta: NarrationMeta,
+  settings: NarrationSettings,
+  fetchImpl: typeof fetch = fetch
+): Promise<string> {
+  const url = `${settings.baseUrl.replace(/\/+$/, '')}/chat/completions`
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (settings.apiKey) {
+    headers['Authorization'] = `Bearer ${settings.apiKey}`
+  }
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: settings.model,
+      messages: buildNarrationMessages(findings, meta),
+      temperature: NARRATION_TEMPERATURE,
+      max_tokens: NARRATION_MAX_TOKENS,
+      stream: false,
+    }),
+  })
+
+  if (!response.ok) {
+    let detail = ''
+    try {
+      const body = (await response.json()) as { error?: { message?: string } | string }
+      detail =
+        typeof body.error === 'string' ? body.error : body.error?.message ?? ''
+    } catch {
+      // Non-JSON error body — the status alone will have to do.
+    }
+    throw new Error(
+      `Narration endpoint returned ${response.status}${detail ? `: ${detail}` : ''}`
+    )
+  }
+
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string | null } }>
+  }
+  const content = data.choices?.[0]?.message?.content
+  if (!content || !content.trim()) {
+    throw new Error('Narration endpoint returned an empty completion')
+  }
+  return content.trim()
+}
+
+/**
+ * Generate a narration and verify it. Returns `ok` with the prose when every
+ * number is vouched for by the findings, or `rejected` (caller falls back to
+ * the plain findings list) when the draft invented any quantity. Network and
+ * endpoint errors propagate as exceptions.
+ */
+export async function narrateSeason(
+  findings: Finding[],
+  meta: NarrationMeta,
+  settings: NarrationSettings,
+  fetchImpl: typeof fetch = fetch
+): Promise<NarrationResult> {
+  const text = await requestNarration(findings, meta, settings, fetchImpl)
+  const verification = verifyNarration(text, findings, { year: meta.year })
+  if (!verification.ok) {
+    return { status: 'rejected', text, unverifiedNumbers: verification.unverifiedNumbers }
+  }
+  return { status: 'ok', text }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,6 +18,12 @@ function buildCspHeader(): string {
     'style-src': ["'self'", "'unsafe-inline'"],
     'connect-src': [
       "'self'",
+      // Season-review narration default preset: the user's own local Ollama.
+      // Browsers exempt localhost from mixed-content blocking, but CSP still
+      // needs the origin. Custom remote narration endpoints require adding
+      // their origin here.
+      'http://localhost:11434',
+      'http://127.0.0.1:11434',
       'https://api.openai.com',
       'https://api.bigdatacloud.net',
       'https://api-bdc.io',


### PR DESCRIPTION
## Summary

Resolves the open Phase 2c decision (`docs/plans/season-observer.md`) with a **provider-agnostic narration client**: configurable OpenAI-compatible endpoint + model, **local Ollama (`http://localhost:11434/v1`) as the default preset**, optional bearer key for hosted endpoints. No new required cloud service; narration is **strictly opt-in and OFF by default** — the deterministic `/season-review` page remains fully useful without it.

**How it works**
- `src/lib/season-review/narration.ts` — the client. Requests go straight from the browser to the endpoint the user configures (no app server in the path — a deployed server could never reach a user's `localhost` anyway). `temperature: 0.2`. The `findings[]` from the Phase 2b rules engine are the **only** season data sent, plus allotment name + year — never coordinates (findings can't contain them by construction), never internal ids. The system prompt forbids introducing numbers absent from the findings.
- `src/lib/season-review/narration-verify.ts` — **the real guarantee, deterministic code**: every numeric token in the model's draft must be vouched for by the findings (summary text, metric values, ISO date parts) or a small derived allowance (season year, year+1, finding counts). Tokens are canonicalized (`21.50` ≡ `21.5`, thousands separators joined, sign treated as grammar); model-side rounding, unit conversion, and arithmetic all fail verification. A failing draft is discarded and the panel says so — the plain findings list is the fallback report.
- `src/components/season-review/NarrationPanel.tsx` — a collapsed `<details>` on `/season-review`, inert until the user presses Generate. **Narration is ephemeral**: never persisted (not in the Yjs doc, not anywhere), dropped when the year or findings change. Endpoint + model persist in localStorage; the optional API key lives in sessionStorage, reusing the AI-advisor BYO-key pattern (`useSessionStorage`).
- `src/middleware.ts` — CSP `connect-src` gains `http://localhost:11434` + `http://127.0.0.1:11434` (browsers exempt localhost from mixed-content blocking, but CSP still needs the origin). Custom remote endpoints require adding their origin there; the panel surfaces a friendly hint (Ollama running? `OLLAMA_ORIGINS`?) on unreachable endpoints.
- **No release-visibility flag**: the collapsed panel that does nothing until configured-and-clicked *is* the gate; a flag would be sprawl (and note `SHOW_AI_ADVISOR` no longer exists — CLAUDE.md is stale there; the advisor is gated by `meta.aiAdvisorEnabled` + sign-in since #255's successor work).
- Docs updated: `season-observer.md` (2c decision + shipped), `current-plan.md`.

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes
- [x] I have updated documentation if needed

**Verification run:** `type-check` ✅ · `lint` ✅ · `test:unit` ✅ (1330 passed, incl. 35 new tests hard-testing the number checker, the mocked client, error paths, and the rejected-fallback orchestration) · `build` ✅ · Playwright chromium: homepage + quick-log specs 11/11 ✅; `data-management.spec.ts` failures in the sandbox are environmental (`failed_to_load_clerk_js` — Clerk CDN unreachable through the sandbox proxy, page untouched by this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dipu5pLuPrWR2kRas4Xe5s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dipu5pLuPrWR2kRas4Xe5s)_