### PR TITLE
Season Observer Phase 3: feed season-review findings into next-season planning

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,24 @@
 # Current Plan
 
-Last updated: 2026-07-14 (Season Observer Phase 2c report narration shipped)
+Last updated: 2026-07-15 (Season Observer Phase 3 plan feedback shipped)
+
+## Season Observer — Phase 3: plan feedback (shipped)
+
+The loop is closed: last season's findings now feed next season's planning,
+fully deterministic (no LLM in this phase). A new pure module
+(`src/lib/season-review/plan-adjustments.ts`) maps the Phase 2b findings[]
+1:1 by rule id into typed suggestions — an observed fact plus a concrete
+action ("Peas went into 6.5°C soil — this year wait until the soil holds 7°C,
+or start indoors"), with the same silence-on-thin-data discipline as the
+rules engine (missing metrics → nothing; context-only rules like monthly
+anomalies never become suggestions). The frost rule compares the planting
+date against `meta.frostDates.lastSpring` when known. A single "Learning
+from <year>" panel (`LastSeasonPanel.tsx`) surfaces them on `/allotment`
+when planning the current/next year with a previous season on record —
+weather cache-first like `/season-review`, degrading to log-only findings.
+Suggestions are computed on demand, never persisted; dismissal is per
+plan-year in localStorage, not the CRDT. Full detail in
+`docs/plans/season-observer.md`.
 
 ## Season Observer — Phase 2c: report narration (shipped)
 

--- a/docs/plans/season-observer.md
+++ b/docs/plans/season-observer.md
@@ -188,6 +188,43 @@ that a server can never reach a user's `localhost`.
   `narration.test.ts` (mocked fetch: request shape, auth header only with a
   key, prompt contract, error paths, verified/rejected orchestration).
 
+### Plan feedback (Phase 3) — **shipped**
+
+Closes the loop: last season's findings feed next season's planning, all
+deterministic (no LLM anywhere in this phase).
+
+- `src/lib/season-review/plan-adjustments.ts` — pure mapper: the findings[]
+  from `evaluateSeason()` in, typed `PlanAdjustment[]` out (observed fact +
+  concrete action, entities carried through). Each suggestion maps 1:1 to a
+  rule id and restates only numbers already in the finding's `metrics`, with
+  the rules engine's silence-on-thin-data discipline: missing metrics → no
+  suggestion, and rules with no concrete plan action (temp/rain anomalies,
+  water deficit, dull months — season context) never become suggestions.
+  Actionable mappings: cold-soil sowing → wait for the crop's soil threshold
+  (with last year's actual threshold date when known) or start indoors; slow
+  germination → sow later / pre-warm the bed; frost after tender planting-out
+  → hold back past `meta.frostDates.lastSpring` (compares the planting date
+  against the average last frost, with a fleece fallback when the frost came
+  after it, and a generic wait when no frost dates are known); heat stress →
+  bolt-resistant variety / earlier sowing, or shade + watering when nothing
+  bolted; dry spell → mulch + a watering routine for the spell's months;
+  pest/disease cluster → early netting/collars or spacing/family rotation for
+  that specific bed.
+- `src/components/allotment/LastSeasonPanel.tsx` — one focused "Learning
+  from <year>" panel on `/allotment`, rendered under the season status widget
+  only when planning the current/next year (selected year ≥ calendar year)
+  with a previous season on record. Weather loads cache-first via
+  `fetchSeasonWeather` + `getBaseline` (same pattern as `/season-review`) and
+  degrades to log-only findings; suggestions are computed on demand and never
+  persisted to the Yjs doc. Dismissal is per plan-year in localStorage
+  (`bwp-plan-feedback-dismissed:<year>`), not the CRDT. No adjustments → the
+  panel renders nothing at all. Links to `/season-review` for the full report.
+- Tests: `plan-adjustments.test.ts` (every rule → suggestion mapping, the
+  frost-date branches, and the missing-metric / unknown-rule / context-rule
+  silence cases) and `LastSeasonPanel.test.tsx` (renders from a log-only
+  season, silence without a record or without actionable findings, dismissal
+  persistence keyed by plan year).
+
 ### Not building (per brief non-goals)
 Bed-layout designer, sensors/hardware, cloud accounts/telemetry for this
 feature, real-time alerts, one-shot photo plant-ID as a headline, any

--- a/src/__tests__/components/LastSeasonPanel.test.tsx
+++ b/src/__tests__/components/LastSeasonPanel.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * LastSeasonPanel — the silence and dismissal guarantees. The panel must
+ * render nothing without a previous season or without actionable adjustments,
+ * work log-only when weather is unavailable, and keep a dismissal for the
+ * plan year in localStorage (never the CRDT).
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LastSeasonPanel from '@/components/allotment/LastSeasonPanel'
+import type { Area, CareLogEntry, SeasonRecord } from '@/types/unified-allotment'
+
+vi.mock('@/lib/weather/open-meteo-archive', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/weather/open-meteo-archive')>()),
+  fetchSeasonWeather: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/weather/weather-baseline', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/weather/weather-baseline')>()),
+  getBaseline: vi.fn().mockResolvedValue(null),
+}))
+
+const AREAS: Area[] = [
+  {
+    id: 'bed-b',
+    kind: 'rotation-bed',
+    name: 'Bed B',
+    canHavePlantings: true,
+    createdAt: '2025-01-01T00:00:00.000Z',
+  },
+]
+
+function pestLog(id: string, date: string): CareLogEntry {
+  return { id, type: 'pest', date, severity: 2 }
+}
+
+/** A 2025 season whose pest logs trigger the log-only cluster rule. */
+function seasonWithPestCluster(): SeasonRecord {
+  return {
+    year: 2025,
+    status: 'historical',
+    areas: [
+      {
+        areaId: 'bed-b',
+        plantings: [],
+        careLogs: [
+          pestLog('l1', '2025-06-05'),
+          pestLog('l2', '2025-06-12'),
+          pestLog('l3', '2025-06-28'),
+        ],
+      },
+    ],
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-12-01T00:00:00.000Z',
+  }
+}
+
+function quietSeason(): SeasonRecord {
+  return { ...seasonWithPestCluster(), areas: [{ areaId: 'bed-b', plantings: [] }] }
+}
+
+describe('LastSeasonPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders actionable suggestions derived from the previous season', async () => {
+    render(
+      <LastSeasonPanel planYear={2026} areas={AREAS} seasonRecord={seasonWithPestCluster()} />
+    )
+
+    expect(await screen.findByText('Learning from 2025')).toBeInTheDocument()
+    expect(screen.getByText(/3 pest observations were logged in Bed B/)).toBeInTheDocument()
+    expect(screen.getByText(/protect Bed B from the start/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /full season review/i })).toHaveAttribute(
+      'href',
+      '/season-review'
+    )
+  })
+
+  it('renders nothing without a previous season record', () => {
+    const { container } = render(
+      <LastSeasonPanel planYear={2026} areas={AREAS} seasonRecord={null} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the previous season yields no actionable adjustments', async () => {
+    const { container } = render(
+      <LastSeasonPanel planYear={2026} areas={AREAS} seasonRecord={quietSeason()} />
+    )
+    await waitFor(() => expect(container).toBeEmptyDOMElement())
+  })
+
+  it('dismissal hides the panel and persists per plan year in localStorage', async () => {
+    const { unmount } = render(
+      <LastSeasonPanel planYear={2026} areas={AREAS} seasonRecord={seasonWithPestCluster()} />
+    )
+    await userEvent.click(
+      await screen.findByRole('button', { name: /dismiss last season's suggestions for 2026/i })
+    )
+    expect(screen.queryByText('Learning from 2025')).not.toBeInTheDocument()
+    expect(localStorage.getItem('bwp-plan-feedback-dismissed:2026')).toBe('1')
+    unmount()
+
+    // A remount for the same plan year stays hidden…
+    const { container } = render(
+      <LastSeasonPanel planYear={2026} areas={AREAS} seasonRecord={seasonWithPestCluster()} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('a dismissal for one plan year does not silence another', async () => {
+    localStorage.setItem('bwp-plan-feedback-dismissed:2026', '1')
+    const record2026 = { ...seasonWithPestCluster(), year: 2026 }
+    record2026.areas[0].careLogs = record2026.areas[0].careLogs!.map((log, i) => ({
+      ...log,
+      date: log.date.replace('2025-', '2026-'),
+      id: `l${i + 1}-2026`,
+    }))
+    render(<LastSeasonPanel planYear={2027} areas={AREAS} seasonRecord={record2026} />)
+    expect(await screen.findByText('Learning from 2026')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/lib/season-review/plan-adjustments.test.ts
+++ b/src/__tests__/lib/season-review/plan-adjustments.test.ts
@@ -172,9 +172,20 @@ describe('derivePlanAdjustments', () => {
     it('suggests fleece when the planting was already after the average last frost', () => {
       const adj = single([frost], { frostDates: { ...FROST_DATES, lastSpring: '2026-04-20' } })
       expect(adj.action).toBe(
-        'You planted after your average last frost (~20 Apr) and still got caught — ' +
+        'You planted on or after your average last frost (~20 Apr) and still got caught — ' +
           'this year keep fleece over Courgette for its first weeks outside.'
       )
+    })
+
+    it('treats planting exactly on the average last frost date as on-or-after, not later-than', () => {
+      const adj = single([frost], { frostDates: { ...FROST_DATES, lastSpring: '2026-05-01' } })
+      expect(adj.action).toContain('You planted on or after your average last frost (~1 May)')
+      expect(adj.action).not.toContain('later than you planted')
+    })
+
+    it('falls back to the generic action when the average last frost date is malformed', () => {
+      const adj = single([frost], { frostDates: { ...FROST_DATES, lastSpring: '2026-99-99' } })
+      expect(adj.action).toContain('wait until frost risk has clearly passed')
     })
 
     it('gives a generic wait-for-frost-risk action when no frost dates are known', () => {

--- a/src/__tests__/lib/season-review/plan-adjustments.test.ts
+++ b/src/__tests__/lib/season-review/plan-adjustments.test.ts
@@ -1,0 +1,319 @@
+/**
+ * plan-adjustments — the Phase 3 findings → suggestions mapper. Every rule id
+ * must map to a concrete adjustment built only from the finding's own metrics,
+ * and anything with missing metrics, an unknown rule, or no concrete action
+ * must yield silence — the same discipline as the rules engine.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Finding } from '@/lib/season-review/findings'
+import {
+  derivePlanAdjustments,
+  type PlanAdjustment,
+} from '@/lib/season-review/plan-adjustments'
+
+const FROST_DATES = {
+  lastSpring: '2026-05-12',
+  firstAutumn: '2026-10-20',
+}
+
+function finding(overrides: Partial<Finding>): Finding {
+  return {
+    id: 'rule:2025:x',
+    ruleId: 'rule',
+    severity: 'notice',
+    summary: 'Something happened.',
+    metrics: {},
+    entities: [],
+    ...overrides,
+  }
+}
+
+function coldSoilFinding(metrics: Finding['metrics'] = {}): Finding {
+  return finding({
+    id: 'cold-soil-sowing:2025:p1',
+    ruleId: 'cold-soil-sowing',
+    severity: 'warning',
+    entities: [{ plantingId: 'p1', plantId: 'peas', plantName: 'Peas', areaId: 'bed-a', areaName: 'Bed A' }],
+    metrics: {
+      sowDate: '2025-03-20',
+      soilTempAtSowC: 6.5,
+      minSoilTempGerminationC: 7,
+      ...metrics,
+    },
+  })
+}
+
+function single(findings: Finding[], context?: Parameters<typeof derivePlanAdjustments>[1]): PlanAdjustment {
+  const adjustments = derivePlanAdjustments(findings, context)
+  expect(adjustments).toHaveLength(1)
+  return adjustments[0]
+}
+
+describe('derivePlanAdjustments', () => {
+  it('returns an empty array for no findings', () => {
+    expect(derivePlanAdjustments([])).toEqual([])
+  })
+
+  it('drops findings from unknown rules', () => {
+    expect(derivePlanAdjustments([finding({ ruleId: 'brand-new-rule' })])).toEqual([])
+  })
+
+  it('drops plot-wide context rules that have no concrete plan action', () => {
+    const contextRules = ['temp-anomaly', 'rain-anomaly', 'water-deficit', 'dull-month']
+    const findings = contextRules.map((ruleId) =>
+      finding({ id: `${ruleId}:2025:6`, ruleId, metrics: { month: 6 } })
+    )
+    expect(derivePlanAdjustments(findings)).toEqual([])
+  })
+
+  it('preserves the input order and carries finding identity through', () => {
+    const frost = finding({
+      id: 'frost-after-tender-planting:2025:p2',
+      ruleId: 'frost-after-tender-planting',
+      severity: 'warning',
+      entities: [{ plantingId: 'p2', plantId: 'courgette', plantName: 'Courgette' }],
+      metrics: { outdoorFrom: '2025-05-01', firstFrostDate: '2025-05-06', frostDays: 1, minTempC: -1 },
+    })
+    const adjustments = derivePlanAdjustments([coldSoilFinding(), frost])
+    expect(adjustments.map((a) => a.findingId)).toEqual([
+      'cold-soil-sowing:2025:p1',
+      'frost-after-tender-planting:2025:p2',
+    ])
+    expect(adjustments[0]).toMatchObject({
+      id: 'plan:cold-soil-sowing:2025:p1',
+      ruleId: 'cold-soil-sowing',
+      severity: 'warning',
+    })
+    expect(adjustments[0].entities).toEqual(coldSoilFinding().entities)
+  })
+
+  describe('cold-soil-sowing', () => {
+    it('maps to a wait-for-soil-temp or start-indoors adjustment', () => {
+      const adj = single([coldSoilFinding()])
+      expect(adj.observed).toBe('Peas went into 6.5°C soil on 20 Mar — below the ~7°C it needs to germinate.')
+      expect(adj.action).toBe(
+        'This year wait until the soil holds 7°C before sowing Peas outdoors, or start it indoors.'
+      )
+    })
+
+    it('includes when the soil actually reached the threshold, when known', () => {
+      const adj = single([coldSoilFinding({ soilReachedThresholdOn: '2025-04-14' })])
+      expect(adj.action).toContain("last year that wasn't until 14 Apr")
+      expect(adj.action).toContain('or start it indoors')
+    })
+
+    it('stays silent when the soil temperature metric is missing', () => {
+      const f = coldSoilFinding()
+      delete f.metrics.soilTempAtSowC
+      expect(derivePlanAdjustments([f])).toEqual([])
+    })
+
+    it('stays silent when the finding names no plant', () => {
+      const f = coldSoilFinding()
+      f.entities = [{ areaId: 'bed-a' }]
+      expect(derivePlanAdjustments([f])).toEqual([])
+    })
+
+    it('stays silent on an unparseable sow date', () => {
+      expect(derivePlanAdjustments([coldSoilFinding({ sowDate: 'not-a-date' })])).toEqual([])
+    })
+  })
+
+  describe('slow-germination', () => {
+    const slow = finding({
+      id: 'slow-germination:2025:p3',
+      ruleId: 'slow-germination',
+      entities: [{ plantingId: 'p3', plantId: 'carrot', plantName: 'Carrot' }],
+      metrics: {
+        sowDate: '2025-04-02',
+        germinatedDate: '2025-04-30',
+        actualDaysToGerminate: 28,
+        typicalDaysToGerminate: 14,
+      },
+    })
+
+    it('maps to a sow-later or pre-warm adjustment with both durations', () => {
+      const adj = single([slow])
+      expect(adj.observed).toBe('Carrot sown on 2 Apr took 28 days to germinate — typically ~14.')
+      expect(adj.action).toContain('sow Carrot a little later into warmer soil')
+      expect(adj.action).toContain('pre-warm the bed')
+    })
+
+    it('stays silent when the typical duration is missing', () => {
+      const f = { ...slow, metrics: { ...slow.metrics } }
+      delete f.metrics.typicalDaysToGerminate
+      expect(derivePlanAdjustments([f])).toEqual([])
+    })
+  })
+
+  describe('frost-after-tender-planting', () => {
+    const frost = finding({
+      id: 'frost-after-tender-planting:2025:p4',
+      ruleId: 'frost-after-tender-planting',
+      severity: 'warning',
+      entities: [{ plantingId: 'p4', plantId: 'courgette', plantName: 'Courgette' }],
+      metrics: {
+        outdoorFrom: '2025-05-01',
+        firstFrostDate: '2025-05-06',
+        frostDays: 1,
+        minTempC: -1.2,
+      },
+    })
+
+    it('uses the average last frost when it is later than the planting date', () => {
+      const adj = single([frost], { frostDates: FROST_DATES })
+      expect(adj.observed).toBe('Frost caught Courgette on 6 May after it went outside on 1 May.')
+      expect(adj.action).toBe(
+        'Your average last frost is around 12 May — later than you planted. ' +
+          'This year hold Courgette back until after that date, and keep fleece handy.'
+      )
+    })
+
+    it('suggests fleece when the planting was already after the average last frost', () => {
+      const adj = single([frost], { frostDates: { ...FROST_DATES, lastSpring: '2026-04-20' } })
+      expect(adj.action).toBe(
+        'You planted after your average last frost (~20 Apr) and still got caught — ' +
+          'this year keep fleece over Courgette for its first weeks outside.'
+      )
+    })
+
+    it('gives a generic wait-for-frost-risk action when no frost dates are known', () => {
+      const adj = single([frost])
+      expect(adj.action).toContain('wait until frost risk has clearly passed')
+      expect(adj.action).toContain('Courgette')
+    })
+
+    it('stays silent when the frost date is missing', () => {
+      const f = { ...frost, metrics: { ...frost.metrics } }
+      delete f.metrics.firstFrostDate
+      expect(derivePlanAdjustments([f], { frostDates: FROST_DATES })).toEqual([])
+    })
+  })
+
+  describe('heat-stress', () => {
+    const heat = finding({
+      id: 'heat-stress:2025:p5',
+      ruleId: 'heat-stress',
+      entities: [{ plantingId: 'p5', plantId: 'lettuce', plantName: 'Lettuce' }],
+      metrics: {
+        heatStressDays: 6,
+        heatStressTempC: 25,
+        windowStart: '2025-06-10',
+        windowEnd: '2025-07-20',
+      },
+    })
+
+    it('suggests a bolt-resistant variety when bolting was logged', () => {
+      const bolted = { ...heat, severity: 'warning' as const, metrics: { ...heat.metrics, boltedOn: '2025-07-01' } }
+      const adj = single([bolted])
+      expect(adj.observed).toBe('Lettuce bolted after 6 days at or above 25°C.')
+      expect(adj.action).toContain('bolt-resistant Lettuce variety')
+      expect(adj.action).toContain('sow earlier')
+    })
+
+    it('suggests shade or watering when there was heat but no bolting', () => {
+      const adj = single([heat])
+      expect(adj.observed).toBe('Lettuce sat through 6 days at or above 25°C.')
+      expect(adj.action).toContain('shade or steadier watering for Lettuce')
+    })
+
+    it('stays silent when the stress-day count is missing', () => {
+      const f = { ...heat, metrics: { ...heat.metrics } }
+      delete f.metrics.heatStressDays
+      expect(derivePlanAdjustments([f])).toEqual([])
+    })
+  })
+
+  describe('dry-spell', () => {
+    const spell = finding({
+      id: 'dry-spell:2025:2025-06-10',
+      ruleId: 'dry-spell',
+      metrics: {
+        startDate: '2025-06-10',
+        endDate: '2025-07-02',
+        lengthDays: 23,
+        totalRainMm: 3.4,
+      },
+    })
+
+    it('maps to a mulch-and-watering-routine adjustment spanning the spell months', () => {
+      const adj = single([spell])
+      expect(adj.observed).toBe('A 23-day dry spell ran 10 Jun–2 Jul with only 3.4mm of rain.')
+      expect(adj.action).toBe(
+        'This year mulch beds in spring to hold moisture, and plan a watering routine for June–July.'
+      )
+    })
+
+    it('names a single month when the spell stays within one', () => {
+      const june = {
+        ...spell,
+        metrics: { ...spell.metrics, startDate: '2025-06-02', endDate: '2025-06-20' },
+      }
+      expect(single([june]).action).toContain('watering routine for June.')
+    })
+
+    it('notes when no watering was logged during the spell', () => {
+      const unwatered = {
+        ...spell,
+        severity: 'warning' as const,
+        metrics: { ...spell.metrics, wateringsLogged: 0 },
+      }
+      expect(single([unwatered]).observed).toContain('and no watering was logged during it')
+    })
+
+    it('does not mention watering logs when some were made', () => {
+      const watered = { ...spell, metrics: { ...spell.metrics, wateringsLogged: 3 } }
+      expect(single([watered]).observed).not.toContain('no watering was logged')
+    })
+
+    it('stays silent when the spell length is missing', () => {
+      const f = { ...spell, metrics: { ...spell.metrics } }
+      delete f.metrics.lengthDays
+      expect(derivePlanAdjustments([f])).toEqual([])
+    })
+  })
+
+  describe('pest-disease-cluster', () => {
+    const cluster = finding({
+      id: 'pest-disease-cluster:2025:bed-b:pest',
+      ruleId: 'pest-disease-cluster',
+      entities: [{ areaId: 'bed-b', areaName: 'Bed B' }],
+      metrics: {
+        observationCount: 4,
+        type: 'pest',
+        firstDate: '2025-06-05',
+        lastDate: '2025-06-28',
+      },
+    })
+
+    it('suggests early protection for the bed on a pest cluster', () => {
+      const adj = single([cluster])
+      expect(adj.observed).toBe('4 pest observations were logged in Bed B, starting 5 Jun.')
+      expect(adj.action).toContain('protect Bed B from the start')
+      expect(adj.action).toContain('netting or collars in place before June')
+    })
+
+    it('suggests spacing and family rotation on a disease cluster', () => {
+      const disease = { ...cluster, metrics: { ...cluster.metrics, type: 'disease' } }
+      const adj = single([disease])
+      expect(adj.action).toContain('wider spacing for airflow')
+      expect(adj.action).toContain('avoid the same crop family')
+    })
+
+    it('falls back to the area id when the bed has no name', () => {
+      const unnamed = { ...cluster, entities: [{ areaId: 'bed-b' }] }
+      expect(single([unnamed]).observed).toContain('in bed-b')
+    })
+
+    it('stays silent on an unexpected observation type', () => {
+      const odd = { ...cluster, metrics: { ...cluster.metrics, type: 'weeds' } }
+      expect(derivePlanAdjustments([odd])).toEqual([])
+    })
+
+    it('stays silent when the observation count is missing', () => {
+      const f = { ...cluster, metrics: { ...cluster.metrics } }
+      delete f.metrics.observationCount
+      expect(derivePlanAdjustments([f])).toEqual([])
+    })
+  })
+})

--- a/src/app/allotment/page.tsx
+++ b/src/app/allotment/page.tsx
@@ -145,6 +145,10 @@ function AllotmentPageContent() {
 
   const selectedPlantings = selectedBedId ? getPlantings(selectedBedId) : []
 
+  // Stable reference so LastSeasonPanel's memoized evaluation only re-runs
+  // when the underlying data changes (same pattern as useTodayData).
+  const allAreas = useMemo(() => getAllAreas(), [getAllAreas])
+
   // Quick stats for empty state
   const quickStats = useMemo(() => ({
     rotationBeds: getRotationBeds().length,
@@ -420,11 +424,14 @@ function AllotmentPageContent() {
 
       {/* Last-season plan feedback (Season Observer Phase 3) — only when
           planning the current/next year with a previous season on record.
-          The panel renders nothing when there are no actionable suggestions. */}
+          The panel renders nothing when there are no actionable suggestions.
+          Keyed by year so switching years remounts it with fresh weather and
+          dismissal state instead of briefly showing the old year's. */}
       {selectedYear >= currentYear && (
         <LastSeasonPanel
+          key={selectedYear}
           planYear={selectedYear}
-          areas={getAllAreas()}
+          areas={allAreas}
           seasonRecord={data?.seasons.find(s => s.year === selectedYear - 1) ?? null}
           coordinates={data?.meta.coordinates}
           frostDates={data?.meta.frostDates}

--- a/src/app/allotment/page.tsx
+++ b/src/app/allotment/page.tsx
@@ -24,6 +24,7 @@ import { SHOW_ROTATION_SUGGESTIONS } from '@/config/release-visibility'
 import AllotmentGrid from '@/components/allotment/AllotmentGrid'
 import Dialog, { ConfirmDialog } from '@/components/ui/Dialog'
 import SeasonStatusWidget from '@/components/allotment/SeasonStatusWidget'
+import LastSeasonPanel from '@/components/allotment/LastSeasonPanel'
 import AddPlantingForm from '@/components/allotment/AddPlantingForm'
 import AddAreaForm from '@/components/allotment/AddAreaForm'
 import EditAreaForm from '@/components/allotment/EditAreaForm'
@@ -416,6 +417,19 @@ function AllotmentPageContent() {
           varietiesCount={getVarietiesForYear(selectedYear - 1).length}
         />
       </div>
+
+      {/* Last-season plan feedback (Season Observer Phase 3) — only when
+          planning the current/next year with a previous season on record.
+          The panel renders nothing when there are no actionable suggestions. */}
+      {selectedYear >= currentYear && (
+        <LastSeasonPanel
+          planYear={selectedYear}
+          areas={getAllAreas()}
+          seasonRecord={data?.seasons.find(s => s.year === selectedYear - 1) ?? null}
+          coordinates={data?.meta.coordinates}
+          frostDates={data?.meta.frostDates}
+        />
+      )}
 
       <div className="max-w-6xl mx-auto px-4 py-2">
         <div className="flex flex-col lg:grid lg:grid-cols-3 gap-6">

--- a/src/components/allotment/LastSeasonPanel.tsx
+++ b/src/components/allotment/LastSeasonPanel.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+/**
+ * Last-season panel (Season Observer Phase 3) — shown on /allotment when the
+ * user is planning a year that has a previous season on record. Feeds the
+ * season review's findings (rules.ts) through the pure plan-adjustments
+ * mapper and surfaces the concrete, rule-derived suggestions where planting
+ * decisions are made.
+ *
+ * Everything is computed on demand: weather comes cache-first from the
+ * archive client (like /season-review) and degrades to log-only findings
+ * when unavailable; nothing here is persisted to the Yjs doc. Dismissal is
+ * per plan-year in localStorage. Renders nothing at all when the previous
+ * season yields no actionable adjustments — silence over noise.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { ArrowRight, BookOpenCheck, X } from 'lucide-react'
+import type { Area, SeasonRecord } from '@/types/unified-allotment'
+import {
+  fetchSeasonWeather,
+  isValidPlotCoordinates,
+  type PlotCoordinates,
+  type SeasonWeather,
+} from '@/lib/weather/open-meteo-archive'
+import { getBaseline, type WeatherBaseline } from '@/lib/weather/weather-baseline'
+import { evaluateSeason } from '@/lib/season-review/rules'
+import type { FindingSeverity } from '@/lib/season-review/findings'
+import {
+  derivePlanAdjustments,
+  type PlanAdjustmentContext,
+} from '@/lib/season-review/plan-adjustments'
+
+const DISMISS_KEY_PREFIX = 'bwp-plan-feedback-dismissed:'
+
+function isDismissed(planYear: number): boolean {
+  try {
+    return localStorage.getItem(`${DISMISS_KEY_PREFIX}${planYear}`) === '1'
+  } catch {
+    return false
+  }
+}
+
+function persistDismissed(planYear: number): void {
+  try {
+    localStorage.setItem(`${DISMISS_KEY_PREFIX}${planYear}`, '1')
+  } catch {
+    // Quota/privacy-mode failure just means the panel returns next visit.
+  }
+}
+
+const SEVERITY_DOT: Record<FindingSeverity, string> = {
+  warning: 'bg-zen-kitsune-500',
+  notice: 'bg-zen-ink-500',
+  info: 'bg-zen-stone-400',
+}
+
+interface LastSeasonPanelProps {
+  /** The year being planned (the selected year on /allotment). */
+  planYear: number
+  /** All areas, for resolving bed names in findings. */
+  areas: Area[]
+  /** The previous year's season record, or null when there isn't one. */
+  seasonRecord: SeasonRecord | null
+  /** Coordinates from meta — re-validated here before any fetch. */
+  coordinates?: PlotCoordinates | null
+  /** Average frost dates from meta, when known. */
+  frostDates?: PlanAdjustmentContext['frostDates']
+}
+
+export default function LastSeasonPanel({
+  planYear,
+  areas,
+  seasonRecord,
+  coordinates,
+  frostDates,
+}: LastSeasonPanelProps) {
+  const reviewYear = planYear - 1
+  const [dismissed, setDismissed] = useState(() => isDismissed(planYear))
+  // Weather settles to null (no coords / offline / no cache) or data; the
+  // panel stays hidden until then so suggestions never pop in piecemeal.
+  const [weatherSettled, setWeatherSettled] = useState(false)
+  const [weather, setWeather] = useState<SeasonWeather | null>(null)
+  const [baseline, setBaseline] = useState<WeatherBaseline | null>(null)
+
+  // Re-read the dismissal when the plan year changes.
+  useEffect(() => {
+    setDismissed(isDismissed(planYear))
+  }, [planYear])
+
+  useEffect(() => {
+    if (!seasonRecord) return
+    if (!isValidPlotCoordinates(coordinates)) {
+      setWeather(null)
+      setBaseline(null)
+      setWeatherSettled(true)
+      return
+    }
+    let cancelled = false
+    setWeatherSettled(false)
+    setWeather(null)
+    setBaseline(null)
+    // Cache-first, same as /season-review — a previously reviewed season
+    // costs no network here.
+    Promise.all([fetchSeasonWeather(coordinates, reviewYear), getBaseline(coordinates)])
+      .then(([season, base]) => {
+        if (cancelled) return
+        setWeather(season)
+        setBaseline(base)
+        setWeatherSettled(true)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setWeather(null)
+        setBaseline(null)
+        setWeatherSettled(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [seasonRecord, coordinates, reviewYear])
+
+  const adjustments = useMemo(() => {
+    if (!seasonRecord || !weatherSettled) return []
+    const findings = evaluateSeason({
+      year: reviewYear,
+      areas,
+      seasonRecord,
+      weather,
+      baseline,
+    })
+    return derivePlanAdjustments(findings, { frostDates })
+  }, [seasonRecord, weatherSettled, reviewYear, areas, weather, baseline, frostDates])
+
+  if (!seasonRecord || dismissed || !weatherSettled || adjustments.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-2">
+      <section className="zen-card p-4 border-zen-moss-200" aria-label={`Learning from ${reviewYear}`}>
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <div className="flex items-center gap-2">
+            <BookOpenCheck className="w-5 h-5 text-zen-moss-600" />
+            <h2 className="font-medium text-zen-ink-800">Learning from {reviewYear}</h2>
+          </div>
+          <button
+            onClick={() => {
+              setDismissed(true)
+              persistDismissed(planYear)
+            }}
+            className="p-2 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-zen text-zen-stone-400 hover:text-zen-ink-700 hover:bg-zen-stone-100 transition"
+            aria-label={`Dismiss last season's suggestions for ${planYear}`}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <ul className="space-y-3">
+          {adjustments.map((adj) => (
+            <li key={adj.id} className="flex items-start gap-2.5">
+              <span
+                className={`w-2 h-2 rounded-full shrink-0 mt-1.5 ${SEVERITY_DOT[adj.severity]}`}
+                aria-hidden="true"
+              />
+              <div className="text-sm">
+                <p className="text-zen-stone-600">{adj.observed}</p>
+                <p className="text-zen-ink-800 font-medium mt-0.5">{adj.action}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <Link
+          href="/season-review"
+          className="mt-3 inline-flex items-center gap-1 text-sm text-zen-moss-700 hover:text-zen-moss-800"
+        >
+          Full season review
+          <ArrowRight className="w-4 h-4" />
+        </Link>
+      </section>
+    </div>
+  )
+}

--- a/src/components/allotment/LastSeasonPanel.tsx
+++ b/src/components/allotment/LastSeasonPanel.tsx
@@ -57,7 +57,11 @@ const SEVERITY_DOT: Record<FindingSeverity, string> = {
 }
 
 interface LastSeasonPanelProps {
-  /** The year being planned (the selected year on /allotment). */
+  /**
+   * The year being planned (the selected year on /allotment). Mount the
+   * panel with `key={planYear}` so a year switch remounts it — dismissal
+   * and weather state initialize per instance rather than tracking changes.
+   */
   planYear: number
   /** All areas, for resolving bed names in findings. */
   areas: Area[]
@@ -83,11 +87,6 @@ export default function LastSeasonPanel({
   const [weatherSettled, setWeatherSettled] = useState(false)
   const [weather, setWeather] = useState<SeasonWeather | null>(null)
   const [baseline, setBaseline] = useState<WeatherBaseline | null>(null)
-
-  // Re-read the dismissal when the plan year changes.
-  useEffect(() => {
-    setDismissed(isDismissed(planYear))
-  }, [planYear])
 
   useEffect(() => {
     if (!seasonRecord) return

--- a/src/lib/season-review/plan-adjustments.ts
+++ b/src/lib/season-review/plan-adjustments.ts
@@ -1,0 +1,283 @@
+/**
+ * Season Observer plan adjustments (Phase 3).
+ *
+ * Closes the plan → observe → learn → better-plan loop: last season's
+ * findings[] (rules.ts) in, typed next-season suggestions out. Pure and
+ * deterministic — no LLM, no storage, no network. Each suggestion maps 1:1
+ * to a rule id and restates only numbers already present in the finding's
+ * `metrics`, so everything shown is traceable to a tested metric.
+ *
+ * Same silence discipline as the rules engine: a finding whose metrics are
+ * missing the pieces an adjustment needs produces nothing, and findings with
+ * no concrete plan action (plot-wide context like temp/rain anomalies) are
+ * skipped entirely — an empty array is a valid, common result.
+ */
+
+import type { Finding, FindingEntity, FindingSeverity } from './findings'
+
+/** Average frost dates from `meta.frostDates`, when the plot has them. */
+export interface PlanAdjustmentContext {
+  frostDates?: {
+    lastSpring: string
+    firstAutumn: string
+  }
+}
+
+/** One concrete, rule-derived adjustment for next season's plan. */
+export interface PlanAdjustment {
+  /** Stable: `plan:${finding.id}`. */
+  id: string
+  /** The finding this adjustment was derived from. */
+  findingId: string
+  /** The rule the finding (and therefore this adjustment) came from. */
+  ruleId: string
+  severity: FindingSeverity
+  /** What happened last season — the finding's key fact, one sentence. */
+  observed: string
+  /** The concrete change to make this year, one sentence. */
+  action: string
+  /** Beds/plantings the adjustment refers to, carried from the finding. */
+  entities: FindingEntity[]
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+
+/** "2026-05-12" → "12 May". Null on anything unparseable — callers skip. */
+function formatDay(isoDate: string): string | null {
+  const month = Number(isoDate.slice(5, 7))
+  const day = Number(isoDate.slice(8, 10))
+  if (!Number.isInteger(month) || month < 1 || month > 12) return null
+  if (!Number.isInteger(day) || day < 1 || day > 31) return null
+  return `${day} ${MONTH_NAMES[month - 1].slice(0, 3)}`
+}
+
+/** "2026-07-03" → "July". Null on anything unparseable. */
+function monthNameOf(isoDate: string): string | null {
+  const month = Number(isoDate.slice(5, 7))
+  if (!Number.isInteger(month) || month < 1 || month > 12) return null
+  return MONTH_NAMES[month - 1]
+}
+
+/** "2026-05-12" → "05-12" for year-free calendar comparison. Null when malformed. */
+function monthDayOf(isoDate: string): string | null {
+  const md = isoDate.slice(5, 10)
+  return /^\d{2}-\d{2}$/.test(md) ? md : null
+}
+
+function metricNumber(finding: Finding, key: string): number | null {
+  const value = finding.metrics[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function metricString(finding: Finding, key: string): string | null {
+  const value = finding.metrics[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+/** The plant the finding is about, when its entities name one. */
+function plantNameOf(finding: Finding): string | null {
+  return finding.entities[0]?.plantName ?? null
+}
+
+function adjustment(
+  finding: Finding,
+  observed: string,
+  action: string
+): PlanAdjustment {
+  return {
+    id: `plan:${finding.id}`,
+    findingId: finding.id,
+    ruleId: finding.ruleId,
+    severity: finding.severity,
+    observed,
+    action,
+    entities: finding.entities,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-rule mappers. Each returns null when the finding is missing anything
+// the adjustment's sentences need — silence over a vague suggestion.
+// ---------------------------------------------------------------------------
+
+type AdjustmentMapper = (
+  finding: Finding,
+  context: PlanAdjustmentContext
+) => PlanAdjustment | null
+
+/** cold-soil-sowing → wait for the soil threshold, or start indoors. */
+function mapColdSoilSowing(finding: Finding): PlanAdjustment | null {
+  const plant = plantNameOf(finding)
+  const soilAtSow = metricNumber(finding, 'soilTempAtSowC')
+  const minTemp = metricNumber(finding, 'minSoilTempGerminationC')
+  const sowDate = metricString(finding, 'sowDate')
+  const sowDay = sowDate ? formatDay(sowDate) : null
+  if (!plant || soilAtSow === null || minTemp === null || !sowDay) return null
+
+  const reached = metricString(finding, 'soilReachedThresholdOn')
+  const reachedDay = reached ? formatDay(reached) : null
+  const observed =
+    `${plant} went into ${soilAtSow}°C soil on ${sowDay} — ` +
+    `below the ~${minTemp}°C it needs to germinate.`
+  const action = reachedDay
+    ? `This year wait until the soil holds ${minTemp}°C before sowing ${plant} outdoors ` +
+      `(last year that wasn't until ${reachedDay}), or start it indoors.`
+    : `This year wait until the soil holds ${minTemp}°C before sowing ${plant} outdoors, ` +
+      `or start it indoors.`
+  return adjustment(finding, observed, action)
+}
+
+/** slow-germination → sow later into warmer soil, or pre-warm the bed. */
+function mapSlowGermination(finding: Finding): PlanAdjustment | null {
+  const plant = plantNameOf(finding)
+  const actual = metricNumber(finding, 'actualDaysToGerminate')
+  const typical = metricNumber(finding, 'typicalDaysToGerminate')
+  const sowDate = metricString(finding, 'sowDate')
+  const sowDay = sowDate ? formatDay(sowDate) : null
+  if (!plant || actual === null || typical === null || !sowDay) return null
+
+  return adjustment(
+    finding,
+    `${plant} sown on ${sowDay} took ${actual} days to germinate — typically ~${typical}.`,
+    `This year sow ${plant} a little later into warmer soil, or pre-warm the bed ` +
+      `with a cloche or fleece for a couple of weeks before sowing.`
+  )
+}
+
+/** frost-after-tender-planting → hold tender plantings past the last frost. */
+function mapFrostAfterTenderPlanting(
+  finding: Finding,
+  context: PlanAdjustmentContext
+): PlanAdjustment | null {
+  const plant = plantNameOf(finding)
+  const outdoorFrom = metricString(finding, 'outdoorFrom')
+  const firstFrost = metricString(finding, 'firstFrostDate')
+  const outdoorDay = outdoorFrom ? formatDay(outdoorFrom) : null
+  const frostDay = firstFrost ? formatDay(firstFrost) : null
+  if (!plant || !outdoorFrom || !outdoorDay || !frostDay) return null
+
+  const observed = `Frost caught ${plant} on ${frostDay} after it went outside on ${outdoorDay}.`
+
+  const lastSpring = context.frostDates?.lastSpring
+  const lastSpringDay = lastSpring ? formatDay(lastSpring) : null
+  const lastSpringMd = lastSpring ? monthDayOf(lastSpring) : null
+  const plantedMd = monthDayOf(outdoorFrom)
+  if (lastSpringDay && lastSpringMd && plantedMd) {
+    const action =
+      lastSpringMd > plantedMd
+        ? `Your average last frost is around ${lastSpringDay} — later than you planted. ` +
+          `This year hold ${plant} back until after that date, and keep fleece handy.`
+        : `You planted after your average last frost (~${lastSpringDay}) and still got caught — ` +
+          `this year keep fleece over ${plant} for its first weeks outside.`
+    return adjustment(finding, observed, action)
+  }
+  return adjustment(
+    finding,
+    observed,
+    `This year wait until frost risk has clearly passed before planting ${plant} out, ` +
+      `and keep fleece handy for cold nights.`
+  )
+}
+
+/** heat-stress → bolt-resistant variety / earlier sowing / shade and water. */
+function mapHeatStress(finding: Finding): PlanAdjustment | null {
+  const plant = plantNameOf(finding)
+  const days = metricNumber(finding, 'heatStressDays')
+  const threshold = metricNumber(finding, 'heatStressTempC')
+  if (!plant || days === null || threshold === null) return null
+
+  const bolted = metricString(finding, 'boltedOn') !== null
+  const observed = bolted
+    ? `${plant} bolted after ${days} days at or above ${threshold}°C.`
+    : `${plant} sat through ${days} days at or above ${threshold}°C.`
+  const action = bolted
+    ? `This year pick a bolt-resistant ${plant} variety, or sow earlier so it matures ` +
+      `before the hottest weeks.`
+    : `This year plan shade or steadier watering for ${plant} in high summer, or time ` +
+      `sowings so it isn't maturing in the hottest weeks.`
+  return adjustment(finding, observed, action)
+}
+
+/** dry-spell → mulch in spring, plan a watering routine around the spell's months. */
+function mapDrySpell(finding: Finding): PlanAdjustment | null {
+  const length = metricNumber(finding, 'lengthDays')
+  const rain = metricNumber(finding, 'totalRainMm')
+  const start = metricString(finding, 'startDate')
+  const end = metricString(finding, 'endDate')
+  const startDay = start ? formatDay(start) : null
+  const endDay = end ? formatDay(end) : null
+  const startMonth = start ? monthNameOf(start) : null
+  const endMonth = end ? monthNameOf(end) : null
+  if (length === null || rain === null || !startDay || !endDay || !startMonth || !endMonth) {
+    return null
+  }
+
+  const noWatering = metricNumber(finding, 'wateringsLogged') === 0
+  const observed =
+    `A ${length}-day dry spell ran ${startDay}–${endDay} with only ${rain}mm of rain` +
+    `${noWatering ? ', and no watering was logged during it' : ''}.`
+  const window = startMonth === endMonth ? startMonth : `${startMonth}–${endMonth}`
+  return adjustment(
+    finding,
+    observed,
+    `This year mulch beds in spring to hold moisture, and plan a watering routine for ${window}.`
+  )
+}
+
+/** pest-disease-cluster → protect that bed from the start of the season. */
+function mapPestDiseaseCluster(finding: Finding): PlanAdjustment | null {
+  const count = metricNumber(finding, 'observationCount')
+  const type = metricString(finding, 'type')
+  const first = metricString(finding, 'firstDate')
+  const firstDay = first ? formatDay(first) : null
+  const firstMonth = first ? monthNameOf(first) : null
+  const bed = finding.entities[0]?.areaName ?? finding.entities[0]?.areaId ?? null
+  if (count === null || (type !== 'pest' && type !== 'disease') || !firstDay || !firstMonth || !bed) {
+    return null
+  }
+
+  const observed = `${count} ${type} observations were logged in ${bed}, starting ${firstDay}.`
+  const action =
+    type === 'pest'
+      ? `This year protect ${bed} from the start — netting or collars in place before ` +
+        `${firstMonth} — and check young plants weekly.`
+      : `This year give plantings in ${bed} wider spacing for airflow, avoid the same crop ` +
+        `family there, and remove affected leaves as soon as they show.`
+  return adjustment(finding, observed, action)
+}
+
+/**
+ * Rule id → mapper. Rules absent here (temp-anomaly, rain-anomaly,
+ * water-deficit, dull-month) are season context with no concrete per-plan
+ * action, so they never become suggestions.
+ */
+const MAPPERS: Readonly<Record<string, AdjustmentMapper>> = {
+  'cold-soil-sowing': mapColdSoilSowing,
+  'slow-germination': mapSlowGermination,
+  'frost-after-tender-planting': mapFrostAfterTenderPlanting,
+  'heat-stress': mapHeatStress,
+  'dry-spell': mapDrySpell,
+  'pest-disease-cluster': mapPestDiseaseCluster,
+}
+
+/**
+ * Derive next-season plan adjustments from a season's findings. Preserves
+ * the findings' order (evaluateSeason already sorts most-severe-first).
+ * Computed on demand, never persisted.
+ */
+export function derivePlanAdjustments(
+  findings: Finding[],
+  context: PlanAdjustmentContext = {}
+): PlanAdjustment[] {
+  const adjustments: PlanAdjustment[] = []
+  for (const finding of findings) {
+    const mapper = MAPPERS[finding.ruleId]
+    if (!mapper) continue
+    const mapped = mapper(finding, context)
+    if (mapped) adjustments.push(mapped)
+  }
+  return adjustments
+}

--- a/src/lib/season-review/plan-adjustments.ts
+++ b/src/lib/season-review/plan-adjustments.ts
@@ -63,8 +63,8 @@ function monthNameOf(isoDate: string): string | null {
 
 /** "2026-05-12" → "05-12" for year-free calendar comparison. Null when malformed. */
 function monthDayOf(isoDate: string): string | null {
-  const md = isoDate.slice(5, 10)
-  return /^\d{2}-\d{2}$/.test(md) ? md : null
+  // Same month/day range validation as formatDay — "2026-99-99" is rejected.
+  return formatDay(isoDate) === null ? null : isoDate.slice(5, 10)
 }
 
 function metricNumber(finding: Finding, key: string): number | null {
@@ -170,7 +170,7 @@ function mapFrostAfterTenderPlanting(
       lastSpringMd > plantedMd
         ? `Your average last frost is around ${lastSpringDay} — later than you planted. ` +
           `This year hold ${plant} back until after that date, and keep fleece handy.`
-        : `You planted after your average last frost (~${lastSpringDay}) and still got caught — ` +
+        : `You planted on or after your average last frost (~${lastSpringDay}) and still got caught — ` +
           `this year keep fleece over ${plant} for its first weeks outside.`
     return adjustment(finding, observed, action)
   }


### PR DESCRIPTION
## Summary

Closes the Season Observer's plan → observe → learn → **better-plan** loop (Phase 3, following #467/#475/#476/#477/#478): last season's rules-engine findings now surface as deterministic planning nudges where planting decisions happen.

- **`src/lib/season-review/plan-adjustments.ts`** — new pure module: `findings[]` (from `evaluateSeason()`) in, typed `PlanAdjustment[]` out (an observed fact + a concrete action, e.g. *"Peas went into 6.5°C soil — this year wait until the soil holds 7°C, or start it indoors"*). Each suggestion maps 1:1 to a rule id and restates only numbers already in the finding's `metrics`, with the rules engine's silence-on-thin-data discipline: missing metrics → no suggestion; context-only rules (temp/rain anomalies, water deficit, dull months) never become suggestions. The frost mapping compares the planting date against `meta.frostDates.lastSpring` when known (*"your average last frost is around 12 May — later than you planted"*). No LLM anywhere.
- **`src/components/allotment/LastSeasonPanel.tsx`** — one focused "Learning from \<year\>" panel on `/allotment`, under the season status widget, only when planning the current/next year with a previous season on record. Weather loads cache-first via the archive client (same pattern as `/season-review`) and degrades to log-only findings. Suggestions are computed on demand, never persisted to the Yjs doc; dismissal is per plan-year in localStorage (`bwp-plan-feedback-dismissed:<year>`), not the CRDT. No actionable adjustments → the panel renders nothing.
- Docs updated: `docs/plans/season-observer.md` and `docs/plans/current-plan.md` (Phase 3 shipped).

**Reused, not rebuilt:** `evaluateSeason()` findings, the cached archive weather client (`fetchSeasonWeather` + `getBaseline`), `meta.frostDates`, and the crop thresholds already embedded in each finding's metrics (sourced from `agronomy.ts`).

## Related issue

Season Observer roadmap (`docs/plans/season-observer.md`) — Phase 3.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes — 33 new unit tests (every rule → suggestion mapping, frost-date branches, no-data silence cases; panel render/silence/dismissal). `type-check`, `lint`, `test:unit` (1386 passed), and `build` all green.
- [x] I have updated documentation if needed


---
_Generated by [Claude Code](https://claude.ai/code/session_01XsyDnEbJpvDq53c9rHjaQB)_