### PR TITLE
Season Observer Phase 4: point-of-decision nudges in the Add Planting flow

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,24 @@
 # Current Plan
 
-Last updated: 2026-07-15 (Season Observer Phase 3 plan feedback shipped)
+Last updated: 2026-07-16 (Season Observer Phase 4 point-of-decision nudges shipped)
+
+## Season Observer — Phase 4: point-of-decision nudges (shipped)
+
+Last season's crop-specific lessons now appear where the decision is made:
+picking a plant in the Add Planting form for a year whose previous season
+produced a finding about that crop shows one compact "Last year: …" note per
+matching adjustment, verbatim from `derivePlanAdjustments` (no new rule
+text). Matching is a small pure selector, `adjustmentsForPlant(plantId,
+adjustments)` in `plan-adjustments.ts`, keyed on each adjustment's
+`entities[].plantId` — plot-wide adjustments (dry-spell) carry no plant
+entity and stay on the `/allotment` panel. The cache-first weather →
+`evaluateSeason` → derive pipeline that `LastSeasonPanel` owned moved into a
+shared `useLastSeasonAdjustments` hook (`src/hooks/useLastSeasonAdjustments.ts`)
+so the panel and the form compute from one place; the panel's rendering and
+dismissal behaviour are unchanged. Same guardrails as Phase 3: deterministic,
+computed on demand, nothing persisted to the Yjs doc, silence when nothing
+matches, evaluation memoized per season/weather (never per keystroke). Full
+detail in `docs/plans/season-observer.md`.
 
 ## Season Observer — Phase 3: plan feedback (shipped)
 

--- a/docs/plans/season-observer.md
+++ b/docs/plans/season-observer.md
@@ -225,6 +225,43 @@ deterministic (no LLM anywhere in this phase).
   season, silence without a record or without actionable findings, dismissal
   persistence keyed by plan year).
 
+### Point-of-decision nudges (Phase 4) — **shipped**
+
+Surfaces last season's crop-specific adjustment inside the Add Planting flow,
+at the moment the crop is picked. Same guardrails as Phase 3: deterministic,
+computed on demand, nothing persisted to the Yjs doc, and silence when
+nothing matches.
+
+- `adjustmentsForPlant(plantId, adjustments)` — small pure selector added to
+  `plan-adjustments.ts`, matching via each adjustment's `entities[].plantId`
+  (the vegetable-database id the form's combobox picks). Plot-wide
+  adjustments (dry-spell) carry no plant entity, so they never match — they
+  stay on the `/allotment` panel and never appear in the form. No new rule
+  text anywhere: the nudge renders the adjustment's `observed` + `action`
+  verbatim.
+- `src/hooks/useLastSeasonAdjustments.ts` — the cache-first weather
+  (`fetchSeasonWeather` + `getBaseline`) → `evaluateSeason` →
+  `derivePlanAdjustments` pipeline that `LastSeasonPanel` owned, extracted so
+  the panel and the form compute from one place. Takes the same inputs the
+  panel took as props (`planYear`, `areas`, `seasonRecord`, `coordinates`,
+  `frostDates`) and returns `{ settled, adjustments }`; evaluation is
+  memoized per (season, weather) — never per keystroke — and the hook adds
+  no fetches beyond the existing cache-first calls. The panel's rendering
+  and per-plan-year dismissal behaviour are unchanged.
+- `AddPlantingForm` — already reads `useAllotment()` (for frost dates), so it
+  derives the previous season record itself and shows one compact
+  "Last year: <observed> <action>" note per matching adjustment directly
+  under the plant picker (alongside the companion hints, complementing the
+  SowDateValidator output further down). The dialog only mounts the form
+  when opened, and `LastSeasonPanel` on the same page has already warmed the
+  season-weather cache, so opening the form costs no network.
+- Tests: selector cases in `plan-adjustments.test.ts` (crop matching,
+  plot-wide exclusion, empty inputs) and form integration in
+  `AddPlantingForm.test.tsx` (right nudge for the picked plant with
+  plot-wide advice excluded, silence for a crop without a matching
+  adjustment, silence when the previous season produced nothing) with the
+  shared hook mocked; existing form and panel tests unchanged.
+
 ### Not building (per brief non-goals)
 Bed-layout designer, sensors/hardware, cloud accounts/telemetry for this
 feature, real-time alerts, one-shot photo plant-ID as a headline, any

--- a/src/__tests__/components/AddPlantingForm.test.tsx
+++ b/src/__tests__/components/AddPlantingForm.test.tsx
@@ -10,6 +10,16 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import AddPlantingForm from '@/components/allotment/AddPlantingForm'
 import { StoredVariety, NewPlanting } from '@/types/unified-allotment'
+import type { PlanAdjustment } from '@/lib/season-review/plan-adjustments'
+
+// Mock the shared last-season adjustments hook (Season Observer Phase 4) so
+// these tests control the adjustments directly — no weather or season setup.
+const { mockUseLastSeasonAdjustments } = vi.hoisted(() => ({
+  mockUseLastSeasonAdjustments: vi.fn(),
+}))
+vi.mock('@/hooks/useLastSeasonAdjustments', () => ({
+  useLastSeasonAdjustments: mockUseLastSeasonAdjustments,
+}))
 
 // Mock the vegetable database
 vi.mock('@/lib/vegetable-database', () => ({
@@ -106,6 +116,9 @@ describe('AddPlantingForm Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default to a settled, adjustment-free previous season; the nudge
+    // tests override this per test.
+    mockUseLastSeasonAdjustments.mockReturnValue({ settled: true, adjustments: [] })
   })
 
   describe('Initial state', () => {
@@ -466,6 +479,83 @@ describe('AddPlantingForm Component', () => {
       await userEvent.selectOptions(screen.getByTestId('plant-select'), 'tomato')
 
       expect(screen.getByText(/add varieties to seed library/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Last-season nudges (Season Observer Phase 4)', () => {
+    const tomatoAdjustment: PlanAdjustment = {
+      id: 'plan:cold-soil-sowing:2025:p1',
+      findingId: 'cold-soil-sowing:2025:p1',
+      ruleId: 'cold-soil-sowing',
+      severity: 'warning',
+      observed: 'Tomato went into 6.5°C soil on 20 Mar — below the ~7°C it needs to germinate.',
+      action: 'This year wait until the soil holds 7°C before sowing Tomato outdoors, or start it indoors.',
+      entities: [{ plantingId: 'p1', plantId: 'tomato', plantName: 'Tomato' }],
+    }
+    const plotWideAdjustment: PlanAdjustment = {
+      id: 'plan:dry-spell:2025:2025-06-10',
+      findingId: 'dry-spell:2025:2025-06-10',
+      ruleId: 'dry-spell',
+      severity: 'notice',
+      observed: 'A 23-day dry spell ran 10 Jun–2 Jul with only 3.4mm of rain.',
+      action: 'This year mulch beds in spring to hold moisture, and plan a watering routine for June–July.',
+      entities: [],
+    }
+
+    it("shows last year's lesson for the picked crop, excluding plot-wide adjustments", async () => {
+      mockUseLastSeasonAdjustments.mockReturnValue({
+        settled: true,
+        adjustments: [tomatoAdjustment, plotWideAdjustment],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={2026}
+        />
+      )
+
+      await userEvent.selectOptions(screen.getByTestId('plant-select'), 'tomato')
+
+      expect(screen.getByText(/last year:/i)).toBeInTheDocument()
+      expect(screen.getByText(/went into 6\.5°C soil on 20 Mar/)).toBeInTheDocument()
+      expect(screen.getByText(/wait until the soil holds 7°C/)).toBeInTheDocument()
+      // Plot-wide dry-spell advice stays on the /allotment panel, never here.
+      expect(screen.queryByText(/dry spell/)).not.toBeInTheDocument()
+    })
+
+    it('stays silent for a picked crop without a matching adjustment', async () => {
+      mockUseLastSeasonAdjustments.mockReturnValue({
+        settled: true,
+        adjustments: [tomatoAdjustment, plotWideAdjustment],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={2026}
+        />
+      )
+
+      await userEvent.selectOptions(screen.getByTestId('plant-select'), 'lettuce')
+
+      expect(screen.queryByText(/last year:/i)).not.toBeInTheDocument()
+    })
+
+    it('stays silent when the previous season produced no adjustments', async () => {
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={2026}
+        />
+      )
+
+      await userEvent.selectOptions(screen.getByTestId('plant-select'), 'tomato')
+
+      expect(screen.queryByText(/last year:/i)).not.toBeInTheDocument()
     })
   })
 })

--- a/src/__tests__/hooks/useLastSeasonAdjustments.test.tsx
+++ b/src/__tests__/hooks/useLastSeasonAdjustments.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * useLastSeasonAdjustments — the shared cache-first weather → findings →
+ * adjustments hook behind LastSeasonPanel and the Add Planting nudges.
+ * The contract under test: `settled` flips true once the outcome is known
+ * (including "no previous season at all"), and the fetch effect keys on
+ * values — not object identities — so unrelated data mutations that
+ * regenerate the snapshot don't reset state or re-run the fetch.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLastSeasonAdjustments } from '@/hooks/useLastSeasonAdjustments'
+import { fetchSeasonWeather } from '@/lib/weather/open-meteo-archive'
+import type { Area, CareLogEntry, SeasonRecord } from '@/types/unified-allotment'
+
+vi.mock('@/lib/weather/open-meteo-archive', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/weather/open-meteo-archive')>()),
+  fetchSeasonWeather: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/weather/weather-baseline', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/weather/weather-baseline')>()),
+  getBaseline: vi.fn().mockResolvedValue(null),
+}))
+
+const AREAS: Area[] = [
+  {
+    id: 'bed-b',
+    kind: 'rotation-bed',
+    name: 'Bed B',
+    canHavePlantings: true,
+    createdAt: '2025-01-01T00:00:00.000Z',
+  },
+]
+
+const COORDINATES = { latitude: 55.95, longitude: -3.19 }
+
+function pestLog(id: string, date: string): CareLogEntry {
+  return { id, type: 'pest', date, severity: 2 }
+}
+
+/** A 2025 season whose pest logs trigger the log-only cluster rule. */
+function seasonWithPestCluster(): SeasonRecord {
+  return {
+    year: 2025,
+    status: 'historical',
+    areas: [
+      {
+        areaId: 'bed-b',
+        plantings: [],
+        careLogs: [
+          pestLog('l1', '2025-06-05'),
+          pestLog('l2', '2025-06-12'),
+          pestLog('l3', '2025-06-28'),
+        ],
+      },
+    ],
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-12-01T00:00:00.000Z',
+  }
+}
+
+describe('useLastSeasonAdjustments', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('settles immediately, with no fetch, when there is no previous season', async () => {
+    const { result } = renderHook(() =>
+      useLastSeasonAdjustments({
+        planYear: 2026,
+        areas: AREAS,
+        seasonRecord: null,
+        coordinates: COORDINATES,
+      })
+    )
+
+    await waitFor(() => expect(result.current.settled).toBe(true))
+    expect(result.current.adjustments).toEqual([])
+    expect(fetchSeasonWeather).not.toHaveBeenCalled()
+  })
+
+  it('derives adjustments from a log-only season and settles', async () => {
+    const { result } = renderHook(() =>
+      useLastSeasonAdjustments({
+        planYear: 2026,
+        areas: AREAS,
+        seasonRecord: seasonWithPestCluster(),
+        coordinates: COORDINATES,
+      })
+    )
+
+    await waitFor(() => expect(result.current.settled).toBe(true))
+    expect(result.current.adjustments).toHaveLength(1)
+    expect(result.current.adjustments[0].ruleId).toBe('pest-disease-cluster')
+    expect(fetchSeasonWeather).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refetch or unsettle when object identities change but values do not', async () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useLastSeasonAdjustments>[0]) =>
+        useLastSeasonAdjustments(props),
+      {
+        initialProps: {
+          planYear: 2026,
+          areas: AREAS,
+          seasonRecord: seasonWithPestCluster(),
+          coordinates: COORDINATES,
+        },
+      }
+    )
+    await waitFor(() => expect(result.current.settled).toBe(true))
+
+    // Fresh object identities, same values — the shape every snapshot
+    // regeneration after an unrelated mutation produces.
+    rerender({
+      planYear: 2026,
+      areas: [...AREAS],
+      seasonRecord: seasonWithPestCluster(),
+      coordinates: { ...COORDINATES },
+    })
+
+    expect(result.current.settled).toBe(true)
+    expect(result.current.adjustments).toHaveLength(1)
+    expect(fetchSeasonWeather).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles back to empty when the season record goes away', async () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useLastSeasonAdjustments>[0]) =>
+        useLastSeasonAdjustments(props),
+      {
+        initialProps: {
+          planYear: 2026,
+          areas: AREAS,
+          seasonRecord: seasonWithPestCluster() as SeasonRecord | null,
+          coordinates: COORDINATES,
+        },
+      }
+    )
+    await waitFor(() => expect(result.current.adjustments).toHaveLength(1))
+
+    rerender({
+      planYear: 2026,
+      areas: AREAS,
+      seasonRecord: null,
+      coordinates: COORDINATES,
+    })
+
+    await waitFor(() => expect(result.current.settled).toBe(true))
+    expect(result.current.adjustments).toEqual([])
+  })
+})

--- a/src/__tests__/lib/season-review/plan-adjustments.test.ts
+++ b/src/__tests__/lib/season-review/plan-adjustments.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Finding } from '@/lib/season-review/findings'
 import {
+  adjustmentsForPlant,
   derivePlanAdjustments,
   type PlanAdjustment,
 } from '@/lib/season-review/plan-adjustments'
@@ -326,5 +327,49 @@ describe('derivePlanAdjustments', () => {
       delete f.metrics.observationCount
       expect(derivePlanAdjustments([f])).toEqual([])
     })
+  })
+})
+
+describe('adjustmentsForPlant', () => {
+  /** Real adjustments from the mapper: peas (crop), lettuce (crop), dry spell (plot-wide). */
+  function mixedAdjustments(): PlanAdjustment[] {
+    const heat = finding({
+      id: 'heat-stress:2025:p5',
+      ruleId: 'heat-stress',
+      entities: [{ plantingId: 'p5', plantId: 'lettuce', plantName: 'Lettuce' }],
+      metrics: { heatStressDays: 6, heatStressTempC: 25 },
+    })
+    const drySpell = finding({
+      id: 'dry-spell:2025:2025-06-10',
+      ruleId: 'dry-spell',
+      metrics: { startDate: '2025-06-10', endDate: '2025-07-02', lengthDays: 23, totalRainMm: 3.4 },
+    })
+    const adjustments = derivePlanAdjustments([coldSoilFinding(), heat, drySpell])
+    expect(adjustments).toHaveLength(3)
+    return adjustments
+  }
+
+  it('returns only the adjustments whose entities name the picked plant', () => {
+    const matched = adjustmentsForPlant('peas', mixedAdjustments())
+    expect(matched).toHaveLength(1)
+    expect(matched[0].ruleId).toBe('cold-soil-sowing')
+    expect(matched[0].entities[0].plantId).toBe('peas')
+  })
+
+  it('never returns plot-wide adjustments, which carry no plant entity', () => {
+    const all = mixedAdjustments()
+    for (const plantId of ['peas', 'lettuce']) {
+      const matched = adjustmentsForPlant(plantId, all)
+      expect(matched.every((adj) => adj.ruleId !== 'dry-spell')).toBe(true)
+    }
+  })
+
+  it('returns an empty array for a plant with no matching adjustment', () => {
+    expect(adjustmentsForPlant('carrot', mixedAdjustments())).toEqual([])
+  })
+
+  it('returns an empty array for an empty plant id or no adjustments', () => {
+    expect(adjustmentsForPlant('', mixedAdjustments())).toEqual([])
+    expect(adjustmentsForPlant('peas', [])).toEqual([])
   })
 })

--- a/src/components/allotment/AddPlantingForm.tsx
+++ b/src/components/allotment/AddPlantingForm.tsx
@@ -1,14 +1,16 @@
 'use client'
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
-import { AlertTriangle, Check, Users, Calendar, ChevronDown, Lightbulb } from 'lucide-react'
+import { AlertTriangle, Check, Users, Calendar, ChevronDown, History, Lightbulb } from 'lucide-react'
 import { getVegetableById } from '@/lib/vegetable-database'
 import { getCompanionStatusForVegetable } from '@/lib/companion-utils'
 import { getRecommendedSowMethod, SowMethodRecommendation } from '@/lib/planting-utils'
 import { populateExpectedHarvest } from '@/lib/date-calculator'
+import { adjustmentsForPlant } from '@/lib/season-review/plan-adjustments'
 import { NewPlanting, Planting, StoredVariety, SowMethod, PlantingStatus } from '@/types/unified-allotment'
 import { VegetableCategory } from '@/types/garden-planner'
 import { useAllotment } from '@/hooks/useAllotment'
+import { useLastSeasonAdjustments } from '@/hooks/useLastSeasonAdjustments'
 import PlantCombobox from './PlantCombobox'
 import SowDateValidator from './SowDateValidator'
 
@@ -48,8 +50,31 @@ export default function AddPlantingForm({
   const [showDateDetails, setShowDateDetails] = useState(false)
   const [lastAdded, setLastAdded] = useState<string | null>(null)
 
-  const { data } = useAllotment()
+  const { data, getAllAreas } = useAllotment()
   const frostDates = data?.meta.frostDates
+
+  // Last season's crop-specific lessons (Season Observer Phase 4). The hook
+  // shares LastSeasonPanel's cache-first weather → findings → adjustments
+  // path and memoizes per season/weather — picking plants or typing never
+  // re-evaluates, and with no previous season it settles to silence.
+  const allAreas = useMemo(() => getAllAreas(), [getAllAreas])
+  const previousSeasonRecord = useMemo(
+    () => data?.seasons.find(s => s.year === selectedYear - 1) ?? null,
+    [data, selectedYear]
+  )
+  const { adjustments: lastSeasonAdjustments } = useLastSeasonAdjustments({
+    planYear: selectedYear,
+    areas: allAreas,
+    seasonRecord: previousSeasonRecord,
+    coordinates: data?.meta.coordinates,
+    frostDates,
+  })
+  // Only adjustments about the picked crop appear here; plot-wide ones
+  // (dry-spell) stay on the /allotment panel. No match → nothing rendered.
+  const cropNudges = useMemo(
+    () => adjustmentsForPlant(plantId, lastSeasonAdjustments),
+    [plantId, lastSeasonAdjustments]
+  )
 
   // Get current month for sow method recommendation
   const currentMonth = new Date().getMonth() + 1 // 1-12
@@ -207,6 +232,25 @@ export default function AddPlantingForm({
                 <span>Neutral with current plantings</span>
               </div>
             )}
+          </div>
+        )}
+
+        {/* Last season's lesson for this crop (Season Observer Phase 4) —
+            one compact note per rule-derived adjustment, verbatim from
+            derivePlanAdjustments. Renders nothing when nothing matched. */}
+        {cropNudges.length > 0 && (
+          <div className="mt-2 space-y-1">
+            {cropNudges.map(adj => (
+              <div
+                key={adj.id}
+                className="flex items-start gap-1.5 text-xs text-zen-ink-700 bg-zen-stone-50 px-2 py-1.5 rounded-zen"
+              >
+                <History className="w-3 h-3 mt-0.5 flex-shrink-0 text-zen-stone-500" aria-hidden="true" />
+                <span>
+                  <span className="font-medium">Last year:</span> {adj.observed} {adj.action}
+                </span>
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/src/components/allotment/LastSeasonPanel.tsx
+++ b/src/components/allotment/LastSeasonPanel.tsx
@@ -2,35 +2,25 @@
 
 /**
  * Last-season panel (Season Observer Phase 3) — shown on /allotment when the
- * user is planning a year that has a previous season on record. Feeds the
- * season review's findings (rules.ts) through the pure plan-adjustments
- * mapper and surfaces the concrete, rule-derived suggestions where planting
- * decisions are made.
+ * user is planning a year that has a previous season on record. Surfaces the
+ * concrete, rule-derived suggestions from `useLastSeasonAdjustments` (the
+ * shared cache-first weather → findings → adjustments hook, also feeding the
+ * Add Planting flow's per-crop nudges) where planting decisions are made.
  *
- * Everything is computed on demand: weather comes cache-first from the
- * archive client (like /season-review) and degrades to log-only findings
- * when unavailable; nothing here is persisted to the Yjs doc. Dismissal is
- * per plan-year in localStorage. Renders nothing at all when the previous
- * season yields no actionable adjustments — silence over noise.
+ * Everything is computed on demand; nothing here is persisted to the Yjs
+ * doc. Dismissal is per plan-year in localStorage. Renders nothing at all
+ * when the previous season yields no actionable adjustments — silence over
+ * noise.
  */
 
-import { useEffect, useMemo, useState } from 'react'
+import { useState } from 'react'
 import Link from 'next/link'
 import { ArrowRight, BookOpenCheck, X } from 'lucide-react'
 import type { Area, SeasonRecord } from '@/types/unified-allotment'
-import {
-  fetchSeasonWeather,
-  isValidPlotCoordinates,
-  type PlotCoordinates,
-  type SeasonWeather,
-} from '@/lib/weather/open-meteo-archive'
-import { getBaseline, type WeatherBaseline } from '@/lib/weather/weather-baseline'
-import { evaluateSeason } from '@/lib/season-review/rules'
+import type { PlotCoordinates } from '@/lib/weather/open-meteo-archive'
 import type { FindingSeverity } from '@/lib/season-review/findings'
-import {
-  derivePlanAdjustments,
-  type PlanAdjustmentContext,
-} from '@/lib/season-review/plan-adjustments'
+import type { PlanAdjustmentContext } from '@/lib/season-review/plan-adjustments'
+import { useLastSeasonAdjustments } from '@/hooks/useLastSeasonAdjustments'
 
 const DISMISS_KEY_PREFIX = 'bwp-plan-feedback-dismissed:'
 
@@ -82,57 +72,15 @@ export default function LastSeasonPanel({
 }: LastSeasonPanelProps) {
   const reviewYear = planYear - 1
   const [dismissed, setDismissed] = useState(() => isDismissed(planYear))
-  // Weather settles to null (no coords / offline / no cache) or data; the
-  // panel stays hidden until then so suggestions never pop in piecemeal.
-  const [weatherSettled, setWeatherSettled] = useState(false)
-  const [weather, setWeather] = useState<SeasonWeather | null>(null)
-  const [baseline, setBaseline] = useState<WeatherBaseline | null>(null)
+  const { settled, adjustments } = useLastSeasonAdjustments({
+    planYear,
+    areas,
+    seasonRecord,
+    coordinates,
+    frostDates,
+  })
 
-  useEffect(() => {
-    if (!seasonRecord) return
-    if (!isValidPlotCoordinates(coordinates)) {
-      setWeather(null)
-      setBaseline(null)
-      setWeatherSettled(true)
-      return
-    }
-    let cancelled = false
-    setWeatherSettled(false)
-    setWeather(null)
-    setBaseline(null)
-    // Cache-first, same as /season-review — a previously reviewed season
-    // costs no network here.
-    Promise.all([fetchSeasonWeather(coordinates, reviewYear), getBaseline(coordinates)])
-      .then(([season, base]) => {
-        if (cancelled) return
-        setWeather(season)
-        setBaseline(base)
-        setWeatherSettled(true)
-      })
-      .catch(() => {
-        if (cancelled) return
-        setWeather(null)
-        setBaseline(null)
-        setWeatherSettled(true)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [seasonRecord, coordinates, reviewYear])
-
-  const adjustments = useMemo(() => {
-    if (!seasonRecord || !weatherSettled) return []
-    const findings = evaluateSeason({
-      year: reviewYear,
-      areas,
-      seasonRecord,
-      weather,
-      baseline,
-    })
-    return derivePlanAdjustments(findings, { frostDates })
-  }, [seasonRecord, weatherSettled, reviewYear, areas, weather, baseline, frostDates])
-
-  if (!seasonRecord || dismissed || !weatherSettled || adjustments.length === 0) {
+  if (!seasonRecord || dismissed || !settled || adjustments.length === 0) {
     return null
   }
 

--- a/src/hooks/useLastSeasonAdjustments.ts
+++ b/src/hooks/useLastSeasonAdjustments.ts
@@ -1,0 +1,120 @@
+'use client'
+
+/**
+ * Last-season plan adjustments for a plan year (Season Observer Phase 4).
+ *
+ * The one place that turns "the year I'm planning" into rule-derived
+ * suggestions from the previous season: weather loads cache-first via the
+ * archive client (a previously reviewed season costs no network), findings
+ * come from `evaluateSeason`, and the pure `derivePlanAdjustments` mapper
+ * produces the suggestions. Extracted from LastSeasonPanel so the panel and
+ * the Add Planting flow compute from the same logic instead of duplicating
+ * the cache-first pattern.
+ *
+ * Everything is computed on demand and memoized per (season, weather) —
+ * never per keystroke — and nothing is persisted to the Yjs doc. Weather
+ * degrades to null (log-only findings) when coordinates are missing, the
+ * device is offline, or nothing is cached; `settled` flips true once that
+ * outcome is known so consumers can hold rendering until suggestions are
+ * complete rather than popping in piecemeal.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import type { Area, SeasonRecord } from '@/types/unified-allotment'
+import {
+  fetchSeasonWeather,
+  isValidPlotCoordinates,
+  type PlotCoordinates,
+  type SeasonWeather,
+} from '@/lib/weather/open-meteo-archive'
+import { getBaseline, type WeatherBaseline } from '@/lib/weather/weather-baseline'
+import { evaluateSeason } from '@/lib/season-review/rules'
+import {
+  derivePlanAdjustments,
+  type PlanAdjustment,
+  type PlanAdjustmentContext,
+} from '@/lib/season-review/plan-adjustments'
+
+export interface UseLastSeasonAdjustmentsInputs {
+  /** The year being planned; the review runs over `planYear - 1`. */
+  planYear: number
+  /** All areas, for resolving bed names in findings. */
+  areas: Area[]
+  /** The previous year's season record, or null when there isn't one. */
+  seasonRecord: SeasonRecord | null
+  /** Coordinates from meta — re-validated here before any fetch. */
+  coordinates?: PlotCoordinates | null
+  /** Average frost dates from meta, when known. */
+  frostDates?: PlanAdjustmentContext['frostDates']
+}
+
+export interface UseLastSeasonAdjustmentsResult {
+  /**
+   * True once weather has settled (loaded, cache-served, or confirmed
+   * unavailable). `adjustments` stays empty until then.
+   */
+  settled: boolean
+  /** Rule-derived suggestions from the previous season; often empty. */
+  adjustments: PlanAdjustment[]
+}
+
+export function useLastSeasonAdjustments({
+  planYear,
+  areas,
+  seasonRecord,
+  coordinates,
+  frostDates,
+}: UseLastSeasonAdjustmentsInputs): UseLastSeasonAdjustmentsResult {
+  const reviewYear = planYear - 1
+  // Weather settles to null (no coords / offline / no cache) or data;
+  // adjustments stay empty until then so suggestions never pop in piecemeal.
+  const [weatherSettled, setWeatherSettled] = useState(false)
+  const [weather, setWeather] = useState<SeasonWeather | null>(null)
+  const [baseline, setBaseline] = useState<WeatherBaseline | null>(null)
+
+  useEffect(() => {
+    if (!seasonRecord) return
+    if (!isValidPlotCoordinates(coordinates)) {
+      setWeather(null)
+      setBaseline(null)
+      setWeatherSettled(true)
+      return
+    }
+    let cancelled = false
+    setWeatherSettled(false)
+    setWeather(null)
+    setBaseline(null)
+    // Cache-first, same as /season-review — a previously reviewed season
+    // costs no network here.
+    Promise.all([fetchSeasonWeather(coordinates, reviewYear), getBaseline(coordinates)])
+      .then(([season, base]) => {
+        if (cancelled) return
+        setWeather(season)
+        setBaseline(base)
+        setWeatherSettled(true)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setWeather(null)
+        setBaseline(null)
+        setWeatherSettled(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [seasonRecord, coordinates, reviewYear])
+
+  const adjustments = useMemo(() => {
+    if (!seasonRecord || !weatherSettled) return []
+    const findings = evaluateSeason({
+      year: reviewYear,
+      areas,
+      seasonRecord,
+      weather,
+      baseline,
+    })
+    return derivePlanAdjustments(findings, { frostDates })
+  }, [seasonRecord, weatherSettled, reviewYear, areas, weather, baseline, frostDates])
+
+  return { settled: weatherSettled, adjustments }
+}

--- a/src/hooks/useLastSeasonAdjustments.ts
+++ b/src/hooks/useLastSeasonAdjustments.ts
@@ -72,9 +72,20 @@ export function useLastSeasonAdjustments({
   const [weather, setWeather] = useState<SeasonWeather | null>(null)
   const [baseline, setBaseline] = useState<WeatherBaseline | null>(null)
 
+  // The fetch needs only "is there a season to review" plus the coordinate
+  // values — depending on primitives rather than object identity keeps
+  // unrelated data mutations (which regenerate the snapshot and every
+  // object in it) from resetting `settled` and re-running the effect.
+  const hasSeasonRecord = seasonRecord !== null
+  const latitude = coordinates?.latitude
+  const longitude = coordinates?.longitude
+
   useEffect(() => {
-    if (!seasonRecord) return
-    if (!isValidPlotCoordinates(coordinates)) {
+    const coords =
+      latitude !== undefined && longitude !== undefined ? { latitude, longitude } : null
+    if (!hasSeasonRecord || !isValidPlotCoordinates(coords)) {
+      // No season means nothing will ever load; no valid coordinates means
+      // weather is log-only. Either way the outcome is known: settle now.
       setWeather(null)
       setBaseline(null)
       setWeatherSettled(true)
@@ -86,7 +97,7 @@ export function useLastSeasonAdjustments({
     setBaseline(null)
     // Cache-first, same as /season-review — a previously reviewed season
     // costs no network here.
-    Promise.all([fetchSeasonWeather(coordinates, reviewYear), getBaseline(coordinates)])
+    Promise.all([fetchSeasonWeather(coords, reviewYear), getBaseline(coords)])
       .then(([season, base]) => {
         if (cancelled) return
         setWeather(season)
@@ -102,7 +113,7 @@ export function useLastSeasonAdjustments({
     return () => {
       cancelled = true
     }
-  }, [seasonRecord, coordinates, reviewYear])
+  }, [hasSeasonRecord, latitude, longitude, reviewYear])
 
   const adjustments = useMemo(() => {
     if (!seasonRecord || !weatherSettled) return []

--- a/src/lib/season-review/plan-adjustments.ts
+++ b/src/lib/season-review/plan-adjustments.ts
@@ -281,3 +281,19 @@ export function derivePlanAdjustments(
   }
   return adjustments
 }
+
+/**
+ * The adjustments that are about one specific crop, matched via each
+ * adjustment's `entities[].plantId` (Phase 4 point-of-decision nudges).
+ * Plot-wide adjustments (dry-spell) carry no plant entity and never match —
+ * they belong on the plan-level panel, not next to a single crop picker.
+ */
+export function adjustmentsForPlant(
+  plantId: string,
+  adjustments: PlanAdjustment[]
+): PlanAdjustment[] {
+  if (!plantId) return []
+  return adjustments.filter((adj) =>
+    adj.entities.some((entity) => entity.plantId === plantId)
+  )
+}


### PR DESCRIPTION
## Summary

Surfaces last season's crop-specific adjustment inside the Add Planting flow: picking a plant for a year whose previous season produced a finding about that same crop shows one compact "Last year: …" note per matching adjustment, rendered directly under the plant picker (complementing the existing SowDateValidator output further down the form).

- **No new rule text** — nudges render each adjustment's `observed` + `action` verbatim from `derivePlanAdjustments`. The only addition to `plan-adjustments.ts` is a small pure selector, `adjustmentsForPlant(plantId, adjustments)`, matching via each adjustment's `entities[].plantId`. Plot-wide adjustments (dry-spell) carry no plant entity, so they never match — they stay on the `/allotment` panel and never appear in the form.
- **Shared hook** — the cache-first weather (`fetchSeasonWeather` + `getBaseline`) → `evaluateSeason` → `derivePlanAdjustments` pipeline that `LastSeasonPanel` owned is extracted into `useLastSeasonAdjustments` (`src/hooks/useLastSeasonAdjustments.ts`), so the form and the panel compute from one place instead of duplicating the pattern. The panel keeps its exact props, rendering, and per-plan-year dismissal behaviour.
- **Phase 3 guardrails hold** — deterministic only, computed on demand, nothing persisted to the Yjs doc. Silence discipline: no matching adjustment → the form shows nothing at all. Evaluation is memoized per season/weather (never per keystroke), and the hook adds no fetches beyond the existing cache-first calls; the dialog only mounts the form when opened, and the panel on the same page has already warmed the season-weather cache.

Note: work landed on `claude/season-observer-phase-4-r1s7pm` (this session's designated branch) rather than the `claude/season-observer-planting-nudges` name from the task description.

## Related issue

Season Observer Phase 4 — follows #467, #475, #476, #477, #478, #479.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes — new selector unit tests (matching, plot-wide exclusion, empty cases) and form integration tests (right nudge for the picked plant, silent otherwise); `type-check`, `lint`, `test:unit` (1395 passed), and `build` all pass, with no regression to existing form or panel tests
- [x] I have updated documentation if needed — `docs/plans/season-observer.md` (Phase 4 shipped) and `docs/plans/current-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSwwqwff3aqgvrrZKCMhcX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSwwqwff3aqgvrrZKCMhcX)_