### PR TITLE
Season Observer Phase 5: bed-scoped nudges in the Add Planting flow

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,25 @@
 # Current Plan
 
-Last updated: 2026-07-16 (Season Observer Phase 4 point-of-decision nudges shipped)
+Last updated: 2026-07-17 (Season Observer Phase 5 bed-scoped nudges shipped)
+
+## Season Observer — Phase 5: bed-scoped nudges (shipped)
+
+Last season's bed-specific lessons now appear in the Add Planting form for
+the bed being planted into, regardless of which plant is picked: one compact
+"Last year in this bed: …" note per matching adjustment, above the Phase 4
+crop nudges, verbatim from `derivePlanAdjustments` (no new rule text).
+Matching is a small pure selector, `adjustmentsForArea(areaId, adjustments)`
+in `plan-adjustments.ts`, keyed on each adjustment's `entities[].areaId` and
+excluding adjustments that name a plant — those stay crop-matched via
+`adjustmentsForPlant`, so a finding carrying both a bed and a plant never
+renders twice. Today only `pest-disease-cluster` emits area-only entities;
+plot-wide adjustments (dry-spell) still never appear in the form. The form
+gained an optional `areaId` prop, passed as `selectedBedId` at its single
+mount point (the `/allotment` Add Planting dialog, which both the desktop
+sidebar and the mobile bottom sheet open). `useLastSeasonAdjustments` and
+`LastSeasonPanel` are unchanged. Same guardrails as Phase 4: deterministic,
+computed on demand, nothing persisted to the Yjs doc, no new fetches,
+silence when nothing matches. Full detail in `docs/plans/season-observer.md`.
 
 ## Season Observer — Phase 4: point-of-decision nudges (shipped)
 

--- a/docs/plans/season-observer.md
+++ b/docs/plans/season-observer.md
@@ -262,6 +262,38 @@ nothing matches.
   adjustment, silence when the previous season produced nothing) with the
   shared hook mocked; existing form and panel tests unchanged.
 
+### Bed-scoped nudges (Phase 5) — **shipped**
+
+Surfaces last season's bed-specific adjustment inside the Add Planting flow,
+for the bed being planted into, regardless of which plant is picked. Same
+guardrails as Phase 4: deterministic, computed on demand, nothing persisted
+to the Yjs doc, no new fetches, and silence when nothing matches.
+
+- `adjustmentsForArea(areaId, adjustments)` — small pure selector added to
+  `plan-adjustments.ts`, matching via each adjustment's `entities[].areaId`.
+  Adjustments that name a plant are excluded even when they also carry the
+  bed (the four planting-level rules emit both via `plantingEntity`): those
+  stay crop-matched via `adjustmentsForPlant`, so a finding carrying both
+  never renders twice. Plot-wide adjustments (dry-spell) carry no entities
+  and never match. Today only `pest-disease-cluster` emits area-only
+  entities, so that is the one rule that surfaces here. No new rule text:
+  the nudge renders the adjustment's `observed` + `action` verbatim.
+- `AddPlantingForm` — gained an optional `areaId` prop and shows one compact
+  "Last year in this bed: <observed> <action>" note per matching adjustment,
+  above the Phase 4 crop nudges and independent of the plant selection.
+  Reuses `useLastSeasonAdjustments` unchanged, so evaluation stays memoized
+  per (season, weather), never per keystroke.
+- Mount point: the form is mounted once, in the `/allotment` page's Add
+  Planting dialog, which both the desktop sidebar and `MobileAreaBottomSheet`
+  open via `openAddDialog` — so passing `areaId={selectedBedId}` at that one
+  mount covers every entry path. `LastSeasonPanel` and the hook are untouched.
+- Tests: selector cases in `plan-adjustments.test.ts` (area matching,
+  plant-entity exclusion even with a matching bed, plot-wide exclusion,
+  empty inputs) and form integration in `AddPlantingForm.test.tsx` (bed
+  nudge shows before and after any plant choice, a crop-and-bed adjustment
+  renders exactly once as a crop nudge, silence for a non-matching bed or a
+  missing `areaId`); existing form tests unchanged.
+
 ### Not building (per brief non-goals)
 Bed-layout designer, sensors/hardware, cloud accounts/telemetry for this
 feature, real-time alerts, one-shot photo plant-ID as a headline, any

--- a/src/__tests__/components/AddPlantingForm.test.tsx
+++ b/src/__tests__/components/AddPlantingForm.test.tsx
@@ -558,4 +558,126 @@ describe('AddPlantingForm Component', () => {
       expect(screen.queryByText(/last year:/i)).not.toBeInTheDocument()
     })
   })
+
+  describe('Bed-scoped nudges (Season Observer Phase 5)', () => {
+    const bedAdjustment: PlanAdjustment = {
+      id: 'plan:pest-disease-cluster:2025:bed-b:pest',
+      findingId: 'pest-disease-cluster:2025:bed-b:pest',
+      ruleId: 'pest-disease-cluster',
+      severity: 'notice',
+      observed: '4 pest observations were logged in Bed B, starting 5 Jun.',
+      action:
+        'This year protect Bed B from the start — netting or collars in place before June — and check young plants weekly.',
+      entities: [{ areaId: 'bed-b', areaName: 'Bed B' }],
+    }
+    const tomatoAdjustment: PlanAdjustment = {
+      id: 'plan:cold-soil-sowing:2025:p1',
+      findingId: 'cold-soil-sowing:2025:p1',
+      ruleId: 'cold-soil-sowing',
+      severity: 'warning',
+      observed: 'Tomato went into 6.5°C soil on 20 Mar — below the ~7°C it needs to germinate.',
+      action: 'This year wait until the soil holds 7°C before sowing Tomato outdoors, or start it indoors.',
+      entities: [{ plantingId: 'p1', plantId: 'tomato', plantName: 'Tomato', areaId: 'bed-b', areaName: 'Bed B' }],
+    }
+
+    it("shows the bed's lesson before any plant is picked", () => {
+      mockUseLastSeasonAdjustments.mockReturnValue({
+        settled: true,
+        adjustments: [bedAdjustment],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={2026}
+          areaId="bed-b"
+        />
+      )
+
+      expect(screen.getByText(/last year in this bed:/i)).toBeInTheDocument()
+      expect(screen.getByText(/4 pest observations were logged in Bed B/)).toBeInTheDocument()
+    })
+
+    it("keeps showing the bed's lesson whichever plant is picked", async () => {
+      mockUseLastSeasonAdjustments.mockReturnValue({
+        settled: true,
+        adjustments: [bedAdjustment],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={2026}
+          areaId="bed-b"
+        />
+      )
+
+      await userEvent.selectOptions(screen.getByTestId('plant-select'), 'lettuce')
+
+      expect(screen.getByText(/last year in this bed:/i)).toBeInTheDocument()
+    })
+
+    it('renders a crop-and-bed adjustment once, as a crop nudge only', async () => {
+      // The tomato adjustment carries both plantId and areaId; the bed
+      // cluster carries only the bed. Picking tomato must show each note
+      // exactly once — the crop lesson never duplicates as a bed nudge.
+      mockUseLastSeasonAdjustments.mockReturnValue({
+        settled: true,
+        adjustments: [bedAdjustment, tomatoAdjustment],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={2026}
+          areaId="bed-b"
+        />
+      )
+
+      await userEvent.selectOptions(screen.getByTestId('plant-select'), 'tomato')
+
+      expect(screen.getAllByText(/4 pest observations were logged in Bed B/)).toHaveLength(1)
+      expect(screen.getAllByText(/went into 6\.5°C soil on 20 Mar/)).toHaveLength(1)
+      expect(screen.getByText(/last year in this bed:/i)).toBeInTheDocument()
+      expect(screen.getByText(/^last year:$/i)).toBeInTheDocument()
+    })
+
+    it('stays silent for a bed without a matching adjustment', () => {
+      mockUseLastSeasonAdjustments.mockReturnValue({
+        settled: true,
+        adjustments: [bedAdjustment],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={2026}
+          areaId="bed-a"
+        />
+      )
+
+      expect(screen.queryByText(/last year in this bed:/i)).not.toBeInTheDocument()
+    })
+
+    it('stays silent when no area id is provided', () => {
+      mockUseLastSeasonAdjustments.mockReturnValue({
+        settled: true,
+        adjustments: [bedAdjustment],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={2026}
+        />
+      )
+
+      expect(screen.queryByText(/last year in this bed:/i)).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/__tests__/lib/season-review/plan-adjustments.test.ts
+++ b/src/__tests__/lib/season-review/plan-adjustments.test.ts
@@ -429,6 +429,28 @@ describe('adjustmentsForArea', () => {
 
   it('returns an empty array for an empty area id or no adjustments', () => {
     expect(adjustmentsForArea('', mixedAdjustments())).toEqual([])
+    expect(adjustmentsForArea(undefined, mixedAdjustments())).toEqual([])
     expect(adjustmentsForArea('bed-b', [])).toEqual([])
+  })
+
+  it('excludes an adjustment with a separate plant entity alongside an area-only entity', () => {
+    // Pins the whole-adjustment dedup rule: any plant entity keeps the
+    // adjustment crop-matched, even when another entity is area-only. A
+    // future rule emitting this mixed shape should surface via
+    // adjustmentsForPlant, not render twice — revisit here if that changes.
+    const mixed: PlanAdjustment = {
+      id: 'plan:pest-disease-cluster:2025:bed-b:pest',
+      findingId: 'pest-disease-cluster:2025:bed-b:pest',
+      ruleId: 'pest-disease-cluster',
+      severity: 'notice',
+      observed: '4 pest observations were logged in Bed B, starting 5 Jun.',
+      action: 'This year protect Bed B from the start.',
+      entities: [
+        { areaId: 'bed-b', areaName: 'Bed B' },
+        { plantingId: 'p9', plantId: 'kale', plantName: 'Kale' },
+      ],
+    }
+    expect(adjustmentsForArea('bed-b', [mixed])).toEqual([])
+    expect(adjustmentsForPlant('kale', [mixed])).toHaveLength(1)
   })
 })

--- a/src/__tests__/lib/season-review/plan-adjustments.test.ts
+++ b/src/__tests__/lib/season-review/plan-adjustments.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Finding } from '@/lib/season-review/findings'
 import {
+  adjustmentsForArea,
   adjustmentsForPlant,
   derivePlanAdjustments,
   type PlanAdjustment,
@@ -371,5 +372,63 @@ describe('adjustmentsForPlant', () => {
   it('returns an empty array for an empty plant id or no adjustments', () => {
     expect(adjustmentsForPlant('', mixedAdjustments())).toEqual([])
     expect(adjustmentsForPlant('peas', [])).toEqual([])
+  })
+})
+
+describe('adjustmentsForArea', () => {
+  /**
+   * Real adjustments from the mapper: a pest cluster in bed-b (area-only),
+   * peas cold-soil in bed-a (carries BOTH the bed and the plant), and a
+   * dry spell (plot-wide, no entities).
+   */
+  function mixedAdjustments(): PlanAdjustment[] {
+    const cluster = finding({
+      id: 'pest-disease-cluster:2025:bed-b:pest',
+      ruleId: 'pest-disease-cluster',
+      entities: [{ areaId: 'bed-b', areaName: 'Bed B' }],
+      metrics: {
+        observationCount: 4,
+        type: 'pest',
+        firstDate: '2025-06-05',
+        lastDate: '2025-06-28',
+      },
+    })
+    const drySpell = finding({
+      id: 'dry-spell:2025:2025-06-10',
+      ruleId: 'dry-spell',
+      metrics: { startDate: '2025-06-10', endDate: '2025-07-02', lengthDays: 23, totalRainMm: 3.4 },
+    })
+    const adjustments = derivePlanAdjustments([cluster, coldSoilFinding(), drySpell])
+    expect(adjustments).toHaveLength(3)
+    return adjustments
+  }
+
+  it('returns only the adjustments whose entities name the bed', () => {
+    const matched = adjustmentsForArea('bed-b', mixedAdjustments())
+    expect(matched).toHaveLength(1)
+    expect(matched[0].ruleId).toBe('pest-disease-cluster')
+    expect(matched[0].entities[0].areaId).toBe('bed-b')
+  })
+
+  it('excludes adjustments that name a plant, even when they also carry the bed', () => {
+    // The peas cold-soil adjustment happened in bed-a — it stays crop-matched
+    // via adjustmentsForPlant, so it must not render again as a bed nudge.
+    expect(adjustmentsForArea('bed-a', mixedAdjustments())).toEqual([])
+  })
+
+  it('never returns plot-wide adjustments, which carry no entities', () => {
+    for (const areaId of ['bed-a', 'bed-b']) {
+      const matched = adjustmentsForArea(areaId, mixedAdjustments())
+      expect(matched.every((adj) => adj.ruleId !== 'dry-spell')).toBe(true)
+    }
+  })
+
+  it('returns an empty array for a bed with no matching adjustment', () => {
+    expect(adjustmentsForArea('bed-c', mixedAdjustments())).toEqual([])
+  })
+
+  it('returns an empty array for an empty area id or no adjustments', () => {
+    expect(adjustmentsForArea('', mixedAdjustments())).toEqual([])
+    expect(adjustmentsForArea('bed-b', [])).toEqual([])
   })
 })

--- a/src/app/allotment/page.tsx
+++ b/src/app/allotment/page.tsx
@@ -517,6 +517,7 @@ function AllotmentPageContent() {
               varieties={data?.varieties || []}
               initialCategoryFilter={selectedArea?.kind === 'berry' ? 'berries' : 'all'}
               initialPlantId={addDialogPrefilledPlantId}
+              areaId={selectedBedId ?? undefined}
             />
           </Dialog>
         )

--- a/src/components/allotment/AddPlantingForm.tsx
+++ b/src/components/allotment/AddPlantingForm.tsx
@@ -6,7 +6,7 @@ import { getVegetableById } from '@/lib/vegetable-database'
 import { getCompanionStatusForVegetable } from '@/lib/companion-utils'
 import { getRecommendedSowMethod, SowMethodRecommendation } from '@/lib/planting-utils'
 import { populateExpectedHarvest } from '@/lib/date-calculator'
-import { adjustmentsForPlant } from '@/lib/season-review/plan-adjustments'
+import { adjustmentsForArea, adjustmentsForPlant } from '@/lib/season-review/plan-adjustments'
 import { NewPlanting, Planting, StoredVariety, SowMethod, PlantingStatus } from '@/types/unified-allotment'
 import { VegetableCategory } from '@/types/garden-planner'
 import { useAllotment } from '@/hooks/useAllotment'
@@ -23,6 +23,8 @@ interface AddPlantingFormProps {
   initialCategoryFilter?: VegetableCategory | 'all'
   /** Optional plant ID to pre-select (e.g. from a "Boost this bed" suggestion). */
   initialPlantId?: string
+  /** The area being planted into — enables last season's bed-scoped nudges. */
+  areaId?: string
 }
 
 // Helper to check if variety has seeds for year
@@ -38,6 +40,7 @@ export default function AddPlantingForm({
   varieties = [],
   initialCategoryFilter = 'all',
   initialPlantId,
+  areaId,
 }: AddPlantingFormProps) {
   const [plantId, setVegetableId] = useState(initialPlantId ?? '')
   const [varietyName, setVarietyName] = useState('')
@@ -74,6 +77,14 @@ export default function AddPlantingForm({
   const cropNudges = useMemo(
     () => adjustmentsForPlant(plantId, lastSeasonAdjustments),
     [plantId, lastSeasonAdjustments]
+  )
+  // Bed-scoped lessons for the area being planted into (Season Observer
+  // Phase 5) — shown regardless of which plant is picked. Adjustments that
+  // name a plant are excluded by the selector, so a crop nudge never also
+  // appears as a bed nudge.
+  const bedNudges = useMemo(
+    () => (areaId ? adjustmentsForArea(areaId, lastSeasonAdjustments) : []),
+    [areaId, lastSeasonAdjustments]
   )
 
   // Get current month for sow method recommendation
@@ -232,6 +243,26 @@ export default function AddPlantingForm({
                 <span>Neutral with current plantings</span>
               </div>
             )}
+          </div>
+        )}
+
+        {/* Last season's lesson for this bed (Season Observer Phase 5) —
+            one compact note per bed-scoped adjustment, verbatim from
+            derivePlanAdjustments, shown whichever plant is picked. Renders
+            nothing when the previous season flagged nothing for this bed. */}
+        {bedNudges.length > 0 && (
+          <div className="mt-2 space-y-1">
+            {bedNudges.map(adj => (
+              <div
+                key={adj.id}
+                className="flex items-start gap-1.5 text-xs text-zen-ink-700 bg-zen-stone-50 px-2 py-1.5 rounded-zen"
+              >
+                <History className="w-3 h-3 mt-0.5 flex-shrink-0 text-zen-stone-500" aria-hidden="true" />
+                <span>
+                  <span className="font-medium">Last year in this bed:</span> {adj.observed} {adj.action}
+                </span>
+              </div>
+            ))}
           </div>
         )}
 

--- a/src/components/allotment/AddPlantingForm.tsx
+++ b/src/components/allotment/AddPlantingForm.tsx
@@ -6,7 +6,7 @@ import { getVegetableById } from '@/lib/vegetable-database'
 import { getCompanionStatusForVegetable } from '@/lib/companion-utils'
 import { getRecommendedSowMethod, SowMethodRecommendation } from '@/lib/planting-utils'
 import { populateExpectedHarvest } from '@/lib/date-calculator'
-import { adjustmentsForArea, adjustmentsForPlant } from '@/lib/season-review/plan-adjustments'
+import { adjustmentsForArea, adjustmentsForPlant, PlanAdjustment } from '@/lib/season-review/plan-adjustments'
 import { NewPlanting, Planting, StoredVariety, SowMethod, PlantingStatus } from '@/types/unified-allotment'
 import { VegetableCategory } from '@/types/garden-planner'
 import { useAllotment } from '@/hooks/useAllotment'
@@ -30,6 +30,20 @@ interface AddPlantingFormProps {
 // Helper to check if variety has seeds for year
 function hasSeedsForYear(variety: StoredVariety, year: number): boolean {
   return variety.seedsByYear?.[year] === 'have'
+}
+
+/** One compact last-season note (Season Observer Phases 4–5), rendered
+    verbatim from derivePlanAdjustments. Shared by the bed-scoped and
+    crop-scoped nudge lists so the presentation can't drift apart. */
+function NudgeNote({ label, adjustment }: { label: string; adjustment: PlanAdjustment }) {
+  return (
+    <div className="flex items-start gap-1.5 text-xs text-zen-ink-700 bg-zen-stone-50 px-2 py-1.5 rounded-zen">
+      <History className="w-3 h-3 mt-0.5 flex-shrink-0 text-zen-stone-500" aria-hidden="true" />
+      <span>
+        <span className="font-medium">{label}</span> {adjustment.observed} {adjustment.action}
+      </span>
+    </div>
+  )
 }
 
 export default function AddPlantingForm({
@@ -83,7 +97,7 @@ export default function AddPlantingForm({
   // name a plant are excluded by the selector, so a crop nudge never also
   // appears as a bed nudge.
   const bedNudges = useMemo(
-    () => (areaId ? adjustmentsForArea(areaId, lastSeasonAdjustments) : []),
+    () => adjustmentsForArea(areaId, lastSeasonAdjustments),
     [areaId, lastSeasonAdjustments]
   )
 
@@ -247,40 +261,24 @@ export default function AddPlantingForm({
         )}
 
         {/* Last season's lesson for this bed (Season Observer Phase 5) —
-            one compact note per bed-scoped adjustment, verbatim from
-            derivePlanAdjustments, shown whichever plant is picked. Renders
-            nothing when the previous season flagged nothing for this bed. */}
+            one compact note per bed-scoped adjustment, shown whichever plant
+            is picked. Renders nothing when the previous season flagged
+            nothing for this bed. */}
         {bedNudges.length > 0 && (
           <div className="mt-2 space-y-1">
             {bedNudges.map(adj => (
-              <div
-                key={adj.id}
-                className="flex items-start gap-1.5 text-xs text-zen-ink-700 bg-zen-stone-50 px-2 py-1.5 rounded-zen"
-              >
-                <History className="w-3 h-3 mt-0.5 flex-shrink-0 text-zen-stone-500" aria-hidden="true" />
-                <span>
-                  <span className="font-medium">Last year in this bed:</span> {adj.observed} {adj.action}
-                </span>
-              </div>
+              <NudgeNote key={adj.id} label="Last year in this bed:" adjustment={adj} />
             ))}
           </div>
         )}
 
         {/* Last season's lesson for this crop (Season Observer Phase 4) —
-            one compact note per rule-derived adjustment, verbatim from
-            derivePlanAdjustments. Renders nothing when nothing matched. */}
+            one compact note per rule-derived adjustment. Renders nothing
+            when nothing matched. */}
         {cropNudges.length > 0 && (
           <div className="mt-2 space-y-1">
             {cropNudges.map(adj => (
-              <div
-                key={adj.id}
-                className="flex items-start gap-1.5 text-xs text-zen-ink-700 bg-zen-stone-50 px-2 py-1.5 rounded-zen"
-              >
-                <History className="w-3 h-3 mt-0.5 flex-shrink-0 text-zen-stone-500" aria-hidden="true" />
-                <span>
-                  <span className="font-medium">Last year:</span> {adj.observed} {adj.action}
-                </span>
-              </div>
+              <NudgeNote key={adj.id} label="Last year:" adjustment={adj} />
             ))}
           </div>
         )}

--- a/src/lib/season-review/plan-adjustments.ts
+++ b/src/lib/season-review/plan-adjustments.ts
@@ -305,10 +305,11 @@ export function adjustmentsForPlant(
  * Adjustments that name a plant are excluded even when they also carry the
  * bed: those stay crop-matched via `adjustmentsForPlant`, so a finding with
  * both never renders twice. Plot-wide adjustments (dry-spell) carry no
- * entities and never match.
+ * entities and never match. Accepts undefined (the form's area is an
+ * optional prop) — no area means no matches.
  */
 export function adjustmentsForArea(
-  areaId: string,
+  areaId: string | undefined,
   adjustments: PlanAdjustment[]
 ): PlanAdjustment[] {
   if (!areaId) return []

--- a/src/lib/season-review/plan-adjustments.ts
+++ b/src/lib/season-review/plan-adjustments.ts
@@ -297,3 +297,24 @@ export function adjustmentsForPlant(
     adj.entities.some((entity) => entity.plantId === plantId)
   )
 }
+
+/**
+ * The adjustments that are about one specific bed and not about a crop,
+ * matched via each adjustment's `entities[].areaId` (Phase 5 bed-scoped
+ * nudges — pest-disease-cluster is the only rule that emits these today).
+ * Adjustments that name a plant are excluded even when they also carry the
+ * bed: those stay crop-matched via `adjustmentsForPlant`, so a finding with
+ * both never renders twice. Plot-wide adjustments (dry-spell) carry no
+ * entities and never match.
+ */
+export function adjustmentsForArea(
+  areaId: string,
+  adjustments: PlanAdjustment[]
+): PlanAdjustment[] {
+  if (!areaId) return []
+  return adjustments.filter(
+    (adj) =>
+      adj.entities.some((entity) => entity.areaId === areaId) &&
+      !adj.entities.some((entity) => entity.plantId)
+  )
+}


### PR DESCRIPTION
## Summary

Surfaces last season's **bed-specific** adjustment inside the Add Planting flow: opening the form for an area whose previous season produced a bed-scoped finding (`pest-disease-cluster` — the only rule that emits area-only entities today) shows one compact "Last year in this bed: …" note per matching adjustment, above the Phase 4 crop nudges, regardless of which plant is picked.

- **New pure selector** `adjustmentsForArea(areaId, adjustments)` in `plan-adjustments.ts`, matching via each adjustment's `entities[].areaId`. Adjustments that name a plant are excluded even when they also carry the bed (the four planting-level rules emit both via `plantingEntity`) — those stay crop-matched via `adjustmentsForPlant`, so a finding carrying both never renders twice. Plot-wide adjustments (dry-spell) carry no entities and never match.
- **`AddPlantingForm`** gains an optional `areaId` prop and renders the bed nudges verbatim from `derivePlanAdjustments` — no new rule text.
- **Mount point:** the form is mounted once, in the `/allotment` Add Planting dialog; both the desktop sidebar and `MobileAreaBottomSheet` open it via `openAddDialog`, so passing `areaId={selectedBedId}` there covers every entry path.
- **Unchanged:** `useLastSeasonAdjustments`, `LastSeasonPanel`, and all rule text. Same guardrails as Phase 4: deterministic, computed on demand, nothing persisted to the Yjs doc, no new fetches, evaluation memoized per season/weather, silent when nothing matches.
- Docs updated: `docs/plans/season-observer.md` (Phase 5 shipped) and `docs/plans/current-plan.md`.

## Related issue

Follow-up to the Season Observer series (#467, #475, #476, #477, #478, #479, #480).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes — new selector unit tests (area matching, plant-entity exclusion, plot-wide exclusion, empty cases) and form integration tests (bed nudge shows before/after plant choice, crop-and-bed adjustment renders exactly once, silent for a non-matching bed or missing `areaId`); full suite: 1409 unit tests pass, `type-check`, `lint`, and `build` all green
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH5esEUeQLS3QV7EqQc4JK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NH5esEUeQLS3QV7EqQc4JK)_