### PR TITLE
Season Observer Phase 5.1: make nudges reachable and year-aware

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,37 @@
 # Current Plan
 
-Last updated: 2026-07-17 (Season Observer Phase 5 bed-scoped nudges shipped)
+Last updated: 2026-07-18 (Season Observer Phase 5.1 nudge reachability + year gating shipped)
+
+## Season Observer — Phase 5.1: nudges reachable and year-aware (shipped)
+
+Two gaps found during the Phase 5 review, both closed:
+
+**Deep-link selection now sets `selectedBedId`.** The `/allotment?bed=<id>`
+deep link (used by `/this-month` planting cards) selects via a
+`{ type: 'area', id }` ref — the only producer of `'area'` refs (confirmed
+by tracing every `selectItem` call site) — but `selectItem` only set the
+legacy `selectedBedId` for `'bed'` refs, so on that path the Add Planting
+dialog got no `areaId` (no bed nudges), no `existingPlantings` (no companion
+checks), and submit was a silent no-op. `selectItem`
+(`useAllotmentAreas.ts`) now resolves `'area'` refs by the area's kind, the
+same routing `AllotmentGrid` and `ItemDetailSwitcher` already use:
+`rotation-bed`/`perennial-bed`/`other` are bed-like and set `selectedBedId`;
+`tree`/`berry`/`herb`/`infrastructure` keep it null, so bed-only UI stays
+hidden for them exactly as with grid clicks. Data is read through a ref so
+`selectItem` stays referentially stable — the deep-link effect depends on
+it, and a data-keyed identity would re-select the query bed on every
+mutation.
+
+**Nudges respect the year being planned.** `LastSeasonPanel` only renders
+when `selectedYear >= currentYear`, but the Add Planting nudges (Phase 4
+crop + Phase 5 bed) had no such gate — back-filling a historical year showed
+imperative advice about an even older season and could fetch its weather.
+`AddPlantingForm` now applies the same planning-year gate by passing
+`seasonRecord: null` into `useLastSeasonAdjustments` for historical years,
+which settles silently with no fetch (already the hook's tested contract).
+Guardrails unchanged: deterministic, on-demand, nothing persisted to the
+Yjs doc, silence when nothing matches, no changes to rule text or
+`derivePlanAdjustments`.
 
 ## Season Observer — Phase 5: bed-scoped nudges (shipped)
 

--- a/src/__tests__/components/AddPlantingForm.test.tsx
+++ b/src/__tests__/components/AddPlantingForm.test.tsx
@@ -9,16 +9,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import AddPlantingForm from '@/components/allotment/AddPlantingForm'
-import { StoredVariety, NewPlanting } from '@/types/unified-allotment'
+import { AllotmentData, SeasonRecord, StoredVariety, NewPlanting } from '@/types/unified-allotment'
 import type { PlanAdjustment } from '@/lib/season-review/plan-adjustments'
 
 // Mock the shared last-season adjustments hook (Season Observer Phase 4) so
 // these tests control the adjustments directly — no weather or season setup.
-const { mockUseLastSeasonAdjustments } = vi.hoisted(() => ({
+const { mockUseLastSeasonAdjustments, mockUseAllotment } = vi.hoisted(() => ({
   mockUseLastSeasonAdjustments: vi.fn(),
+  mockUseAllotment: vi.fn(),
 }))
 vi.mock('@/hooks/useLastSeasonAdjustments', () => ({
   useLastSeasonAdjustments: mockUseLastSeasonAdjustments,
+}))
+// Mock useAllotment so the planning-year gate tests can supply seasons
+// without standing up the Yjs storage engine. The form only reads `data`
+// and `getAllAreas` from it.
+vi.mock('@/hooks/useAllotment', () => ({
+  useAllotment: mockUseAllotment,
 }))
 
 // Mock the vegetable database
@@ -119,6 +126,7 @@ describe('AddPlantingForm Component', () => {
     // Default to a settled, adjustment-free previous season; the nudge
     // tests override this per test.
     mockUseLastSeasonAdjustments.mockReturnValue({ settled: true, adjustments: [] })
+    mockUseAllotment.mockReturnValue({ data: null, getAllAreas: () => [] })
   })
 
   describe('Initial state', () => {
@@ -677,6 +685,133 @@ describe('AddPlantingForm Component', () => {
         />
       )
 
+      expect(screen.queryByText(/last year in this bed:/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Planning-year gate (Season Observer Phase 5.1)', () => {
+    // The gate compares against the real current year, same as the
+    // LastSeasonPanel gate on /allotment, so years here are relative.
+    const CURRENT_YEAR = new Date().getFullYear()
+
+    function season(year: number): SeasonRecord {
+      return {
+        year,
+        status: 'historical',
+        areas: [],
+        createdAt: `${year}-01-01T00:00:00.000Z`,
+        updatedAt: `${year}-12-01T00:00:00.000Z`,
+      }
+    }
+
+    function dataWithSeasons(years: number[]): AllotmentData {
+      return {
+        version: 19,
+        meta: {
+          name: 'Test Allotment',
+          createdAt: '2020-01-01T00:00:00.000Z',
+          updatedAt: '2020-01-01T00:00:00.000Z',
+        },
+        layout: { areas: [] },
+        seasons: years.map(season),
+        currentYear: CURRENT_YEAR,
+        varieties: [],
+      } as unknown as AllotmentData
+    }
+
+    const bedAdjustment: PlanAdjustment = {
+      id: 'plan:pest-disease-cluster:prev:bed-b:pest',
+      findingId: 'pest-disease-cluster:prev:bed-b:pest',
+      ruleId: 'pest-disease-cluster',
+      severity: 'notice',
+      observed: '4 pest observations were logged in Bed B, starting 5 Jun.',
+      action: 'This year protect Bed B from the start.',
+      entities: [{ areaId: 'bed-b', areaName: 'Bed B' }],
+    }
+
+    beforeEach(() => {
+      // Behave like the real hook: a null season record settles to silence,
+      // so the gate's effect shows through to the rendered nudges.
+      mockUseLastSeasonAdjustments.mockImplementation(
+        ({ seasonRecord }: { seasonRecord: SeasonRecord | null }) => ({
+          settled: true,
+          adjustments: seasonRecord ? [bedAdjustment] : [],
+        })
+      )
+    })
+
+    it('passes the previous season record when planning the current year', () => {
+      mockUseAllotment.mockReturnValue({
+        data: dataWithSeasons([CURRENT_YEAR - 1, CURRENT_YEAR]),
+        getAllAreas: () => [],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={CURRENT_YEAR}
+          areaId="bed-b"
+        />
+      )
+
+      expect(mockUseLastSeasonAdjustments).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          planYear: CURRENT_YEAR,
+          seasonRecord: expect.objectContaining({ year: CURRENT_YEAR - 1 }),
+        })
+      )
+      expect(screen.getByText(/last year in this bed:/i)).toBeInTheDocument()
+    })
+
+    it('passes the previous season record when planning next year', () => {
+      mockUseAllotment.mockReturnValue({
+        data: dataWithSeasons([CURRENT_YEAR, CURRENT_YEAR + 1]),
+        getAllAreas: () => [],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={CURRENT_YEAR + 1}
+          areaId="bed-b"
+        />
+      )
+
+      expect(mockUseLastSeasonAdjustments).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          planYear: CURRENT_YEAR + 1,
+          seasonRecord: expect.objectContaining({ year: CURRENT_YEAR }),
+        })
+      )
+      expect(screen.getByText(/last year in this bed:/i)).toBeInTheDocument()
+    })
+
+    it('passes no season record when back-filling a historical year, even though that season exists', () => {
+      // Planning CURRENT_YEAR - 2 with CURRENT_YEAR - 3 on record: without
+      // the gate this would surface imperative advice about the older
+      // season and could fetch its weather.
+      mockUseAllotment.mockReturnValue({
+        data: dataWithSeasons([CURRENT_YEAR - 3, CURRENT_YEAR - 2]),
+        getAllAreas: () => [],
+      })
+
+      render(
+        <AddPlantingForm
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          selectedYear={CURRENT_YEAR - 2}
+          areaId="bed-b"
+        />
+      )
+
+      expect(mockUseLastSeasonAdjustments).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          planYear: CURRENT_YEAR - 2,
+          seasonRecord: null,
+        })
+      )
       expect(screen.queryByText(/last year in this bed:/i)).not.toBeInTheDocument()
     })
   })

--- a/src/__tests__/hooks/useAllotmentAreas.test.tsx
+++ b/src/__tests__/hooks/useAllotmentAreas.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * useAllotmentAreas — unified item selection.
+ *
+ * The contract under test (Season Observer Phase 5.1): selectItem resolves
+ * 'area' refs (produced only by the /allotment?bed= deep link) to the legacy
+ * selectedBedId by looking up the area's kind — bed-like kinds set it, so
+ * the Add Planting flow gets areaId/existingPlantings and submit works;
+ * permanent and infrastructure kinds keep it null, so bed-only UI stays
+ * hidden for them exactly as it does for grid clicks.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useAllotmentAreas } from '@/hooks/allotment/useAllotmentAreas'
+import type { AllotmentData, Area, AreaKind } from '@/types/unified-allotment'
+
+function area(id: string, kind: AreaKind): Area {
+  return {
+    id,
+    kind,
+    name: id,
+    canHavePlantings: kind !== 'infrastructure',
+    createdAt: '2025-01-01T00:00:00.000Z',
+  }
+}
+
+function dataWithAreas(areas: Area[]): AllotmentData {
+  return {
+    version: 19,
+    meta: {
+      name: 'Test Allotment',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    },
+    layout: { areas },
+    seasons: [],
+    currentYear: 2026,
+    varieties: [],
+  } as unknown as AllotmentData
+}
+
+const ALL_KINDS_DATA = dataWithAreas([
+  area('bed-a', 'rotation-bed'),
+  area('asparagus-bed', 'perennial-bed'),
+  area('flower-patch', 'other'),
+  area('apple-tree', 'tree'),
+  area('raspberry-row', 'berry'),
+  area('herb-spiral', 'herb'),
+  area('shed', 'infrastructure'),
+])
+
+function renderAreasHook(data: AllotmentData | null = ALL_KINDS_DATA) {
+  return renderHook(
+    (props: { data: AllotmentData | null }) =>
+      useAllotmentAreas({ data: props.data, mutate: vi.fn() }),
+    { initialProps: { data } }
+  )
+}
+
+describe('useAllotmentAreas selection', () => {
+  describe("selectItem with 'area' refs (deep-link path)", () => {
+    it.each([
+      ['rotation-bed', 'bed-a'],
+      ['perennial-bed', 'asparagus-bed'],
+      ['other', 'flower-patch'],
+    ])('sets selectedBedId for a %s area', (_kind, id) => {
+      const { result } = renderAreasHook()
+
+      act(() => result.current.selectItem({ type: 'area', id }))
+
+      expect(result.current.selectedItemRef).toEqual({ type: 'area', id })
+      // selectedBedId set means the Add Planting submit guard passes —
+      // the deep-link path can actually add plantings.
+      expect(result.current.selectedBedId).toBe(id)
+    })
+
+    it.each([
+      ['tree', 'apple-tree'],
+      ['berry', 'raspberry-row'],
+      ['herb', 'herb-spiral'],
+      ['infrastructure', 'shed'],
+    ])('keeps selectedBedId null for a %s area', (_kind, id) => {
+      const { result } = renderAreasHook()
+
+      act(() => result.current.selectItem({ type: 'area', id }))
+
+      expect(result.current.selectedItemRef).toEqual({ type: 'area', id })
+      expect(result.current.selectedBedId).toBeNull()
+    })
+
+    it('keeps selectedBedId null for an unknown area id', () => {
+      const { result } = renderAreasHook()
+
+      act(() => result.current.selectItem({ type: 'area', id: 'no-such-area' }))
+
+      expect(result.current.selectedBedId).toBeNull()
+    })
+
+    it('keeps selectedBedId null when data has not loaded yet', () => {
+      const { result } = renderAreasHook(null)
+
+      act(() => result.current.selectItem({ type: 'area', id: 'bed-a' }))
+
+      expect(result.current.selectedBedId).toBeNull()
+    })
+
+    it('resolves against the latest data even though selectItem was created earlier', () => {
+      const { result, rerender } = renderAreasHook(null)
+      const selectItemBeforeData = result.current.selectItem
+
+      rerender({ data: ALL_KINDS_DATA })
+
+      act(() => selectItemBeforeData({ type: 'area', id: 'bed-a' }))
+
+      expect(result.current.selectedBedId).toBe('bed-a')
+    })
+  })
+
+  describe("selectItem with typed refs (grid click path — unchanged)", () => {
+    it("sets selectedBedId for 'bed' refs", () => {
+      const { result } = renderAreasHook()
+
+      act(() => result.current.selectItem({ type: 'bed', id: 'bed-a' }))
+
+      expect(result.current.selectedBedId).toBe('bed-a')
+    })
+
+    it("keeps selectedBedId null for 'permanent' refs", () => {
+      const { result } = renderAreasHook()
+
+      act(() => result.current.selectItem({ type: 'permanent', id: 'apple-tree' }))
+
+      expect(result.current.selectedBedId).toBeNull()
+    })
+
+    it("keeps selectedBedId null for 'infrastructure' refs", () => {
+      const { result } = renderAreasHook()
+
+      act(() => result.current.selectItem({ type: 'infrastructure', id: 'shed' }))
+
+      expect(result.current.selectedBedId).toBeNull()
+    })
+
+    it('clears both selections on null', () => {
+      const { result } = renderAreasHook()
+
+      act(() => result.current.selectItem({ type: 'area', id: 'bed-a' }))
+      act(() => result.current.selectItem(null))
+
+      expect(result.current.selectedItemRef).toBeNull()
+      expect(result.current.selectedBedId).toBeNull()
+    })
+  })
+
+  it('keeps selectItem referentially stable across data changes', () => {
+    // The /allotment deep-link effect depends on selectItem; a data-keyed
+    // identity would re-fire it (re-selecting the query bed) on every
+    // mutation.
+    const { result, rerender } = renderAreasHook()
+    const first = result.current.selectItem
+
+    rerender({ data: dataWithAreas([area('bed-a', 'rotation-bed')]) })
+
+    expect(result.current.selectItem).toBe(first)
+  })
+})

--- a/src/__tests__/hooks/useAllotmentAreas.test.tsx
+++ b/src/__tests__/hooks/useAllotmentAreas.test.tsx
@@ -87,6 +87,20 @@ describe('useAllotmentAreas selection', () => {
       expect(result.current.selectedBedId).toBeNull()
     })
 
+    it('stores the canonical area id when the ref uses a shortId', () => {
+      // getAreaById resolves shortIds/names too; downstream consumers
+      // exact-match selectedBedId against AreaSeason.areaId, so the raw
+      // ref id would silently miss (empty plantings, orphaned submit).
+      const withShortId = dataWithAreas([
+        { ...area('bed-a', 'rotation-bed'), shortId: 'A' },
+      ])
+      const { result } = renderAreasHook(withShortId)
+
+      act(() => result.current.selectItem({ type: 'area', id: 'A' }))
+
+      expect(result.current.selectedBedId).toBe('bed-a')
+    })
+
     it('keeps selectedBedId null for an unknown area id', () => {
       const { result } = renderAreasHook()
 

--- a/src/components/allotment/AddPlantingForm.tsx
+++ b/src/components/allotment/AddPlantingForm.tsx
@@ -75,9 +75,17 @@ export default function AddPlantingForm({
   // path and memoizes per season/weather — picking plants or typing never
   // re-evaluates, and with no previous season it settles to silence.
   const allAreas = useMemo(() => getAllAreas(), [getAllAreas])
+  // Nudges only apply when planning the current or a future season — the
+  // same gate LastSeasonPanel uses. Back-filling a historical year passes
+  // no season record, so the hook settles silently without a weather fetch
+  // instead of surfacing imperative advice about an even older season.
+  const isPlanningYear = selectedYear >= new Date().getFullYear()
   const previousSeasonRecord = useMemo(
-    () => data?.seasons.find(s => s.year === selectedYear - 1) ?? null,
-    [data, selectedYear]
+    () =>
+      isPlanningYear
+        ? data?.seasons.find(s => s.year === selectedYear - 1) ?? null
+        : null,
+    [data, selectedYear, isPlanningYear]
   )
   const { adjustments: lastSeasonAdjustments } = useLastSeasonAdjustments({
     planYear: selectedYear,

--- a/src/components/allotment/AddPlantingForm.tsx
+++ b/src/components/allotment/AddPlantingForm.tsx
@@ -79,14 +79,10 @@ export default function AddPlantingForm({
   // same gate LastSeasonPanel uses. Back-filling a historical year passes
   // no season record, so the hook settles silently without a weather fetch
   // instead of surfacing imperative advice about an even older season.
-  const isPlanningYear = selectedYear >= new Date().getFullYear()
-  const previousSeasonRecord = useMemo(
-    () =>
-      isPlanningYear
-        ? data?.seasons.find(s => s.year === selectedYear - 1) ?? null
-        : null,
-    [data, selectedYear, isPlanningYear]
-  )
+  const previousSeasonRecord = useMemo(() => {
+    if (selectedYear < new Date().getFullYear()) return null
+    return data?.seasons.find(s => s.year === selectedYear - 1) ?? null
+  }, [data, selectedYear])
   const { adjustments: lastSeasonAdjustments } = useLastSeasonAdjustments({
     planYear: selectedYear,
     areas: allAreas,

--- a/src/hooks/allotment/useAllotmentAreas.ts
+++ b/src/hooks/allotment/useAllotmentAreas.ts
@@ -99,12 +99,17 @@ export function useAllotmentAreas({
     if (ref && ref.type === 'bed') {
       setSelectedBedId(ref.id as PhysicalBedId)
     } else if (ref && ref.type === 'area') {
-      const kind = dataRef.current
-        ? getAreaById(dataRef.current, ref.id)?.kind
+      const area = dataRef.current
+        ? getAreaById(dataRef.current, ref.id)
         : undefined
       const isBedLike =
-        kind === 'rotation-bed' || kind === 'perennial-bed' || kind === 'other'
-      setSelectedBedId(isBedLike ? (ref.id as PhysicalBedId) : null)
+        area?.kind === 'rotation-bed' ||
+        area?.kind === 'perennial-bed' ||
+        area?.kind === 'other'
+      // getAreaById also resolves shortIds and names, so store the
+      // canonical area.id — downstream consumers exact-match it against
+      // AreaSeason.areaId, and a raw shortId would silently miss.
+      setSelectedBedId(isBedLike ? (area.id as PhysicalBedId) : null)
     } else {
       setSelectedBedId(null)
     }

--- a/src/hooks/allotment/useAllotmentAreas.ts
+++ b/src/hooks/allotment/useAllotmentAreas.ts
@@ -11,7 +11,7 @@
 
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import {
   AllotmentData,
   Area,
@@ -83,11 +83,28 @@ export function useAllotmentAreas({
 
   // ============ UNIFIED ITEM SELECTION ============
 
+  // Read via a ref so selectItem stays referentially stable — the
+  // /allotment deep-link effect depends on it, and a data-keyed identity
+  // would re-fire that effect (re-selecting the query bed) on every
+  // mutation.
+  const dataRef = useRef(data)
+  dataRef.current = data
+
   const selectItem = useCallback((ref: AllotmentItemRef | null) => {
     setSelectedItemRef(ref)
-    // Also update legacy selectedBedId for backwards compatibility
+    // Also update legacy selectedBedId for backwards compatibility.
+    // 'area' refs (deep links) carry no kind, so resolve it here the same
+    // way AllotmentGrid routes clicks: rotation/perennial beds and 'other'
+    // are bed-like; trees, berries, herbs, and infrastructure are not.
     if (ref && ref.type === 'bed') {
       setSelectedBedId(ref.id as PhysicalBedId)
+    } else if (ref && ref.type === 'area') {
+      const kind = dataRef.current
+        ? getAreaById(dataRef.current, ref.id)?.kind
+        : undefined
+      const isBedLike =
+        kind === 'rotation-bed' || kind === 'perennial-bed' || kind === 'other'
+      setSelectedBedId(isBedLike ? (ref.id as PhysicalBedId) : null)
     } else {
       setSelectedBedId(null)
     }


### PR DESCRIPTION
## Summary

Closes the two gaps found during the Phase 5 review (Phases 1–5 merged in #467, #475–#481):

**Gap 1 — deep-link selection never set `selectedBedId`.** The `/allotment?bed=<id>` deep link (used by `/this-month` planting cards) selects via a `{ type: 'area', id }` ref — confirmed in Phase 0 to be the *only* producer of `'area'` refs — but `selectItem` only set the legacy `selectedBedId` for `'bed'` refs. On that path the Add Planting dialog got `areaId=undefined` (no bed nudges), empty `existingPlantings` (no companion checks), and submit was a silent no-op. `selectItem` (`useAllotmentAreas.ts`) now resolves `'area'` refs by the area's kind, mirroring how `AllotmentGrid` and `ItemDetailSwitcher` already route: `rotation-bed`/`perennial-bed`/`other` set `selectedBedId`; `tree`/`berry`/`herb`/`infrastructure` keep it null, so bed-only UI stays hidden for permanent/infrastructure areas exactly as with grid clicks. Data is read through a ref so `selectItem` stays referentially stable — the deep-link effect depends on it, and a data-keyed identity would re-select the query bed on every mutation.

**Gap 2 — nudges ignored the year being planned.** `LastSeasonPanel` only renders when `selectedYear >= currentYear`, but the Add Planting nudges (Phase 4 crop + Phase 5 bed) had no such gate: back-filling e.g. 2024 showed imperative advice about 2023 and could fetch that old season's weather. `AddPlantingForm` now applies the same planning-year gate by passing `seasonRecord: null` into `useLastSeasonAdjustments` for historical years — the hook's tested contract is that it then settles silently with no fetch.

Guardrails unchanged: deterministic, on-demand, nothing persisted to the Yjs doc, silence when nothing matches, no changes to rule text or `derivePlanAdjustments`.

Also updates `docs/plans/current-plan.md`.

## Related issue

Follow-up to the Phase 5 review of #481.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] I have tested my changes
- [x] I have updated documentation if needed

Tests: new `useAllotmentAreas` selection suite (deep-link `'area'` refs set `selectedBedId` for bed kinds — the submit guard — and keep it null for permanent/infrastructure/unknown; grid-click refs unchanged; `selectItem` identity stable across data changes) and a planning-year gate suite on `AddPlantingForm` (season record passed for current/next year, `null` for historical years with nudges staying silent). `type-check`, `lint`, `test:unit` (1428 passed), and `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGf3fp1rHKopJvtmhMmtcz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGf3fp1rHKopJvtmhMmtcz)_