### PR TITLE
Consolidate bed-like selection routing and fix deep-link re-fire

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,39 @@
 # Current Plan
 
-Last updated: 2026-07-18 (Season Observer Phase 5.1 nudge reachability + year gating shipped)
+Last updated: 2026-07-19 (selection routing consolidation shipped)
+
+## Selection routing consolidation (shipped)
+
+Follow-up to the #482 review: the area-kind → selection-category routing
+existed in three inline copies that disagreed on `'other'`, plus a
+deep-link re-fire quirk. Both closed:
+
+**One predicate, one behavior for `'other'` areas.** `isBedLikeKind(kind)`
+(exported from `area-queries.ts` via the `allotment-storage` barrel) is now
+the single routing predicate: `rotation-bed`/`perennial-bed`/`other` are
+bed-like. `AllotmentGrid.handleItemClick`, `useAllotmentAreas.selectItem`,
+`ItemDetailSwitcher`, and `MobileAreaBottomSheet` all route through it. The
+observable bug this fixes: clicking or deep-linking an `'other'` area set
+`selectedBedId` (so the mobile FAB offered Add Planting and submits wrote
+real plantings) while the desktop sidebar said "Select an item" and the
+mobile sheet hid the plantings/notes sections. `ItemDetailSwitcher` now
+renders `BedDetailPanel` for `'other'` — the panel already kept its
+rotation UI conditional on `kind === 'rotation-bed'`, and its header
+subtitle was fixed to degrade to "Area" instead of mislabelling `'other'`
+as "Perennial". Deliberately unchanged: `getAllBeds`/`getBedAreaById` stay
+rotation+perennial only, because their only callers are the deprecated
+`PhysicalBed` wrappers whose `'rotation' | 'perennial'` status has no
+representation for `'other'` (asserted by tests). Season Observer rules,
+nudges, and `derivePlanAdjustments` untouched.
+
+**Deep link fires once per query value.** The `/allotment?bed=` effect
+listed `isMobile` in its deps, so resizing across the 768px breakpoint
+re-ran `selectItem` and clobbered whatever the user had selected since.
+The effect moved into `useBedDeepLink` (`src/hooks/allotment/`) with a
+handled-value ref: selection fires once per query value (again for a new
+value), still gated on `!isLoading`, and still opens the mobile sheet when
+the arrival itself happens on mobile. Covered by hook tests including a
+simulated resize.
 
 ## Season Observer — Phase 5.1: nudges reachable and year-aware (shipped)
 

--- a/src/__tests__/components/AllotmentGrid.test.tsx
+++ b/src/__tests__/components/AllotmentGrid.test.tsx
@@ -24,14 +24,19 @@ vi.mock('react-grid-layout', () => ({
   ),
 }))
 
-// Mock allotment-storage
-vi.mock('@/services/allotment-storage', () => ({
-  wasAreaActiveInYear: vi.fn((area: Area, year: number) => {
-    if (area.createdYear && year < area.createdYear) return false
-    if (area.retiredYear && year >= area.retiredYear) return false
-    return true
-  }),
-}))
+// Mock allotment-storage (keeping the real isBedLikeKind — it's the
+// routing predicate under test when clicking areas)
+vi.mock('@/services/allotment-storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/allotment-storage')>()
+  return {
+    isBedLikeKind: actual.isBedLikeKind,
+    wasAreaActiveInYear: vi.fn((area: Area, year: number) => {
+      if (area.createdYear && year < area.createdYear) return false
+      if (area.retiredYear && year >= area.retiredYear) return false
+      return true
+    }),
+  }
+})
 
 // Mock BedItem component
 vi.mock('@/components/allotment/BedItem', () => ({

--- a/src/__tests__/components/ItemDetailSwitcher.test.tsx
+++ b/src/__tests__/components/ItemDetailSwitcher.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * ItemDetailSwitcher — kind → detail-panel routing.
+ *
+ * The contract under test: routing agrees with isBedLikeKind, so an
+ * 'other' area renders BedDetailPanel (matching the grid/selectItem bed
+ * routing that already enables the Add Planting flow for it) instead of
+ * silently falling back to the empty state, while unresolvable ids
+ * (unknown or archived — getArea filters archived areas) still show the
+ * empty state.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ItemDetailSwitcher from '@/components/allotment/details/ItemDetailSwitcher'
+import type { Area, AreaKind } from '@/types/unified-allotment'
+
+function area(id: string, kind: AreaKind, isArchived = false): Area {
+  return {
+    id,
+    kind,
+    name: `Name of ${id}`,
+    canHavePlantings: kind !== 'infrastructure',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...(isArchived ? { isArchived } : {}),
+  }
+}
+
+const AREAS: Area[] = [
+  area('bed-a', 'rotation-bed'),
+  area('flower-patch', 'other'),
+  area('apple-tree', 'tree'),
+  area('old-bed', 'rotation-bed', true),
+]
+
+function renderSwitcher(selectedId: string | null) {
+  // Mirrors production: getArea resolves via getAreaById, which filters
+  // archived areas.
+  const getArea = (id: string) =>
+    AREAS.find(a => a.id === id && !a.isArchived)
+
+  return render(
+    <ItemDetailSwitcher
+      selectedItemRef={selectedId ? { type: 'bed', id: selectedId } : null}
+      getArea={getArea}
+      getAreaSeason={() => undefined}
+      getPlantings={() => []}
+      getAreaNotes={() => []}
+      getPreviousYearRotation={() => null}
+      getCareLogs={() => []}
+      getHarvestTotal={() => null}
+      selectedYear={2026}
+      varieties={[]}
+      onAddPlanting={vi.fn()}
+      onAddPlantingToArea={vi.fn()}
+      onDeletePlanting={vi.fn()}
+      onRemovePlantingFromArea={vi.fn()}
+      onUpdatePlanting={vi.fn()}
+      onAddNote={vi.fn()}
+      onUpdateNote={vi.fn()}
+      onRemoveNote={vi.fn()}
+      onUpdateRotation={vi.fn()}
+      onAutoRotate={vi.fn()}
+      onArchiveArea={vi.fn()}
+      onUpdateArea={vi.fn()}
+      onAddCareLog={vi.fn()}
+      onRemoveCareLog={vi.fn()}
+      onLogHarvest={vi.fn()}
+      quickStats={{ rotationBeds: 1, perennialBeds: 0, permanentPlantings: 1 }}
+    />
+  )
+}
+
+describe('ItemDetailSwitcher routing', () => {
+  it("renders the bed panel for an 'other' area", () => {
+    renderSwitcher('flower-patch')
+
+    expect(screen.getByText('Name of flower-patch')).toBeInTheDocument()
+    expect(screen.getByText('2026 Plantings')).toBeInTheDocument()
+    expect(screen.queryByText('Select an item')).not.toBeInTheDocument()
+    // Rotation-specific UI stays hidden and the subtitle degrades to a
+    // plain label, not the perennial one.
+    expect(screen.queryByLabelText('Rotation Type')).not.toBeInTheDocument()
+    expect(screen.queryByText('Perennial')).not.toBeInTheDocument()
+    expect(screen.getByText('Area')).toBeInTheDocument()
+  })
+
+  it('still renders rotation UI for a rotation bed', () => {
+    renderSwitcher('bed-a')
+
+    expect(screen.getByText('Name of bed-a')).toBeInTheDocument()
+    expect(screen.getByLabelText('Rotation Type')).toBeInTheDocument()
+  })
+
+  it('renders the empty state for an unknown id', () => {
+    renderSwitcher('no-such-area')
+
+    expect(screen.getByText('Select an item')).toBeInTheDocument()
+  })
+
+  it('renders the empty state for an archived id', () => {
+    renderSwitcher('old-bed')
+
+    expect(screen.getByText('Select an item')).toBeInTheDocument()
+  })
+
+  it('renders the empty state with no selection', () => {
+    renderSwitcher(null)
+
+    expect(screen.getByText('Select an item')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/hooks/useBedDeepLink.test.tsx
+++ b/src/__tests__/hooks/useBedDeepLink.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * useBedDeepLink — /allotment?bed= deep-link selection.
+ *
+ * The contract under test: the selection fires exactly once per query
+ * value. The effect depends on isMobile (to open the sheet on mobile
+ * arrival), so without the handled-value guard a viewport resize across
+ * the 768px breakpoint would re-run it and clobber whatever the user
+ * selected since arriving.
+ */
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useBedDeepLink } from '@/hooks/allotment/useBedDeepLink'
+
+interface HookProps {
+  bedIdFromQuery: string | null
+  isLoading: boolean
+  isMobile: boolean
+}
+
+function setup(initialProps: HookProps) {
+  const selectItem = vi.fn()
+  const onMobileArrival = vi.fn()
+  const { rerender } = renderHook(
+    (props: HookProps) =>
+      useBedDeepLink({ ...props, selectItem, onMobileArrival }),
+    { initialProps }
+  )
+  return { selectItem, onMobileArrival, rerender }
+}
+
+describe('useBedDeepLink', () => {
+  it('does not select while data is loading, then fires once loaded', () => {
+    const { selectItem, rerender } = setup({
+      bedIdFromQuery: 'bed-a',
+      isLoading: true,
+      isMobile: false,
+    })
+
+    expect(selectItem).not.toHaveBeenCalled()
+
+    rerender({ bedIdFromQuery: 'bed-a', isLoading: false, isMobile: false })
+
+    expect(selectItem).toHaveBeenCalledTimes(1)
+    expect(selectItem).toHaveBeenCalledWith({ type: 'area', id: 'bed-a' })
+  })
+
+  it('does not re-select when a resize crosses the mobile breakpoint', () => {
+    const { selectItem, onMobileArrival, rerender } = setup({
+      bedIdFromQuery: 'bed-a',
+      isLoading: false,
+      isMobile: false,
+    })
+
+    expect(selectItem).toHaveBeenCalledTimes(1)
+
+    // Simulated resize: desktop -> mobile -> desktop. The user's later
+    // selections must survive, so the deep link must not re-fire.
+    rerender({ bedIdFromQuery: 'bed-a', isLoading: false, isMobile: true })
+    rerender({ bedIdFromQuery: 'bed-a', isLoading: false, isMobile: false })
+
+    expect(selectItem).toHaveBeenCalledTimes(1)
+    // The sheet only opens when the arrival itself happens on mobile.
+    expect(onMobileArrival).not.toHaveBeenCalled()
+  })
+
+  it('opens the mobile sheet when arriving on mobile', () => {
+    const { selectItem, onMobileArrival, rerender } = setup({
+      bedIdFromQuery: 'bed-a',
+      isLoading: false,
+      isMobile: true,
+    })
+
+    expect(selectItem).toHaveBeenCalledTimes(1)
+    expect(onMobileArrival).toHaveBeenCalledTimes(1)
+
+    rerender({ bedIdFromQuery: 'bed-a', isLoading: false, isMobile: false })
+    rerender({ bedIdFromQuery: 'bed-a', isLoading: false, isMobile: true })
+
+    expect(onMobileArrival).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires again for a new query value', () => {
+    const { selectItem, rerender } = setup({
+      bedIdFromQuery: 'bed-a',
+      isLoading: false,
+      isMobile: false,
+    })
+
+    rerender({ bedIdFromQuery: 'bed-b', isLoading: false, isMobile: false })
+
+    expect(selectItem).toHaveBeenCalledTimes(2)
+    expect(selectItem).toHaveBeenLastCalledWith({ type: 'area', id: 'bed-b' })
+  })
+
+  it('does nothing without a query value', () => {
+    const { selectItem, rerender } = setup({
+      bedIdFromQuery: null,
+      isLoading: false,
+      isMobile: true,
+    })
+
+    rerender({ bedIdFromQuery: null, isLoading: false, isMobile: false })
+
+    expect(selectItem).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/hooks/useBedDeepLink.test.tsx
+++ b/src/__tests__/hooks/useBedDeepLink.test.tsx
@@ -92,6 +92,21 @@ describe('useBedDeepLink', () => {
     expect(selectItem).toHaveBeenLastCalledWith({ type: 'area', id: 'bed-b' })
   })
 
+  it('re-fires when the query is cleared and later returns with the same value', () => {
+    // e.g. client-side nav to /allotment (no query) and back to the same
+    // deep link — the handled ref must reset so the second arrival works.
+    const { selectItem, rerender } = setup({
+      bedIdFromQuery: 'bed-a',
+      isLoading: false,
+      isMobile: false,
+    })
+
+    rerender({ bedIdFromQuery: null, isLoading: false, isMobile: false })
+    rerender({ bedIdFromQuery: 'bed-a', isLoading: false, isMobile: false })
+
+    expect(selectItem).toHaveBeenCalledTimes(2)
+  })
+
   it('does nothing without a query value', () => {
     const { selectItem, rerender } = setup({
       bedIdFromQuery: null,

--- a/src/__tests__/services/area-queries.test.ts
+++ b/src/__tests__/services/area-queries.test.ts
@@ -1,0 +1,83 @@
+/**
+ * isBedLikeKind — the single area-kind → selection-category predicate.
+ *
+ * Grid clicks (AllotmentGrid), deep-link selection (useAllotmentAreas),
+ * and both detail switchers (ItemDetailSwitcher, MobileAreaBottomSheet)
+ * all route through this predicate, so its truth table is the routing
+ * contract: bed-like kinds set selectedBedId, render BedDetailPanel, and
+ * expose the Add Planting flow.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  isBedLikeKind,
+  getAllBeds,
+  getBedAreaById,
+} from '@/services/allotment-storage'
+import type { AllotmentData, Area, AreaKind } from '@/types/unified-allotment'
+
+function area(id: string, kind: AreaKind, isArchived = false): Area {
+  return {
+    id,
+    kind,
+    name: id,
+    canHavePlantings: kind !== 'infrastructure',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...(isArchived ? { isArchived } : {}),
+  }
+}
+
+function dataWithAreas(areas: Area[]): AllotmentData {
+  return {
+    version: 18,
+    meta: {
+      name: 'Test Allotment',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    },
+    layout: { areas },
+    seasons: [],
+    currentYear: 2026,
+    varieties: [],
+  } as unknown as AllotmentData
+}
+
+describe('isBedLikeKind', () => {
+  it.each(['rotation-bed', 'perennial-bed', 'other'] as AreaKind[])(
+    'returns true for %s',
+    kind => {
+      expect(isBedLikeKind(kind)).toBe(true)
+    }
+  )
+
+  it.each(['tree', 'berry', 'herb', 'infrastructure'] as AreaKind[])(
+    'returns false for %s',
+    kind => {
+      expect(isBedLikeKind(kind)).toBe(false)
+    }
+  )
+
+  it('returns false for undefined (unresolved area)', () => {
+    expect(isBedLikeKind(undefined)).toBe(false)
+  })
+})
+
+describe('legacy bed queries keep rotation+perennial semantics', () => {
+  // Deliberate: getAllBeds/getBedAreaById feed the deprecated PhysicalBed
+  // wrappers whose 'rotation'|'perennial' status has no representation for
+  // 'other'. Selection routing uses isBedLikeKind instead.
+  const data = dataWithAreas([
+    area('bed-a', 'rotation-bed'),
+    area('asparagus-bed', 'perennial-bed'),
+    area('flower-patch', 'other'),
+    area('shed', 'infrastructure'),
+  ])
+
+  it("getAllBeds excludes 'other' areas", () => {
+    expect(getAllBeds(data).map(a => a.id)).toEqual(['bed-a', 'asparagus-bed'])
+  })
+
+  it("getBedAreaById returns undefined for an 'other' area", () => {
+    expect(getBedAreaById(data, 'flower-patch')).toBeUndefined()
+    expect(getBedAreaById(data, 'bed-a')?.id).toBe('bed-a')
+  })
+})

--- a/src/__tests__/services/area-queries.test.ts
+++ b/src/__tests__/services/area-queries.test.ts
@@ -13,7 +13,12 @@ import {
   getAllBeds,
   getBedAreaById,
 } from '@/services/allotment-storage'
-import type { AllotmentData, Area, AreaKind } from '@/types/unified-allotment'
+import {
+  CURRENT_SCHEMA_VERSION,
+  type AllotmentData,
+  type Area,
+  type AreaKind,
+} from '@/types/unified-allotment'
 
 function area(id: string, kind: AreaKind, isArchived = false): Area {
   return {
@@ -28,7 +33,7 @@ function area(id: string, kind: AreaKind, isArchived = false): Area {
 
 function dataWithAreas(areas: Area[]): AllotmentData {
   return {
-    version: 18,
+    version: CURRENT_SCHEMA_VERSION,
     meta: {
       name: 'Test Allotment',
       createdAt: '2025-01-01T00:00:00.000Z',

--- a/src/app/allotment/page.tsx
+++ b/src/app/allotment/page.tsx
@@ -19,6 +19,7 @@ import { getNextRotationGroup, ROTATION_GROUP_DISPLAY, getVegetablesForRotationG
 import { RotationGroup } from '@/types/garden-planner'
 import { NewPlanting, AreaSeason, GridPosition } from '@/types/unified-allotment'
 import { useAllotment } from '@/hooks/useAllotment'
+import { useBedDeepLink } from '@/hooks/allotment/useBedDeepLink'
 import { ArrowRight } from 'lucide-react'
 import { SHOW_ROTATION_SUGGESTIONS } from '@/config/release-visibility'
 import AllotmentGrid from '@/components/allotment/AllotmentGrid'
@@ -122,17 +123,16 @@ function AllotmentPageContent() {
     return () => window.removeEventListener('resize', checkMobile)
   }, [])
 
-  // Handle query parameters for deep linking from other pages
-  useEffect(() => {
-    if (bedIdFromQuery && !isLoading) {
-      // Select the area from the query parameter
-      selectItem({ type: 'area', id: bedIdFromQuery })
-      // On mobile, also open the sheet
-      if (isMobile) {
-        setShowMobileSheet(true)
-      }
-    }
-  }, [bedIdFromQuery, isLoading, selectItem, isMobile])
+  // Handle query parameters for deep linking from other pages — fires once
+  // per query value so later resizes/mutations don't clobber the selection.
+  const openMobileSheet = useCallback(() => setShowMobileSheet(true), [])
+  useBedDeepLink({
+    bedIdFromQuery,
+    isLoading,
+    isMobile,
+    selectItem,
+    onMobileArrival: openMobileSheet,
+  })
 
   // Get available years and add next/previous year options
   // Sort years in ascending order (oldest to newest) for left-to-right timeline

--- a/src/components/allotment/AllotmentGrid.tsx
+++ b/src/components/allotment/AllotmentGrid.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/data/allotment-layout'
 import { AllotmentItemRef } from '@/types/garden-planner'
 import { Area, Planting, AreaSeason, GridPosition } from '@/types/unified-allotment'
-import { wasAreaActiveInYear } from '@/services/allotment-storage'
+import { isBedLikeKind, wasAreaActiveInYear } from '@/services/allotment-storage'
 import BedItem from './BedItem'
 
 import 'react-grid-layout/css/styles.css'
@@ -228,16 +228,14 @@ export default function AllotmentGrid({ onItemSelect, selectedItemRef, getPlanti
     if (visibleAreas) {
       const area = visibleAreas.find(a => a.id === item.i)
       if (area) {
-        // Use 'bed' type for rotation/perennial beds, 'permanent' for trees/berries/herbs, 'infrastructure' for infra
-        if (area.kind === 'rotation-bed' || area.kind === 'perennial-bed') {
+        // Bed-like kinds (incl. 'other', per isBedLikeKind) use the 'bed'
+        // ref; trees/berries/herbs are 'permanent'; infra is 'infrastructure'.
+        if (isBedLikeKind(area.kind)) {
           onItemSelect({ type: 'bed', id: area.id })
         } else if (area.kind === 'tree' || area.kind === 'berry' || area.kind === 'herb') {
           onItemSelect({ type: 'permanent', id: area.id })
         } else if (area.kind === 'infrastructure') {
           onItemSelect({ type: 'infrastructure', id: area.id })
-        } else {
-          // 'other' kind - treat as bed for now
-          onItemSelect({ type: 'bed', id: area.id })
         }
       }
       return

--- a/src/components/allotment/MobileAreaBottomSheet.tsx
+++ b/src/components/allotment/MobileAreaBottomSheet.tsx
@@ -8,6 +8,7 @@ import { BED_COLORS } from '@/data/allotment-layout'
 import { getVegetableName } from '@/lib/vegetable-loader'
 import { getNextRotationGroup, ROTATION_GROUP_DISPLAY, getVegetablesForRotationGroup } from '@/lib/rotation'
 import { SHOW_ROTATION_SUGGESTIONS } from '@/config/release-visibility'
+import { isBedLikeKind } from '@/services/allotment-storage'
 import PlantingCard from './PlantingCard'
 import PlantingDetailDialog from './PlantingDetailDialog'
 import PlantSummaryDialog from '@/components/plants/PlantSummaryDialog'
@@ -126,8 +127,11 @@ export default function MobileAreaBottomSheet({
 
   if (!area) return null
 
-  const isRotationOrPerennialBed = area.kind === 'rotation-bed' || area.kind === 'perennial-bed'
-  const canAddPlantings = isRotationOrPerennialBed || area.kind === 'berry'
+  // Bed-like kinds (incl. 'other', see isBedLikeKind) get notes and the
+  // plantings section — the FAB already offers Add Planting for them, so
+  // the sheet must expose the same flow.
+  const isBedLike = isBedLikeKind(area.kind)
+  const canAddPlantings = isBedLike || area.kind === 'berry'
 
   return (
     <>
@@ -255,7 +259,7 @@ export default function MobileAreaBottomSheet({
             )}
 
             {/* Notes section for beds */}
-            {isRotationOrPerennialBed && (
+            {isBedLike && (
               <BedNotes
                 notes={notes}
                 onAdd={onAddNote}

--- a/src/components/allotment/details/BedDetailPanel.tsx
+++ b/src/components/allotment/details/BedDetailPanel.tsx
@@ -62,8 +62,11 @@ export default function BedDetailPanel({
   const selectedPlanting = selectedPlantingId
     ? plantings.find(p => p.id === selectedPlantingId) || null
     : null
-  // Determine if this is a rotation bed (vs perennial bed)
+  // This panel renders every bed-like kind (see isBedLikeKind): rotation
+  // beds get the rotation UI, perennial beds the perennial label, and
+  // 'other' areas a plain bed with neither.
   const isRotationBed = area.kind === 'rotation-bed'
+  const isPerennialBed = area.kind === 'perennial-bed'
 
   // Compute auto-rotate info
   const autoRotateInfo = useMemo(() => {
@@ -115,10 +118,14 @@ export default function BedDetailPanel({
           <div className="flex-1">
             <h3 className="font-display text-zen-ink-800">{area.name}</h3>
             <div className={`text-xs flex items-center gap-1 ${
-              !isRotationBed ? 'text-zen-sakura-600' : 'text-zen-moss-600'
+              isRotationBed ? 'text-zen-moss-600'
+                : isPerennialBed ? 'text-zen-sakura-600'
+                : 'text-zen-stone-500'
             }`}>
-              {!isRotationBed && <Leaf className="w-3 h-3" />}
-              {!isRotationBed ? 'Perennial' : areaSeason?.rotationGroup || 'Rotation'}
+              {isPerennialBed && <Leaf className="w-3 h-3" />}
+              {isRotationBed
+                ? areaSeason?.rotationGroup || 'Rotation'
+                : isPerennialBed ? 'Perennial' : 'Area'}
             </div>
           </div>
           <button

--- a/src/components/allotment/details/ItemDetailSwitcher.tsx
+++ b/src/components/allotment/details/ItemDetailSwitcher.tsx
@@ -3,6 +3,7 @@
 import { Map } from 'lucide-react'
 import { AllotmentItemRef, RotationGroup } from '@/types/garden-planner'
 import { Planting, PlantingUpdate, Area, AreaSeason, AreaNote, NewAreaNote, AreaNoteUpdate, NewPlanting, CareLogEntry, NewCareLogEntry, StoredVariety } from '@/types/unified-allotment'
+import { isBedLikeKind } from '@/services/allotment-storage'
 import BedDetailPanel from './BedDetailPanel'
 import PermanentDetailPanel from './PermanentDetailPanel'
 import InfrastructureDetailPanel from './InfrastructureDetailPanel'
@@ -113,15 +114,17 @@ export default function ItemDetailSwitcher({
   const area = getArea(selectedItemRef.id)
   if (!area) return <EmptyState stats={quickStats} />
 
-  // Route based on area.kind
-  const isRotationOrPerennialBed = area.kind === 'rotation-bed' || area.kind === 'perennial-bed'
+  // Route based on area.kind. Bed-like kinds (incl. 'other') get the bed
+  // panel — the grid and selectItem already route 'other' to the bed
+  // selection path, so the sidebar must not silently show the empty state.
+  const isBedLike = isBedLikeKind(area.kind)
   const isPermanentPlanting = area.kind === 'tree' || area.kind === 'berry' || area.kind === 'herb'
   const isInfrastructure = area.kind === 'infrastructure'
 
   // Determine which detail panel to render
   let detailPanel: React.ReactNode = null
 
-  if (isRotationOrPerennialBed) {
+  if (isBedLike) {
     detailPanel = (
       <BedDetailPanel
         key={`${area.id}-${area.kind}`}

--- a/src/hooks/allotment/useAllotmentAreas.ts
+++ b/src/hooks/allotment/useAllotmentAreas.ts
@@ -33,6 +33,7 @@ import {
   getAreaById,
   getAreasByKind as storageGetAreasByKind,
   getAllAreas as storageGetAllAreas,
+  isBedLikeKind,
 } from '@/services/allotment-storage'
 import { wasAreaActiveInYear } from '@/services/area-mutations'
 import { generateSlugId } from '@/lib/utils'
@@ -93,23 +94,19 @@ export function useAllotmentAreas({
   const selectItem = useCallback((ref: AllotmentItemRef | null) => {
     setSelectedItemRef(ref)
     // Also update legacy selectedBedId for backwards compatibility.
-    // 'area' refs (deep links) carry no kind, so resolve it here the same
-    // way AllotmentGrid routes clicks: rotation/perennial beds and 'other'
-    // are bed-like; trees, berries, herbs, and infrastructure are not.
+    // 'area' refs (deep links) carry no kind, so resolve it here with the
+    // same isBedLikeKind predicate AllotmentGrid uses to route clicks:
+    // trees, berries, herbs, and infrastructure are not bed-like.
     if (ref && ref.type === 'bed') {
       setSelectedBedId(ref.id as PhysicalBedId)
     } else if (ref && ref.type === 'area') {
       const area = dataRef.current
         ? getAreaById(dataRef.current, ref.id)
         : undefined
-      const isBedLike =
-        area?.kind === 'rotation-bed' ||
-        area?.kind === 'perennial-bed' ||
-        area?.kind === 'other'
       // getAreaById also resolves shortIds and names, so store the
       // canonical area.id — downstream consumers exact-match it against
       // AreaSeason.areaId, and a raw shortId would silently miss.
-      setSelectedBedId(isBedLike ? (area.id as PhysicalBedId) : null)
+      setSelectedBedId(area && isBedLikeKind(area.kind) ? (area.id as PhysicalBedId) : null)
     } else {
       setSelectedBedId(null)
     }

--- a/src/hooks/allotment/useBedDeepLink.ts
+++ b/src/hooks/allotment/useBedDeepLink.ts
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { AllotmentItemRef } from '@/types/garden-planner'
+
+export interface UseBedDeepLinkProps {
+  /** The ?bed= query value on /allotment, or null when absent. */
+  bedIdFromQuery: string | null
+  /** Selection must wait for data so the area lookup can resolve. */
+  isLoading: boolean
+  isMobile: boolean
+  selectItem: (ref: AllotmentItemRef | null) => void
+  /** Opens the mobile bottom sheet when the deep link arrives on mobile. */
+  onMobileArrival: () => void
+}
+
+/**
+ * Applies the /allotment?bed= deep link exactly once per query value.
+ *
+ * The effect's dependencies include isMobile (needed to open the sheet on
+ * a mobile arrival), so without the handled-value guard a viewport resize
+ * across the breakpoint would re-run it and clobber whatever the user has
+ * selected since arriving.
+ */
+export function useBedDeepLink({
+  bedIdFromQuery,
+  isLoading,
+  isMobile,
+  selectItem,
+  onMobileArrival,
+}: UseBedDeepLinkProps) {
+  const handledBedIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!bedIdFromQuery || isLoading) return
+    if (handledBedIdRef.current === bedIdFromQuery) return
+    handledBedIdRef.current = bedIdFromQuery
+
+    selectItem({ type: 'area', id: bedIdFromQuery })
+    if (isMobile) {
+      onMobileArrival()
+    }
+  }, [bedIdFromQuery, isLoading, isMobile, selectItem, onMobileArrival])
+}

--- a/src/hooks/allotment/useBedDeepLink.ts
+++ b/src/hooks/allotment/useBedDeepLink.ts
@@ -32,7 +32,13 @@ export function useBedDeepLink({
   const handledBedIdRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (!bedIdFromQuery || isLoading) return
+    if (isLoading) return
+    if (!bedIdFromQuery) {
+      // Query cleared: reset so navigating back to the same deep link
+      // fires again.
+      handledBedIdRef.current = null
+      return
+    }
     if (handledBedIdRef.current === bedIdFromQuery) return
     handledBedIdRef.current = bedIdFromQuery
 

--- a/src/services/allotment-storage.ts
+++ b/src/services/allotment-storage.ts
@@ -80,6 +80,7 @@ export {
   getPermanentAreas,
   getInfrastructureAreas,
   isRotationBed,
+  isBedLikeKind,
   canHavePlantings,
   getBedsFromAreas,
   getPermanentPlantingsFromAreas,

--- a/src/services/area-queries.ts
+++ b/src/services/area-queries.ts
@@ -95,6 +95,28 @@ export function isRotationBed(area: Area): boolean {
 }
 
 /**
+ * Area kinds that route to the bed-like selection path: selecting one sets
+ * the legacy selectedBedId, the detail UI renders BedDetailPanel, and the
+ * Add Planting flow is available. 'other' is deliberately bed-like — custom
+ * areas behave as plain beds without rotation tracking.
+ *
+ * This is the single routing predicate; grid clicks, deep-link selection,
+ * and the detail switchers must all agree with it. Note getAllBeds /
+ * getBedAreaById intentionally stay rotation+perennial only: their callers
+ * are the deprecated PhysicalBed wrappers, whose 'rotation'|'perennial'
+ * status has no representation for 'other'.
+ */
+const BED_LIKE_KINDS: ReadonlySet<AreaKind> = new Set<AreaKind>([
+  'rotation-bed',
+  'perennial-bed',
+  'other',
+])
+
+export function isBedLikeKind(kind: AreaKind | undefined): boolean {
+  return kind !== undefined && BED_LIKE_KINDS.has(kind)
+}
+
+/**
  * Check if an area can have plantings
  */
 export function canHavePlantings(area: Area): boolean {


### PR DESCRIPTION
## Summary

Follow-up to the #482 review. The area-kind → selection-category routing existed in three inline copies that disagreed on `'other'`, and the `/allotment?bed=` deep-link effect re-fired on viewport resize.

**Gap 1 — one predicate, one behavior for `'other'` areas.** `AllotmentGrid.handleItemClick` and `useAllotmentAreas.selectItem` routed `rotation-bed`/`perennial-bed`/`'other'` to the bed selection path (setting `selectedBedId`, enabling the Add Planting flow), while `ItemDetailSwitcher` and `MobileAreaBottomSheet` excluded `'other'`. Observable bug: click or deep-link an `'other'` area → the mobile FAB offers Add Planting and submits write real plantings, yet the desktop sidebar says "Select an item" and the mobile sheet hides its notes/plantings sections.

- New `isBedLikeKind(kind)` predicate exported from `area-queries.ts` (re-exported via the `allotment-storage` barrel), used by all four routing sites.
- Divergence resolved deliberately toward bed-like: `ItemDetailSwitcher` now renders `BedDetailPanel` for `'other'`, and the mobile sheet shows notes/plantings for it. Phase-0 check confirmed `BedDetailPanel` degrades gracefully (rotation UI already conditional on `kind === 'rotation-bed'`); the one flaw — the header subtitle labelling every non-rotation kind "Perennial" — is fixed with a conditional, not a forked panel.
- `getAllBeds`/`getBedAreaById` deliberately keep rotation+perennial semantics: their only callers are the deprecated `PhysicalBed` wrappers whose `'rotation' | 'perennial'` status has no representation for `'other'`. Pinned by tests.
- Untouched: Season Observer rules, nudges, `derivePlanAdjustments`, grid styling/legacy `bedId` config.

**Gap 2 — deep link fires once per query value.** The effect listed `isMobile` in its deps, so resizing across the 768px breakpoint re-ran `selectItem({ type: 'area', id })` and clobbered whatever the user selected since. The effect moved into `useBedDeepLink` with a handled-value ref: fires once per query value (again for a new value), keeps the `!isLoading` gate, and still opens the mobile sheet when the arrival itself happens on mobile.

## Related issue

Follow-up to the #482 review (Season Observer Phases 1–5.1).

## Type of change

- [x] Bug fix

## Checklist

- [x] I have tested my changes — predicate truth-table tests, `ItemDetailSwitcher` renders a bed panel for `'other'` and the empty state for unknown/archived ids, `useBedDeepLink` survives a simulated resize without re-selecting; full suite green (1449 unit tests), plus `type-check`, `lint`, and `build`
- [x] I have updated documentation if needed — `docs/plans/current-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U1DKbmxnayRMzrbaKjw19

---
_Generated by [Claude Code](https://claude.ai/code/session_016U1DKbmxnayRMzrbaKjw19)_