### PR TITLE
Season Observer: hosted narration via the Gemini free tier

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,26 @@
 # Current Plan
 
-Last updated: 2026-07-19 (selection routing consolidation shipped)
+Last updated: 2026-07-19 (hosted season narration shipped)
+
+## Season Observer — hosted narration via the free tier (shipped)
+
+The `/season-review` AI summary now works in the deployed app without
+Ollama. Signed-in users get a "Built-in" provider in `NarrationPanel`
+(default when signed in) that routes through a new `POST
+/api/season-narration` route reusing Aitor's Gemini free-tier plumbing:
+the `gemini.ts` adapter and the shared `ai_usage` monthly quota (one
+30-requests counter across Aitor and narration, checked before the call,
+incremented only on success, plus a short-window per-user rate limit).
+Guardrails held: the zod schema strips everything outside the narration
+payload contract, so findings[] + allotment name + year remain the only
+season data sent — never coordinates or internal ids; the draft still
+passes through the identical `verifyNarration` gate client-side
+(`narrateSeasonHosted`), and a failing draft is discarded exactly as
+before; a quota-exhausted 429 renders the same friendly two-options
+message as Aitor (switch to your own endpoint / wait for the monthly
+reset). The Ollama/BYO-endpoint path is unchanged for everyone and stays
+the only option when signed out. Full detail in
+`docs/plans/season-observer.md`.
 
 ## Selection routing consolidation (shipped)
 

--- a/docs/plans/season-observer.md
+++ b/docs/plans/season-observer.md
@@ -188,6 +188,41 @@ that a server can never reach a user's `localhost`.
   `narration.test.ts` (mocked fetch: request shape, auth header only with a
   key, prompt contract, error paths, verified/rejected orchestration).
 
+**Hosted free-tier provider (follow-up).** The browser→endpoint client can
+never work for a deployed user without their own Ollama/endpoint, so
+signed-in users now get a second provider that routes through the app
+server and reuses the Gemini free-tier plumbing Aitor built (PR #345):
+
+- `POST /api/season-narration` (`src/app/api/season-narration/route.ts`) —
+  Clerk-gated, per-user short-window rate limit, then the same `ai_usage`
+  monthly quota check/increment as Aitor (one shared 30-requests counter),
+  then `callGemini` (gemini.ts adapter) with the narration system prompt at
+  `NARRATION_TEMPERATURE`. The zod schema
+  (`src/lib/validations/season-narration.ts`) is the server-side enforcement
+  of the payload contract: it accepts only severity, summary, metrics,
+  entity display names and dates, stripping unknown keys — so internal ids
+  never reach the prompt and coordinates can't (no accepted field holds
+  them). The prompt itself comes from the shared `buildNarrationMessages`,
+  identical to the direct path.
+- `narrateSeasonHosted` in `narration.ts` posts the stripped
+  `toNarrationPayload` shape (ids removed before the request leaves the
+  browser) and then runs the draft through the exact same `verifyNarration`
+  gate — a failing draft is discarded identically on both paths.
+  Quota-exhausted 429s surface as a typed `HostedNarrationError` with
+  `quotaExceeded`.
+- `NarrationPanel` offers an "AI provider" toggle only when signed in:
+  Built-in (default for signed-in users — zero setup, works deployed) vs
+  Your own endpoint (the existing Ollama/BYO path, unchanged and still the
+  only path for anonymous users). Quota exhaustion renders the same
+  friendly two-options message as Aitor (switch provider / wait for the
+  monthly reset), not an error. Provider choice persists in the existing
+  `bwp-narration-config` localStorage entry.
+- Tests: route handler (auth gate, rate limit, quota 429 with
+  `quotaExceeded`, prompt contract incl. id-stripping, increment-only-on-
+  success), hosted client (payload shape, quota error, unchanged verify
+  gate), and panel provider selection (hidden signed-out, hosted default,
+  two-options quota message, custom path untouched).
+
 ### Plan feedback (Phase 3) — **shipped**
 
 Closes the loop: last season's findings feed next season's planning, all

--- a/src/__tests__/api/season-narration.test.ts
+++ b/src/__tests__/api/season-narration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Hosted season-narration route — auth gate, quota enforcement, and the
+ * prompt contract: the Gemini call must be built from the stripped narration
+ * payload (no internal ids), with the narration system prompt and low
+ * temperature.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mockGetToken = vi.fn<(opts?: { template?: string }) => Promise<string | null>>(
+  async () => 'supabase-token'
+)
+const mockAuth = vi.fn(async () => ({
+  userId: 'user_test_123' as string | null,
+  getToken: mockGetToken,
+}))
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+}))
+
+vi.mock('@/lib/ai/gemini', () => ({
+  callGemini: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/ai-usage', () => ({
+  FREE_TIER_MONTHLY_QUOTA: 30,
+  getCurrentUsage: vi.fn(),
+  incrementUsage: vi.fn(),
+}))
+
+vi.mock('@/lib/server-rate-limiter', () => ({
+  checkRateLimit: vi.fn(),
+}))
+
+const { POST } = await import('@/app/api/season-narration/route')
+const { callGemini } = await import('@/lib/ai/gemini')
+const { getCurrentUsage, incrementUsage } = await import('@/lib/supabase/ai-usage')
+const { checkRateLimit } = await import('@/lib/server-rate-limiter')
+
+const callGeminiMock = vi.mocked(callGemini)
+const getCurrentUsageMock = vi.mocked(getCurrentUsage)
+const incrementUsageMock = vi.mocked(incrementUsage)
+const checkRateLimitMock = vi.mocked(checkRateLimit)
+
+// A full Finding as the client library sends it — including the internal ids
+// the route must strip before the model ever sees them.
+const REQUEST_BODY = {
+  year: 2025,
+  allotmentName: 'Bonnie Wee Plot',
+  findings: [
+    {
+      id: 'cold-soil:2025:p1',
+      ruleId: 'cold-soil',
+      severity: 'warning',
+      summary: 'Peas sown 2025-03-12 into 6.5°C soil, below their 7°C minimum.',
+      metrics: { soilTempC: 6.5, minSoilTempC: 7 },
+      entities: [
+        { areaId: 'internal-area-1', areaName: 'Bed A', plantId: 'peas', plantName: 'Peas' },
+      ],
+      dates: { start: '2025-03-12' },
+    },
+  ],
+}
+
+function createRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/season-narration', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('Season narration API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('GEMINI_API_KEY', 'gemini-test-key')
+    mockAuth.mockResolvedValue({ userId: 'user_test_123', getToken: mockGetToken })
+    mockGetToken.mockResolvedValue('supabase-token')
+    checkRateLimitMock.mockResolvedValue({ allowed: true, remaining: 9, resetInSeconds: 0 })
+    getCurrentUsageMock.mockResolvedValue({ yearMonth: '2026-07', requestCount: 3, remaining: 27 })
+    callGeminiMock.mockResolvedValue({ text: 'A fine season on the plot.' })
+    incrementUsageMock.mockResolvedValue(4)
+  })
+
+  it('rejects unauthenticated callers with 401 and never calls Gemini', async () => {
+    mockAuth.mockResolvedValueOnce({ userId: null, getToken: mockGetToken })
+
+    const response = await POST(createRequest(REQUEST_BODY))
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data.error).toMatch(/sign in/i)
+    expect(callGeminiMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid body with 400', async () => {
+    const response = await POST(createRequest({ findings: [] }))
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toMatch(/validation error/i)
+    expect(callGeminiMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when the server has no Gemini key', async () => {
+    vi.stubEnv('GEMINI_API_KEY', '')
+
+    const response = await POST(createRequest(REQUEST_BODY))
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toMatch(/not available/i)
+    expect(callGeminiMock).not.toHaveBeenCalled()
+  })
+
+  it('enforces the short-window rate limit with 429 and Retry-After', async () => {
+    checkRateLimitMock.mockResolvedValueOnce({ allowed: false, remaining: 0, resetInSeconds: 120 })
+
+    const response = await POST(createRequest(REQUEST_BODY))
+    const data = await response.json()
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('Retry-After')).toBe('120')
+    expect(data.error).toMatch(/too many requests/i)
+    expect(callGeminiMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the quota-exhausted 429 without calling Gemini or burning quota', async () => {
+    getCurrentUsageMock.mockResolvedValueOnce({ yearMonth: '2026-07', requestCount: 30, remaining: 0 })
+
+    const response = await POST(createRequest(REQUEST_BODY))
+    const data = await response.json()
+
+    expect(response.status).toBe(429)
+    expect(data.quotaExceeded).toBe(true)
+    expect(data.error).toMatch(/30 free AI requests/i)
+    expect(callGeminiMock).not.toHaveBeenCalled()
+    expect(incrementUsageMock).not.toHaveBeenCalled()
+  })
+
+  it('fails safe with 500 when the quota check itself errors', async () => {
+    getCurrentUsageMock.mockRejectedValueOnce(new Error('supabase down'))
+
+    const response = await POST(createRequest(REQUEST_BODY))
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toMatch(/quota/i)
+    expect(callGeminiMock).not.toHaveBeenCalled()
+  })
+
+  it('narrates via Gemini with the stripped prompt contract, then increments usage', async () => {
+    const response = await POST(createRequest(REQUEST_BODY))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.text).toBe('A fine season on the plot.')
+
+    expect(callGeminiMock).toHaveBeenCalledTimes(1)
+    const call = callGeminiMock.mock.calls[0][0]
+    expect(call.apiKey).toBe('gemini-test-key')
+    expect(call.history).toEqual([])
+    expect(call.temperature).toBe(0.2)
+    // The narration system prompt, not Aitor's.
+    expect(call.systemPrompt).toContain('Never write a number that does not appear in the findings')
+    expect(call.systemPrompt).toContain('Do not mention coordinates')
+    // Findings + allotment name + year are the only season data sent…
+    expect(call.userMessage).toContain('Allotment: Bonnie Wee Plot')
+    expect(call.userMessage).toContain('Season: 2025')
+    expect(call.userMessage).toContain('Peas sown 2025-03-12')
+    expect(call.userMessage).toContain('"soilTempC":6.5')
+    expect(call.userMessage).toContain('Bed A')
+    // …and internal ids never reach the model even though the client sent them.
+    expect(call.userMessage).not.toContain('cold-soil:2025:p1')
+    expect(call.userMessage).not.toContain('internal-area-1')
+    expect(call.userMessage).not.toContain('"areaId"')
+    expect(call.userMessage).not.toContain('"plantId"')
+    expect(call.userMessage).not.toContain('"ruleId"')
+
+    expect(incrementUsageMock).toHaveBeenCalledWith('supabase-token', 'user_test_123')
+  })
+
+  it('passes through a Gemini failure status without incrementing usage', async () => {
+    const err = new Error('Gemini overloaded') as Error & { status?: number }
+    err.status = 503
+    callGeminiMock.mockRejectedValueOnce(err)
+
+    const response = await POST(createRequest(REQUEST_BODY))
+    const data = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(data.error).toBe('Gemini overloaded')
+    expect(incrementUsageMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/api/season-narration.test.ts
+++ b/src/__tests__/api/season-narration.test.ts
@@ -93,6 +93,21 @@ describe('Season narration API', () => {
     expect(callGeminiMock).not.toHaveBeenCalled()
   })
 
+  it('rejects a malformed JSON body with 400, not 500', async () => {
+    const request = new NextRequest('http://localhost:3000/api/season-narration', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json{',
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toMatch(/invalid json/i)
+    expect(callGeminiMock).not.toHaveBeenCalled()
+  })
+
   it('rejects an invalid body with 400', async () => {
     const response = await POST(createRequest({ findings: [] }))
     const data = await response.json()

--- a/src/__tests__/components/NarrationPanel.test.tsx
+++ b/src/__tests__/components/NarrationPanel.test.tsx
@@ -201,6 +201,27 @@ describe('NarrationPanel', () => {
       expect(screen.getByRole('radio', { name: /your own endpoint/i })).toBeChecked()
     })
 
+    it('discards an in-flight result when the provider is switched mid-request', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      const pending = deferred<NarrationResult>()
+      narrateSeasonHostedMock.mockReturnValue(pending.promise)
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+      expect(screen.getByRole('button', { name: /writing/i })).toBeInTheDocument()
+
+      // The user switches provider while the model is still writing.
+      await userEvent.click(screen.getByRole('radio', { name: /your own endpoint/i }))
+
+      pending.resolve({ status: 'ok', text: 'Late prose from the previous provider.' })
+      // The orphaned resolution must not repopulate the panel.
+      await waitFor(() => {
+        expect(narrateSeasonHostedMock).toHaveBeenCalledTimes(1)
+      })
+      expect(screen.queryByText('Late prose from the previous provider.')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /generate narration/i })).toBeInTheDocument()
+    })
+
     it('keeps an edited endpoint when switching provider — no silent revert across mounts', async () => {
       useOptionalAuthMock.mockReturnValue(authState(true))
       const { unmount } = render(<NarrationPanel findings={FINDINGS} year={2024} />)

--- a/src/__tests__/components/NarrationPanel.test.tsx
+++ b/src/__tests__/components/NarrationPanel.test.tsx
@@ -8,14 +8,37 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import NarrationPanel from '@/components/season-review/NarrationPanel'
 import type { Finding } from '@/lib/season-review/findings'
-import { narrateSeason, type NarrationResult } from '@/lib/season-review/narration'
+import {
+  HostedNarrationError,
+  narrateSeason,
+  narrateSeasonHosted,
+  type NarrationResult,
+} from '@/lib/season-review/narration'
+import { useOptionalAuth } from '@/hooks/useOptionalAuth'
 
 vi.mock('@/lib/season-review/narration', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/season-review/narration')>()),
   narrateSeason: vi.fn(),
+  narrateSeasonHosted: vi.fn(),
+}))
+
+vi.mock('@/hooks/useOptionalAuth', () => ({
+  useOptionalAuth: vi.fn(),
 }))
 
 const narrateSeasonMock = vi.mocked(narrateSeason)
+const narrateSeasonHostedMock = vi.mocked(narrateSeasonHosted)
+const useOptionalAuthMock = vi.mocked(useOptionalAuth)
+
+function authState(isSignedIn: boolean) {
+  return {
+    isSignedIn,
+    userId: isSignedIn ? 'user_1' : null,
+    getToken: async () => null,
+    signOut: async () => {},
+    userEmail: undefined,
+  }
+}
 
 const FINDINGS: Finding[] = [
   {
@@ -39,6 +62,8 @@ function deferred<T>() {
 describe('NarrationPanel', () => {
   beforeEach(() => {
     narrateSeasonMock.mockReset()
+    narrateSeasonHostedMock.mockReset()
+    useOptionalAuthMock.mockReturnValue(authState(false))
     localStorage.clear()
     sessionStorage.clear()
   })
@@ -86,5 +111,94 @@ describe('NarrationPanel', () => {
     })
     expect(screen.queryByText('Stale prose about 2024.')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /generate narration/i })).toBeInTheDocument()
+  })
+
+  describe('provider selection', () => {
+    it('never offers the built-in provider when signed out', () => {
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      expect(screen.queryByRole('radio', { name: /built-in/i })).not.toBeInTheDocument()
+      // The direct-endpoint fields are the only path.
+      expect(screen.getByLabelText(/openai-compatible/i)).toBeInTheDocument()
+    })
+
+    it('defaults signed-in users to the built-in provider and hides the endpoint fields', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      narrateSeasonHostedMock.mockResolvedValue({ status: 'ok', text: 'A grand year.' })
+      render(<NarrationPanel findings={FINDINGS} year={2024} allotmentName="Plot" />)
+
+      expect(screen.getByRole('radio', { name: /built-in/i })).toBeChecked()
+      expect(screen.queryByLabelText(/openai-compatible/i)).not.toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+
+      expect(await screen.findByText('A grand year.')).toBeInTheDocument()
+      expect(screen.getByText(/every number above appears in the findings/i)).toBeInTheDocument()
+      expect(narrateSeasonHostedMock).toHaveBeenCalledTimes(1)
+      expect(narrateSeasonHostedMock.mock.calls[0][0]).toBe(FINDINGS)
+      expect(narrateSeasonHostedMock.mock.calls[0][1]).toEqual({ year: 2024, allotmentName: 'Plot' })
+      expect(narrateSeasonMock).not.toHaveBeenCalled()
+    })
+
+    it('runs the hosted draft through the same verify gate — rejected drafts are discarded', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      narrateSeasonHostedMock.mockResolvedValue({
+        status: 'rejected',
+        text: 'It hit 99°C.',
+        unverifiedNumbers: ['99'],
+      })
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+
+      expect(await screen.findByText(/numbers that aren't in the findings/i)).toBeInTheDocument()
+      expect(screen.queryByText('It hit 99°C.')).not.toBeInTheDocument()
+    })
+
+    it('shows the friendly two-options message when the free quota is exhausted', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      narrateSeasonHostedMock.mockRejectedValue(
+        new HostedNarrationError(
+          "You've used your 30 free AI requests for this month.",
+          429,
+          true
+        )
+      )
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+
+      expect(await screen.findByText(/free quota used up/i)).toBeInTheDocument()
+      expect(screen.getByText(/30 free AI requests/i)).toBeInTheDocument()
+      expect(screen.getByText(/your own endpoint/i, { selector: 'strong' })).toBeInTheDocument()
+      expect(screen.getByText(/free quota resets then/i)).toBeInTheDocument()
+      // A quota stop is guidance, not a failure.
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('lets signed-in users switch to their own endpoint, which uses the direct client', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      narrateSeasonMock.mockResolvedValue({ status: 'ok', text: 'Prose from Ollama.' })
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      await userEvent.click(screen.getByRole('radio', { name: /your own endpoint/i }))
+      expect(screen.getByLabelText(/openai-compatible/i)).toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+
+      expect(await screen.findByText('Prose from Ollama.')).toBeInTheDocument()
+      expect(narrateSeasonMock).toHaveBeenCalledTimes(1)
+      expect(narrateSeasonHostedMock).not.toHaveBeenCalled()
+    })
+
+    it('remembers the provider choice across mounts', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      const { unmount } = render(<NarrationPanel findings={FINDINGS} year={2024} />)
+      await userEvent.click(screen.getByRole('radio', { name: /your own endpoint/i }))
+      unmount()
+
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+      expect(screen.getByRole('radio', { name: /your own endpoint/i })).toBeChecked()
+    })
   })
 })

--- a/src/__tests__/components/NarrationPanel.test.tsx
+++ b/src/__tests__/components/NarrationPanel.test.tsx
@@ -200,5 +200,33 @@ describe('NarrationPanel', () => {
       render(<NarrationPanel findings={FINDINGS} year={2024} />)
       expect(screen.getByRole('radio', { name: /your own endpoint/i })).toBeChecked()
     })
+
+    it('keeps an edited endpoint when switching provider — no silent revert across mounts', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      const { unmount } = render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      await userEvent.click(screen.getByRole('radio', { name: /your own endpoint/i }))
+      const endpointInput = screen.getByLabelText(/openai-compatible/i)
+      await userEvent.clear(endpointInput)
+      await userEvent.type(endpointInput, 'http://my-llm.local:8080/v1')
+      // Switching provider persists the config as the UI showed it.
+      await userEvent.click(screen.getByRole('radio', { name: /built-in/i }))
+      unmount()
+
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+      await userEvent.click(screen.getByRole('radio', { name: /your own endpoint/i }))
+      expect(screen.getByLabelText(/openai-compatible/i)).toHaveValue('http://my-llm.local:8080/v1')
+    })
+
+    it('does not stamp a provider choice the user never made when generating signed out', async () => {
+      narrateSeasonMock.mockResolvedValue({ status: 'ok', text: 'Prose.' })
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+      await screen.findByText('Prose.')
+
+      const stored = JSON.parse(localStorage.getItem('bwp-narration-config') ?? '{}')
+      expect(stored.provider).toBeUndefined()
+    })
   })
 })

--- a/src/__tests__/lib/season-review/narration.test.ts
+++ b/src/__tests__/lib/season-review/narration.test.ts
@@ -7,8 +7,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Finding } from '@/lib/season-review/findings'
 import {
   buildNarrationMessages,
+  HOSTED_NARRATION_PATH,
+  HostedNarrationError,
   narrateSeason,
+  narrateSeasonHosted,
   OLLAMA_PRESET,
+  requestHostedNarration,
   requestNarration,
   type NarrationSettings,
 } from '@/lib/season-review/narration'
@@ -277,6 +281,132 @@ describe('narrateSeason', () => {
   it('lets endpoint errors escape as exceptions rather than fake rejections', async () => {
     const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
     await expect(narrateSeason(FINDINGS, META, SETTINGS, fetchMock)).rejects.toThrow()
+  })
+})
+
+function hostedOkResponse(text: string | null) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ text }),
+  } as Response
+}
+
+describe('requestHostedNarration', () => {
+  it('POSTs the stripped findings payload to the app narration route', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(hostedOkResponse('A fine season.'))
+    const text = await requestHostedNarration(FINDINGS, META, fetchMock)
+
+    expect(text).toBe('A fine season.')
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(HOSTED_NARRATION_PATH)
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/json')
+
+    const body = JSON.parse(init.body)
+    expect(body.year).toBe(2025)
+    expect(body.allotmentName).toBe('Bonnie Wee Plot')
+    expect(body.findings).toHaveLength(1)
+    expect(body.findings[0].summary).toContain('Peas sown 2025-03-12')
+    // Internal ids are stripped before the request leaves the browser.
+    expect(init.body).not.toContain('cold-soil:2025:p1')
+    expect(init.body).not.toContain('"areaId"')
+    expect(init.body).not.toContain('"plantId"')
+  })
+
+  it('omits the allotment name field when none is set', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(hostedOkResponse('ok'))
+    await requestHostedNarration(FINDINGS, { year: 2025 }, fetchMock)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).not.toHaveProperty('allotmentName')
+  })
+
+  it('throws HostedNarrationError with quotaExceeded on the quota 429', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({
+        error: "You've used your 30 free AI requests for this month.",
+        quotaExceeded: true,
+      }),
+    } as Response)
+
+    const pending = requestHostedNarration(FINDINGS, META, fetchMock)
+    await expect(pending).rejects.toBeInstanceOf(HostedNarrationError)
+    await expect(pending).rejects.toMatchObject({
+      status: 429,
+      quotaExceeded: true,
+      message: "You've used your 30 free AI requests for this month.",
+    })
+  })
+
+  it('throws a plain HostedNarrationError on other non-OK responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'Sign in to use the built-in narration.' }),
+    } as Response)
+
+    await expect(requestHostedNarration(FINDINGS, META, fetchMock)).rejects.toMatchObject({
+      status: 401,
+      quotaExceeded: false,
+    })
+  })
+
+  it('falls back to the status message when the error body is not JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error('not json')
+      },
+    } as unknown as Response)
+
+    await expect(requestHostedNarration(FINDINGS, META, fetchMock)).rejects.toThrow(
+      'Hosted narration returned 502'
+    )
+  })
+
+  it('throws on an empty response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(hostedOkResponse('  '))
+    await expect(requestHostedNarration(FINDINGS, META, fetchMock)).rejects.toThrow(
+      'empty response'
+    )
+  })
+
+  it('rejects immediately when called with an already-aborted signal', async () => {
+    const fetchMock = vi.fn()
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      requestHostedNarration(FINDINGS, META, fetchMock, { signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('narrateSeasonHosted', () => {
+  it('returns ok for a draft whose numbers the findings vouch for', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      hostedOkResponse('Your peas went into 6.5°C soil on 12 March — under the 7°C they prefer.')
+    )
+    const result = await narrateSeasonHosted(FINDINGS, META, fetchMock)
+    expect(result.status).toBe('ok')
+  })
+
+  it('rejects a draft with an invented number — the verify gate is unchanged', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      hostedOkResponse('Soil hit 6.5°C, and you lost around 40% of the crop.')
+    )
+    const result = await narrateSeasonHosted(FINDINGS, META, fetchMock)
+    expect(result.status).toBe('rejected')
+    if (result.status === 'rejected') {
+      expect(result.unverifiedNumbers).toEqual(['40'])
+    }
+  })
+
+  it('lets route errors escape as exceptions rather than fake rejections', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    await expect(narrateSeasonHosted(FINDINGS, META, fetchMock)).rejects.toThrow()
   })
 })
 

--- a/src/app/api/season-narration/route.ts
+++ b/src/app/api/season-narration/route.ts
@@ -39,6 +39,15 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Fail fast when the deployment has no free tier at all — before spending
+    // a Redis round-trip or parsing the body.
+    if (!process.env.GEMINI_API_KEY) {
+      return NextResponse.json(
+        { error: 'Built-in narration is not available on this deployment. Use your own endpoint instead.' },
+        { status: 500 }
+      )
+    }
+
     // Short-window per-user rate limit on top of the monthly quota, bounding
     // burst abuse. Fails open if Redis is down.
     const rateLimit = await checkRateLimit(userId, {
@@ -56,7 +65,13 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const body = await request.json()
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      // A client-side mistake, not a server fault.
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+    }
     const validationResult = seasonNarrationRequestSchema.safeParse(body)
     if (!validationResult.success) {
       const errors = validationResult.error.issues.map((e) => e.message).join(', ')
@@ -66,13 +81,6 @@ export async function POST(request: NextRequest) {
       )
     }
     const { findings, year, allotmentName } = validationResult.data
-
-    if (!process.env.GEMINI_API_KEY) {
-      return NextResponse.json(
-        { error: 'Built-in narration is not available on this deployment. Use your own endpoint instead.' },
-        { status: 500 }
-      )
-    }
 
     const supabaseToken = await getToken({ template: 'supabase' })
     if (!supabaseToken) {

--- a/src/app/api/season-narration/route.ts
+++ b/src/app/api/season-narration/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { seasonNarrationRequestSchema } from '@/lib/validations/season-narration'
+import {
+  buildNarrationMessages,
+  NARRATION_TEMPERATURE,
+} from '@/lib/season-review/narration'
+import { callGemini } from '@/lib/ai/gemini'
+import {
+  FREE_TIER_MONTHLY_QUOTA,
+  getCurrentUsage,
+  incrementUsage,
+} from '@/lib/supabase/ai-usage'
+import { checkRateLimit } from '@/lib/server-rate-limiter'
+import { logger } from '@/lib/logger'
+
+/**
+ * Hosted season narration (Season Observer Phase 2c, hosted tier).
+ *
+ * Server-side twin of the browser→Ollama narration client: signed-in users
+ * without their own endpoint get their season-review findings narrated by
+ * the same Gemini free tier that backs Aitor, drawing on the same per-user
+ * monthly `ai_usage` quota. The prompt is built by `buildNarrationMessages`
+ * from the zod-validated body, which strips everything outside the narration
+ * payload contract — internal ids never reach the model, and coordinates
+ * can't (no accepted field carries them). Verification of the returned draft
+ * stays client-side in `narrateSeasonHosted`, identical to the direct path.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Mirrors the Aitor route's gate: the panel only offers the hosted
+    // option to signed-in users, and matching that at the route level stops
+    // the server-side Gemini key being drained by anonymous callers.
+    const { userId, getToken } = await auth()
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Sign in to use the built-in narration.' },
+        { status: 401 }
+      )
+    }
+
+    // Short-window per-user rate limit on top of the monthly quota, bounding
+    // burst abuse. Fails open if Redis is down.
+    const rateLimit = await checkRateLimit(userId, {
+      maxRequests: 10,
+      windowSeconds: 300,
+      prefix: 'season-narration',
+    })
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please wait a few minutes and try again.' },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(rateLimit.resetInSeconds) },
+        }
+      )
+    }
+
+    const body = await request.json()
+    const validationResult = seasonNarrationRequestSchema.safeParse(body)
+    if (!validationResult.success) {
+      const errors = validationResult.error.issues.map((e) => e.message).join(', ')
+      return NextResponse.json(
+        { error: `Validation error: ${errors}` },
+        { status: 400 }
+      )
+    }
+    const { findings, year, allotmentName } = validationResult.data
+
+    if (!process.env.GEMINI_API_KEY) {
+      return NextResponse.json(
+        { error: 'Built-in narration is not available on this deployment. Use your own endpoint instead.' },
+        { status: 500 }
+      )
+    }
+
+    const supabaseToken = await getToken({ template: 'supabase' })
+    if (!supabaseToken) {
+      return NextResponse.json(
+        { error: 'Free tier requires the "supabase" Clerk JWT template. Use your own endpoint instead.' },
+        { status: 500 }
+      )
+    }
+
+    try {
+      const usage = await getCurrentUsage(supabaseToken, userId)
+      if (usage.remaining <= 0) {
+        return NextResponse.json(
+          {
+            error: `You've used your ${FREE_TIER_MONTHLY_QUOTA} free AI requests for this month (the narration quota is shared with Aitor).`,
+            quotaExceeded: true,
+            usage,
+          },
+          { status: 429 }
+        )
+      }
+    } catch (err) {
+      logger.error('Narration quota check failed', { error: String(err) })
+      return NextResponse.json(
+        { error: 'Could not check your free-tier quota. Try again in a moment.' },
+        { status: 500 }
+      )
+    }
+
+    // Same prompt as the direct client, built from the stripped payload.
+    const [systemMessage, userMessage] = buildNarrationMessages(findings, {
+      year,
+      allotmentName,
+    })
+
+    try {
+      const result = await callGemini({
+        apiKey: process.env.GEMINI_API_KEY,
+        systemPrompt: systemMessage.content,
+        history: [],
+        userMessage: userMessage.content,
+        temperature: NARRATION_TEMPERATURE,
+      })
+      // Increment after a successful response so failed requests don't burn
+      // the user's quota (same race tolerance as the Aitor route).
+      await incrementUsage(supabaseToken, userId)
+      return NextResponse.json({ text: result.text, usage: result.usage })
+    } catch (err) {
+      logger.error('Narration Gemini call failed', { error: String(err) })
+      const status = (err as { status?: number }).status ?? 500
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'Failed to generate the narration.' },
+        { status }
+      )
+    }
+  } catch (error) {
+    logger.error('Season narration API error', { error: String(error) })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -5,33 +5,45 @@
  *
  * Collapsed by default and completely inert until the user opens it and
  * presses Generate — the deterministic findings above are the report, this
- * is optional prose over them. The request goes straight from the browser to
- * whatever OpenAI-compatible endpoint the user configures (local Ollama by
- * default), and the result is ephemeral: shown once, never persisted.
+ * is optional prose over them. Two providers:
  *
- * Every generated draft is number-checked against the findings
- * (narration-verify.ts); a draft that mentions any number the findings don't
- * vouch for is discarded and the panel says so.
+ * - Built-in (signed-in users only): the app's /api/season-narration route,
+ *   backed by the server-side Gemini free tier and sharing Aitor's monthly
+ *   quota. This is the path that works in the deployed app with no setup.
+ * - Your own endpoint (everyone): straight from the browser to whatever
+ *   OpenAI-compatible endpoint the user configures — local Ollama by default.
+ *
+ * On both paths only the findings, allotment name and year are sent (never
+ * coordinates or internal ids), the result is ephemeral (shown once, never
+ * persisted), and every generated draft is number-checked against the
+ * findings (narration-verify.ts); a draft that mentions any number the
+ * findings don't vouch for is discarded and the panel says so.
  */
 
 import { useEffect, useRef, useState } from 'react'
 import { CheckCircle2, Sparkles } from 'lucide-react'
 import type { Finding } from '@/lib/season-review/findings'
 import {
+  HostedNarrationError,
   narrateSeason,
+  narrateSeasonHosted,
   OLLAMA_PRESET,
   type NarrationSettings,
 } from '@/lib/season-review/narration'
 import { getStorageItem, setStorageItem } from '@/services/generic-storage'
 import { useSessionStorage } from '@/hooks/useSessionStorage'
+import { useOptionalAuth } from '@/hooks/useOptionalAuth'
 
-/** Endpoint + model persist across sessions; the optional key is session-only. */
+/** Endpoint + model + provider persist across sessions; the optional key is session-only. */
 const NARRATION_CONFIG_KEY = 'bwp-narration-config'
 const NARRATION_API_KEY_KEY = 'bwp-narration-key'
+
+type NarrationProvider = 'hosted' | 'custom'
 
 interface StoredNarrationConfig {
   baseUrl: string
   model: string
+  provider?: NarrationProvider
 }
 
 type PanelStatus =
@@ -39,6 +51,7 @@ type PanelStatus =
   | { kind: 'loading' }
   | { kind: 'ok'; text: string }
   | { kind: 'rejected'; unverifiedNumbers: string[] }
+  | { kind: 'quota'; message: string }
   | { kind: 'error'; message: string }
 
 function friendlyRequestError(error: unknown, baseUrl: string): string {
@@ -65,6 +78,16 @@ function friendlyRequestError(error: unknown, baseUrl: string): string {
   return message
 }
 
+function friendlyHostedError(error: unknown): string {
+  if ((error as { name?: unknown } | null)?.name === 'AbortError') {
+    return 'The narration request timed out — try again in a moment.'
+  }
+  if (error instanceof TypeError) {
+    return "Couldn't reach the app's narration service. Check your connection and try again."
+  }
+  return error instanceof Error ? error.message : String(error)
+}
+
 export default function NarrationPanel({
   findings,
   year,
@@ -74,6 +97,11 @@ export default function NarrationPanel({
   year: number
   allotmentName?: string
 }) {
+  const { isSignedIn } = useOptionalAuth()
+  // Signed-in users default to the zero-setup built-in tier; the stored
+  // choice (loaded below) wins once they've picked. Signed-out users never
+  // see the hosted option and always run the direct client.
+  const [provider, setProvider] = useState<NarrationProvider>('hosted')
   const [baseUrl, setBaseUrl] = useState(OLLAMA_PRESET.baseUrl)
   const [model, setModel] = useState(OLLAMA_PRESET.model)
   const [apiKey, setApiKey] = useSessionStorage<string>(NARRATION_API_KEY_KEY, '')
@@ -83,7 +111,24 @@ export default function NarrationPanel({
     const stored = getStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY)
     if (stored?.baseUrl) setBaseUrl(stored.baseUrl)
     if (stored?.model) setModel(stored.model)
+    if (stored?.provider === 'hosted' || stored?.provider === 'custom') {
+      setProvider(stored.provider)
+    }
   }, [])
+
+  const effectiveProvider: NarrationProvider =
+    isSignedIn && provider === 'hosted' ? 'hosted' : 'custom'
+
+  const chooseProvider = (next: NarrationProvider) => {
+    setProvider(next)
+    setStatus({ kind: 'idle' })
+    const stored = getStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY)
+    setStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY, {
+      baseUrl: stored?.baseUrl ?? baseUrl,
+      model: stored?.model ?? model,
+      provider: next,
+    })
+  }
 
   // A new year (or freshly recomputed findings) makes old prose stale —
   // narration is ephemeral by design, so simply drop it. Bumping the request
@@ -116,16 +161,25 @@ export default function NarrationPanel({
     setStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY, {
       baseUrl: settings.baseUrl,
       model: settings.model,
+      provider,
     })
     setStatus({ kind: 'loading' })
     try {
-      const result = await narrateSeason(
-        findings,
-        { year, allotmentName },
-        settings,
-        undefined,
-        { signal: abortController.signal }
-      )
+      const result =
+        effectiveProvider === 'hosted'
+          ? await narrateSeasonHosted(
+              findings,
+              { year, allotmentName },
+              undefined,
+              { signal: abortController.signal }
+            )
+          : await narrateSeason(
+              findings,
+              { year, allotmentName },
+              settings,
+              undefined,
+              { signal: abortController.signal }
+            )
       if (generation !== requestGeneration.current) return
       if (result.status === 'ok') {
         setStatus({ kind: 'ok', text: result.text })
@@ -134,7 +188,13 @@ export default function NarrationPanel({
       }
     } catch (error) {
       if (generation !== requestGeneration.current) return
-      setStatus({ kind: 'error', message: friendlyRequestError(error, settings.baseUrl) })
+      if (error instanceof HostedNarrationError && error.quotaExceeded) {
+        setStatus({ kind: 'quota', message: error.message })
+      } else if (effectiveProvider === 'hosted') {
+        setStatus({ kind: 'error', message: friendlyHostedError(error) })
+      } else {
+        setStatus({ kind: 'error', message: friendlyRequestError(error, settings.baseUrl) })
+      }
     }
   }
 
@@ -143,63 +203,101 @@ export default function NarrationPanel({
       <summary className="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden p-4 text-sm text-zen-ink-700 hover:bg-zen-stone-50 rounded-zen">
         <Sparkles className="w-4 h-4 text-zen-moss-600" aria-hidden="true" />
         <span className="font-medium">Narrate this season</span>
-        <span className="text-zen-stone-400 font-normal">optional — bring your own AI</span>
+        <span className="text-zen-stone-400 font-normal">optional — AI summary</span>
       </summary>
 
       <div className="px-4 pb-4 space-y-4">
         <p className="text-xs text-zen-stone-500">
-          Turns the findings above into a few paragraphs of prose using an AI model you run or
-          choose — by default a local Ollama, so nothing leaves your machine. Only the findings
-          and your allotment&apos;s name are sent (never your coordinates), directly from this
-          browser to the address below. Every number in the result is checked against the
-          findings; a draft that invents numbers is discarded. Nothing is saved.
+          Turns the findings above into a few paragraphs of prose. Only the findings and your
+          allotment&apos;s name are sent (never your coordinates). Every number in the result is
+          checked against the findings; a draft that invents numbers is discarded. Nothing is
+          saved.
         </p>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div>
-            <label htmlFor="narration-base-url" className="block text-xs font-medium text-zen-ink-700 mb-1">
-              Endpoint (OpenAI-compatible)
-            </label>
-            <input
-              id="narration-base-url"
-              type="text"
-              value={baseUrl}
-              onChange={(e) => setBaseUrl(e.target.value)}
-              placeholder={OLLAMA_PRESET.baseUrl}
-              className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
-              autoComplete="off"
-            />
-          </div>
-          <div>
-            <label htmlFor="narration-model" className="block text-xs font-medium text-zen-ink-700 mb-1">
-              Model
-            </label>
-            <input
-              id="narration-model"
-              type="text"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              placeholder={OLLAMA_PRESET.model}
-              className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
-              autoComplete="off"
-            />
-          </div>
-        </div>
+        {isSignedIn && (
+          <fieldset>
+            <legend className="block text-xs font-medium text-zen-ink-700 mb-2">AI provider</legend>
+            <div className="flex flex-col gap-2 sm:flex-row sm:gap-6">
+              <label className="flex items-center gap-2 text-sm text-zen-ink-700 cursor-pointer">
+                <input
+                  type="radio"
+                  name="narration-provider"
+                  value="hosted"
+                  checked={provider === 'hosted'}
+                  onChange={() => chooseProvider('hosted')}
+                  className="accent-zen-moss-600"
+                />
+                Built-in <span className="text-xs text-zen-stone-400">(free, shares Aitor&apos;s monthly quota)</span>
+              </label>
+              <label className="flex items-center gap-2 text-sm text-zen-ink-700 cursor-pointer">
+                <input
+                  type="radio"
+                  name="narration-provider"
+                  value="custom"
+                  checked={provider === 'custom'}
+                  onChange={() => chooseProvider('custom')}
+                  className="accent-zen-moss-600"
+                />
+                Your own endpoint <span className="text-xs text-zen-stone-400">(e.g. local Ollama)</span>
+              </label>
+            </div>
+          </fieldset>
+        )}
 
-        <div>
-          <label htmlFor="narration-api-key" className="block text-xs font-medium text-zen-ink-700 mb-1">
-            API key <span className="text-zen-stone-400 font-normal">(optional — Ollama needs none; kept for this session only)</span>
-          </label>
-          <input
-            id="narration-api-key"
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="sk-…"
-            className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
-            autoComplete="off"
-          />
-        </div>
+        {effectiveProvider === 'custom' && (
+          <>
+            <p className="text-xs text-zen-stone-500">
+              Uses an AI model you run or choose — by default a local Ollama, so nothing leaves
+              your machine. The request goes directly from this browser to the address below.
+            </p>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="narration-base-url" className="block text-xs font-medium text-zen-ink-700 mb-1">
+                  Endpoint (OpenAI-compatible)
+                </label>
+                <input
+                  id="narration-base-url"
+                  type="text"
+                  value={baseUrl}
+                  onChange={(e) => setBaseUrl(e.target.value)}
+                  placeholder={OLLAMA_PRESET.baseUrl}
+                  className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
+                  autoComplete="off"
+                />
+              </div>
+              <div>
+                <label htmlFor="narration-model" className="block text-xs font-medium text-zen-ink-700 mb-1">
+                  Model
+                </label>
+                <input
+                  id="narration-model"
+                  type="text"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  placeholder={OLLAMA_PRESET.model}
+                  className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
+                  autoComplete="off"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="narration-api-key" className="block text-xs font-medium text-zen-ink-700 mb-1">
+                API key <span className="text-zen-stone-400 font-normal">(optional — Ollama needs none; kept for this session only)</span>
+              </label>
+              <input
+                id="narration-api-key"
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="sk-…"
+                className="w-full px-3 py-2 text-sm border border-zen-stone-200 rounded-zen focus:outline-none focus:ring-2 focus:ring-zen-moss-500 focus:border-transparent"
+                autoComplete="off"
+              />
+            </div>
+          </>
+        )}
 
         <button
           onClick={handleGenerate}
@@ -224,6 +322,21 @@ export default function NarrationPanel({
             The model&apos;s draft mentioned numbers that aren&apos;t in the findings
             ({status.unverifiedNumbers.join(', ')}), so it was discarded. The findings above
             are the verified report — you can try generating again.
+          </div>
+        )}
+
+        {status.kind === 'quota' && (
+          <div role="note" className="rounded-zen border border-zen-bamboo-200 bg-zen-bamboo-50 p-4 text-sm text-zen-ink-700 space-y-2">
+            <p className="font-medium">Free quota used up</p>
+            <p>{status.message}</p>
+            <p className="font-medium">Two ways forward:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                Switch to <strong>Your own endpoint</strong> above — a local Ollama keeps
+                narration free and private.
+              </li>
+              <li>Or check back on the 1st of next month — your free quota resets then.</li>
+            </ul>
           </div>
         )}
 

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -122,10 +122,12 @@ export default function NarrationPanel({
   const chooseProvider = (next: NarrationProvider) => {
     setProvider(next)
     setStatus({ kind: 'idle' })
-    const stored = getStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY)
+    // Persist the current in-memory endpoint/model (state was seeded from
+    // storage on mount, so it is at least as fresh) — writing the stored
+    // values back would silently revert edits made since.
     setStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY, {
-      baseUrl: stored?.baseUrl ?? baseUrl,
-      model: stored?.model ?? model,
+      baseUrl: baseUrl.trim() || OLLAMA_PRESET.baseUrl,
+      model: model.trim() || OLLAMA_PRESET.model,
       provider: next,
     })
   }
@@ -158,10 +160,15 @@ export default function NarrationPanel({
       model: model.trim() || OLLAMA_PRESET.model,
       ...(trimmedKey ? { apiKey: trimmedKey } : {}),
     }
+    // Signed-out users never chose a provider (the toggle isn't rendered),
+    // so persist only a choice they actually made — stamping the signed-in
+    // default here would override their real preference for a later session.
+    const storedProvider = getStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY)?.provider
+    const providerToStore = isSignedIn ? provider : storedProvider
     setStorageItem<StoredNarrationConfig>(NARRATION_CONFIG_KEY, {
       baseUrl: settings.baseUrl,
       model: settings.model,
-      provider,
+      ...(providerToStore ? { provider: providerToStore } : {}),
     })
     setStatus({ kind: 'loading' })
     try {

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -121,6 +121,11 @@ export default function NarrationPanel({
 
   const chooseProvider = (next: NarrationProvider) => {
     setProvider(next)
+    // A provider switch makes any in-flight draft moot (the radios stay
+    // enabled while Writing…) — orphan and cancel it so a late response
+    // can't populate the panel with prose from the previous provider.
+    requestGeneration.current += 1
+    abortRef.current?.abort()
     setStatus({ kind: 'idle' })
     // Persist the current in-memory endpoint/model (state was seeded from
     // storage on mount, so it is at least as fresh) — writing the stored

--- a/src/lib/season-review/narration.ts
+++ b/src/lib/season-review/narration.ts
@@ -1,18 +1,25 @@
 /**
  * Season narration client (Phase 2c).
  *
- * Turns the deterministic findings[] into a few paragraphs of prose via a
- * user-configured, OpenAI-compatible chat endpoint — local Ollama by default.
- * Strictly opt-in and ephemeral: nothing here runs unless the user presses
- * Generate on /season-review, the request goes straight from the browser to
- * the endpoint the user configured (no app server in the path), and the
- * result is never persisted anywhere.
+ * Turns the deterministic findings[] into a few paragraphs of prose via one
+ * of two paths, both strictly opt-in and ephemeral (nothing runs unless the
+ * user presses Generate on /season-review, and the result is never persisted
+ * anywhere):
  *
- * The findings are the ONLY season data the model sees — plus the allotment
- * name and year. Coordinates never appear in findings and are never sent.
- * The prose is decoration, not information: every draft is checked by
- * `verifyNarration` (narration-verify.ts) and discarded if it contains any
- * number the findings don't vouch for.
+ * - `narrateSeason` — a user-configured, OpenAI-compatible chat endpoint,
+ *   local Ollama by default. Browser → endpoint directly, no app server in
+ *   the path.
+ * - `narrateSeasonHosted` — the app's own /api/season-narration route, which
+ *   proxies to the server-side Gemini free tier for signed-in users (shared
+ *   monthly quota with Aitor). This is what makes narration work in the
+ *   deployed app, where a server can never reach a user's localhost.
+ *
+ * On both paths the findings are the ONLY season data the model sees — plus
+ * the allotment name and year. Coordinates never appear in findings and are
+ * never sent, and internal ids are stripped by `toNarrationPayload` before
+ * anything leaves this module. The prose is decoration, not information:
+ * every draft is checked by `verifyNarration` (narration-verify.ts) and
+ * discarded if it contains any number the findings don't vouch for.
  */
 
 import type { Finding } from './findings'
@@ -43,7 +50,7 @@ export type NarrationResult =
   | { status: 'rejected'; text: string; unverifiedNumbers: string[] }
 
 /** Low temperature: the job is faithful restatement, not creativity. */
-const NARRATION_TEMPERATURE = 0.2
+export const NARRATION_TEMPERATURE = 0.2
 const NARRATION_MAX_TOKENS = 700
 /** Generous — a cold local model may need to load first — but never infinite. */
 const NARRATION_TIMEOUT_MS = 60_000
@@ -58,12 +65,36 @@ Rules — follow every one:
 - Do not mention coordinates or any location.
 - Write 2 to 4 short paragraphs of plain prose addressed to the gardener. No headings, no bullet points, no markdown.`
 
+/** A finding entity as narration sees it: display names only, no ids. */
+export interface NarrationEntityPayload {
+  areaName?: string
+  plantName?: string
+  varietyName?: string
+}
+
+/**
+ * The wire shape of one finding as narration sees it — the narration payload
+ * contract. No internal ids (finding, rule, area, planting, plant) and never
+ * coordinates. `Finding` is structurally assignable to this, so callers can
+ * pass raw findings and the mapping in `toNarrationPayload` does the strip.
+ */
+export interface NarrationFindingPayload {
+  severity: string
+  summary: string
+  metrics: Record<string, number | string>
+  entities: NarrationEntityPayload[]
+  dates?: { start?: string; end?: string }
+}
+
 /**
  * The exact findings payload sent to the model: severity, summary, metrics,
  * entity display names and dates — nothing else from the season, and never
- * coordinates (findings can't contain them by construction).
+ * coordinates (findings can't contain them by construction). Both the direct
+ * client and the hosted route build their prompts from this.
  */
-function findingsPayload(findings: Finding[]): unknown[] {
+export function toNarrationPayload(
+  findings: NarrationFindingPayload[]
+): NarrationFindingPayload[] {
   return findings.map((f) => ({
     severity: f.severity,
     summary: f.summary,
@@ -82,9 +113,9 @@ export interface ChatMessage {
   content: string
 }
 
-/** Build the chat messages. Exported for tests. */
+/** Build the chat messages. Used by the hosted route too; exported for tests. */
 export function buildNarrationMessages(
-  findings: Finding[],
+  findings: NarrationFindingPayload[],
   meta: NarrationMeta
 ): ChatMessage[] {
   const lines = [
@@ -93,7 +124,7 @@ export function buildNarrationMessages(
     'Findings (JSON):',
     // Compact — pretty-printing only spends context window, which is scarce
     // on small local models.
-    JSON.stringify(findingsPayload(findings)),
+    JSON.stringify(toNarrationPayload(findings)),
   ].filter((line): line is string => line !== null)
   return [
     { role: 'system', content: SYSTEM_PROMPT },
@@ -104,6 +135,34 @@ export function buildNarrationMessages(
 export interface NarrationRequestOptions {
   /** External cancellation (e.g. the inputs changed and the draft is moot). */
   signal?: AbortSignal
+}
+
+/**
+ * A fetch signal that fires on either the narration timeout or the caller's
+ * own signal — a hung endpoint must fail predictably rather than pin the UI
+ * on "Writing…" forever, and a superseded request is actively cancelled, not
+ * just ignored. Throws immediately when the caller's signal is already
+ * aborted. `cleanup` must run once the fetch settles.
+ */
+function linkAbortSignals(external?: AbortSignal): {
+  signal: AbortSignal
+  cleanup: () => void
+} {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), NARRATION_TIMEOUT_MS)
+  const abortFromCaller = () => controller.abort()
+  if (external?.aborted) {
+    clearTimeout(timeoutId)
+    throw new DOMException('The operation was aborted.', 'AbortError')
+  }
+  external?.addEventListener('abort', abortFromCaller)
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timeoutId)
+      external?.removeEventListener('abort', abortFromCaller)
+    },
+  }
 }
 
 /**
@@ -150,17 +209,7 @@ export async function requestNarration(
     headers['Authorization'] = `Bearer ${apiKey}`
   }
 
-  // A hung endpoint must fail predictably rather than pin the UI on
-  // "Writing…" forever. The caller's signal chains into the same controller
-  // so a superseded request is actively cancelled, not just ignored.
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), NARRATION_TIMEOUT_MS)
-  const abortFromCaller = () => controller.abort()
-  if (options.signal?.aborted) {
-    clearTimeout(timeoutId)
-    throw new DOMException('The operation was aborted.', 'AbortError')
-  }
-  options.signal?.addEventListener('abort', abortFromCaller)
+  const { signal, cleanup } = linkAbortSignals(options.signal)
 
   try {
     const response = await fetchImpl(url, {
@@ -173,7 +222,7 @@ export async function requestNarration(
         max_tokens: NARRATION_MAX_TOKENS,
         stream: false,
       }),
-      signal: controller.signal,
+      signal,
     })
 
     if (!response.ok) {
@@ -199,9 +248,24 @@ export async function requestNarration(
     }
     return content.trim()
   } finally {
-    clearTimeout(timeoutId)
-    options.signal?.removeEventListener('abort', abortFromCaller)
+    cleanup()
   }
+}
+
+/** The verification gate every draft passes through, whichever path produced it. */
+function verifyDraft(
+  text: string,
+  findings: Finding[],
+  meta: NarrationMeta
+): NarrationResult {
+  const verification = verifyNarration(text, findings, {
+    year: meta.year,
+    allotmentName: meta.allotmentName,
+  })
+  if (!verification.ok) {
+    return { status: 'rejected', text, unverifiedNumbers: verification.unverifiedNumbers }
+  }
+  return { status: 'ok', text }
 }
 
 /**
@@ -218,12 +282,90 @@ export async function narrateSeason(
   options: NarrationRequestOptions = {}
 ): Promise<NarrationResult> {
   const text = await requestNarration(findings, meta, settings, fetchImpl, options)
-  const verification = verifyNarration(text, findings, {
-    year: meta.year,
-    allotmentName: meta.allotmentName,
-  })
-  if (!verification.ok) {
-    return { status: 'rejected', text, unverifiedNumbers: verification.unverifiedNumbers }
+  return verifyDraft(text, findings, meta)
+}
+
+/** Same-origin route backing the hosted (server-side free tier) path. */
+export const HOSTED_NARRATION_PATH = '/api/season-narration'
+
+/**
+ * A non-OK response from the hosted narration route. `quotaExceeded` is true
+ * when the 429 was the monthly free-tier quota (shared with Aitor) running
+ * out — the UI renders that case as guidance, not as a failure.
+ */
+export class HostedNarrationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly quotaExceeded: boolean = false
+  ) {
+    super(message)
+    this.name = 'HostedNarrationError'
   }
-  return { status: 'ok', text }
+}
+
+/**
+ * Call the app's own /api/season-narration route (server-side Gemini free
+ * tier, signed-in users only) and return the raw draft. Sends the stripped
+ * `toNarrationPayload` shape plus year and allotment name — the same
+ * findings-only contract as the direct client, with internal ids removed
+ * before the request leaves the browser. Throws `HostedNarrationError` on a
+ * non-OK status, and plain errors on network failure or an empty response.
+ */
+export async function requestHostedNarration(
+  findings: Finding[],
+  meta: NarrationMeta,
+  fetchImpl: typeof fetch = fetch,
+  options: NarrationRequestOptions = {}
+): Promise<string> {
+  const { signal, cleanup } = linkAbortSignals(options.signal)
+
+  try {
+    const response = await fetchImpl(HOSTED_NARRATION_PATH, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        year: meta.year,
+        ...(meta.allotmentName ? { allotmentName: meta.allotmentName } : {}),
+        findings: toNarrationPayload(findings),
+      }),
+      signal,
+    })
+
+    if (!response.ok) {
+      let message = `Hosted narration returned ${response.status}`
+      let quotaExceeded = false
+      try {
+        const body = (await response.json()) as { error?: string; quotaExceeded?: boolean }
+        if (body.error) message = body.error
+        quotaExceeded = body.quotaExceeded === true
+      } catch {
+        // Non-JSON error body — the status alone will have to do.
+      }
+      throw new HostedNarrationError(message, response.status, quotaExceeded)
+    }
+
+    const data = (await response.json()) as { text?: string }
+    if (!data.text || !data.text.trim()) {
+      throw new Error('Hosted narration returned an empty response')
+    }
+    return data.text.trim()
+  } finally {
+    cleanup()
+  }
+}
+
+/**
+ * Hosted twin of `narrateSeason`: fetch a draft from the app's free-tier
+ * route, then run it through the exact same `verifyNarration` gate — a
+ * failing draft is discarded identically on both paths.
+ */
+export async function narrateSeasonHosted(
+  findings: Finding[],
+  meta: NarrationMeta,
+  fetchImpl: typeof fetch = fetch,
+  options: NarrationRequestOptions = {}
+): Promise<NarrationResult> {
+  const text = await requestHostedNarration(findings, meta, fetchImpl, options)
+  return verifyDraft(text, findings, meta)
 }

--- a/src/lib/validations/season-narration.ts
+++ b/src/lib/validations/season-narration.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+
+/**
+ * Validation schema for the hosted season-narration route.
+ *
+ * This is the server-side enforcement of the narration payload contract
+ * (`toNarrationPayload` in src/lib/season-review/narration.ts): findings
+ * carry severity, summary, metrics, entity display names and dates — and
+ * nothing else. Zod strips unknown keys by default, so internal ids
+ * (finding id, ruleId, areaId, plantingId, plantId) and anything else a
+ * caller might send are dropped before the prompt is built. Coordinates can
+ * never appear: no field of this shape holds them.
+ */
+
+const MAX_FINDINGS = 60
+const MAX_SUMMARY_LENGTH = 500
+const MAX_NAME_LENGTH = 200
+const MAX_ENTITIES_PER_FINDING = 12
+const MAX_METRIC_KEY_LENGTH = 80
+const MAX_METRIC_VALUE_LENGTH = 200
+const MAX_DATE_LENGTH = 40
+
+const narrationEntitySchema = z.object({
+  areaName: z.string().max(MAX_NAME_LENGTH).optional(),
+  plantName: z.string().max(MAX_NAME_LENGTH).optional(),
+  varietyName: z.string().max(MAX_NAME_LENGTH).optional(),
+})
+
+const narrationFindingSchema = z.object({
+  severity: z.enum(['info', 'notice', 'warning']),
+  summary: z.string().min(1).max(MAX_SUMMARY_LENGTH),
+  metrics: z.record(
+    z.string().max(MAX_METRIC_KEY_LENGTH),
+    z.union([z.number(), z.string().max(MAX_METRIC_VALUE_LENGTH)])
+  ),
+  entities: z.array(narrationEntitySchema).max(MAX_ENTITIES_PER_FINDING),
+  dates: z
+    .object({
+      start: z.string().max(MAX_DATE_LENGTH).optional(),
+      end: z.string().max(MAX_DATE_LENGTH).optional(),
+    })
+    .optional(),
+})
+
+export const seasonNarrationRequestSchema = z.object({
+  year: z.number().int().min(1900).max(2200),
+  allotmentName: z.string().max(MAX_NAME_LENGTH).optional(),
+  // The panel only mounts with findings on screen, so an empty array is a
+  // caller bug, not a state worth spending quota on.
+  findings: z.array(narrationFindingSchema).min(1).max(MAX_FINDINGS),
+})
+
+export type SeasonNarrationRequest = z.infer<typeof seasonNarrationRequestSchema>


### PR DESCRIPTION
## Summary

Makes the `/season-review` AI summary work in the deployed app without Ollama. `NarrationPanel` gains an "AI provider" toggle, shown only to signed-in users: **Built-in** (default when signed in) routes through a new `POST /api/season-narration` route that reuses the existing Gemini free-tier plumbing from Aitor — the `gemini.ts` adapter and the shared `ai_usage` monthly quota (checked before the call, incremented only on success), plus a short-window per-user rate limit. **Your own endpoint** is the existing Ollama/BYO path, unchanged and still the only option when signed out.

Guardrails preserved:
- **Findings-only contract**: the zod schema (`src/lib/validations/season-narration.ts`) strips everything outside the narration payload shape, so findings[] + allotment name + year stay the only season data sent — never coordinates or internal ids (`narrateSeasonHosted` also strips ids client-side via `toNarrationPayload` before the request leaves the browser). The prompt itself comes from the shared `buildNarrationMessages`, identical to the direct path.
- **Verify gate unchanged**: the hosted draft passes through the exact same `verifyNarration` gate; a failing draft is discarded exactly as today.
- **Quota UX**: a quota-exhausted 429 (typed `HostedNarrationError` with `quotaExceeded`) renders the same friendly two-options message as Aitor — switch to your own endpoint, or wait for the monthly reset — rather than an error.

Docs updated: `docs/plans/current-plan.md` and `docs/plans/season-observer.md`.

## Related issue

Follow-up to the Season Observer Phase 2c narration (see `docs/plans/season-observer.md`) building on the Gemini free tier from #345.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes — new route-handler tests (auth, rate limit, quota, prompt contract incl. id-stripping, increment-only-on-success), hosted-client tests (payload shape, quota error, unchanged verify gate), and panel provider-selection tests; `type-check`, `lint`, `test:unit` (1474 passed), and `build` all green
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dzPz7s3b5agF3jNJwiHeY

---
_Generated by [Claude Code](https://claude.ai/code/session_016dzPz7s3b5agF3jNJwiHeY)_