### PR TITLE
Surface the shared AI free-tier quota where it's spent

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,23 @@
 # Current Plan
 
-Last updated: 2026-07-19 (hosted season narration shipped)
+Last updated: 2026-07-19 (shared AI quota made visible)
+
+## Quota visibility for the shared AI free tier (shipped)
+
+Follow-up to hosted narration below: season narration and Aitor now spend
+one `ai_usage` counter, so the remaining quota is surfaced where it's
+spent. The client-side lookup that `AiQuotaSection` did inline was
+extracted into a shared `useAiQuota` hook (`src/hooks/useAiQuota.ts` —
+signed-in + Supabase-configured gate, Clerk `supabase` JWT, `getCurrentUsage`,
+plus a `refresh()` re-read); no new endpoints, no schema changes.
+`NarrationPanel` shows "X of 30 free requests left this month (shared with
+Aitor)" while the Built-in provider is selected, degrades silently (no
+count, no error) when signed out or the lookup fails, and re-reads the
+counter after each hosted generation so the number stays honest.
+Settings → `AiQuotaSection` reuses the hook and its copy now says the
+quota is shared between Aitor and season narration. Covered by
+`useAiQuota` hook tests, NarrationPanel quota-visibility tests, and
+AiQuotaSection copy/reuse tests.
 
 ## Season Observer — hosted narration via the free tier (shipped)
 

--- a/src/__tests__/components/AiQuotaSection.test.tsx
+++ b/src/__tests__/components/AiQuotaSection.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * AiQuotaSection — Settings surface for the shared free-tier AI quota.
+ * The lookup itself lives in useAiQuota (shared with NarrationPanel); this
+ * component renders it with copy that says the quota is shared between Aitor
+ * and season narration.
+ */
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AiQuotaSection from '@/components/settings/AiQuotaSection'
+import { useAiQuota } from '@/hooks/useAiQuota'
+import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+
+vi.mock('@/hooks/useAiQuota', () => ({
+  useAiQuota: vi.fn(),
+}))
+
+vi.mock('@/hooks/useOptionalAuth', () => ({
+  useOptionalAuth: vi.fn(),
+}))
+
+const useAiQuotaMock = vi.mocked(useAiQuota)
+const useOptionalAuthMock = vi.mocked(useOptionalAuth)
+
+function authState(isSignedIn: boolean) {
+  return {
+    isSignedIn,
+    userId: isSignedIn ? 'user_1' : null,
+    getToken: async () => null,
+    signOut: async () => {},
+    userEmail: undefined,
+  }
+}
+
+function quotaState(overrides: Partial<ReturnType<typeof useAiQuota>> = {}) {
+  return {
+    usage: null,
+    error: null,
+    isLoading: false,
+    refresh: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('AiQuotaSection', () => {
+  beforeEach(() => {
+    useOptionalAuthMock.mockReturnValue(authState(true))
+    useAiQuotaMock.mockReset()
+    useAiQuotaMock.mockReturnValue(quotaState())
+  })
+
+  it('reuses the shared useAiQuota lookup, disabled for BYO-key users', () => {
+    render(<AiQuotaSection hasOwnToken={false} />)
+    expect(useAiQuotaMock).toHaveBeenCalledWith(true)
+
+    useAiQuotaMock.mockClear()
+    render(<AiQuotaSection hasOwnToken={true} />)
+    expect(useAiQuotaMock).toHaveBeenCalledWith(false)
+  })
+
+  it('shows the count with copy saying the quota is shared with season narration', () => {
+    useAiQuotaMock.mockReturnValue(
+      quotaState({ usage: { yearMonth: '2026-07', requestCount: 3, remaining: 27 } })
+    )
+    render(<AiQuotaSection hasOwnToken={false} />)
+
+    expect(screen.getByText(/3 \/ 30 free AI requests used this month/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/shared between Aitor and season narration/i)
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the shared-quota mention in the exhausted state', () => {
+    useAiQuotaMock.mockReturnValue(
+      quotaState({ usage: { yearMonth: '2026-07', requestCount: 30, remaining: 0 } })
+    )
+    render(<AiQuotaSection hasOwnToken={false} />)
+
+    expect(screen.getByText(/30 \/ 30 free AI requests used this month/i)).toBeInTheDocument()
+    expect(screen.getByText(/quota exhausted/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/shared between Aitor and season narration/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders nothing for BYO-key users and signed-out users', () => {
+    const { container: withToken } = render(<AiQuotaSection hasOwnToken={true} />)
+    expect(withToken).toBeEmptyDOMElement()
+
+    useOptionalAuthMock.mockReturnValue(authState(false))
+    const { container: signedOut } = render(<AiQuotaSection hasOwnToken={false} />)
+    expect(signedOut).toBeEmptyDOMElement()
+  })
+
+  it('shows the lookup error message when the fetch fails', () => {
+    useAiQuotaMock.mockReturnValue(quotaState({ error: 'supabase down' }))
+    render(<AiQuotaSection hasOwnToken={false} />)
+
+    expect(screen.getByText('supabase down')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/components/NarrationPanel.test.tsx
+++ b/src/__tests__/components/NarrationPanel.test.tsx
@@ -15,6 +15,7 @@ import {
   type NarrationResult,
 } from '@/lib/season-review/narration'
 import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+import { useAiQuota } from '@/hooks/useAiQuota'
 
 vi.mock('@/lib/season-review/narration', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/season-review/narration')>()),
@@ -26,9 +27,24 @@ vi.mock('@/hooks/useOptionalAuth', () => ({
   useOptionalAuth: vi.fn(),
 }))
 
+vi.mock('@/hooks/useAiQuota', () => ({
+  useAiQuota: vi.fn(),
+}))
+
 const narrateSeasonMock = vi.mocked(narrateSeason)
 const narrateSeasonHostedMock = vi.mocked(narrateSeasonHosted)
 const useOptionalAuthMock = vi.mocked(useOptionalAuth)
+const useAiQuotaMock = vi.mocked(useAiQuota)
+
+function quotaState(overrides: Partial<ReturnType<typeof useAiQuota>> = {}) {
+  return {
+    usage: null,
+    error: null,
+    isLoading: false,
+    refresh: vi.fn(),
+    ...overrides,
+  }
+}
 
 function authState(isSignedIn: boolean) {
   return {
@@ -64,6 +80,8 @@ describe('NarrationPanel', () => {
     narrateSeasonMock.mockReset()
     narrateSeasonHostedMock.mockReset()
     useOptionalAuthMock.mockReturnValue(authState(false))
+    useAiQuotaMock.mockReset()
+    useAiQuotaMock.mockReturnValue(quotaState())
     localStorage.clear()
     sessionStorage.clear()
   })
@@ -248,6 +266,63 @@ describe('NarrationPanel', () => {
 
       const stored = JSON.parse(localStorage.getItem('bwp-narration-config') ?? '{}')
       expect(stored.provider).toBeUndefined()
+    })
+  })
+
+  describe('shared quota visibility', () => {
+    const USAGE = { yearMonth: '2026-07', requestCount: 3, remaining: 27 }
+
+    it('shows the remaining shared quota when the built-in provider is selected', () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      useAiQuotaMock.mockReturnValue(quotaState({ usage: USAGE }))
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      expect(screen.getByText(/27 of 30 free requests left this month/i)).toBeInTheDocument()
+    })
+
+    it('degrades silently when the quota lookup fails', () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      useAiQuotaMock.mockReturnValue(quotaState({ error: 'supabase down' }))
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      expect(screen.queryByText(/free requests left this month/i)).not.toBeInTheDocument()
+      expect(screen.queryByText('supabase down')).not.toBeInTheDocument()
+    })
+
+    it('never enables the lookup for signed-out users', () => {
+      useAiQuotaMock.mockReturnValue(quotaState({ usage: USAGE }))
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      // Signed out means the custom provider — the lookup is disabled and no
+      // count renders even if a stale usage value were returned.
+      expect(useAiQuotaMock).toHaveBeenCalledWith(false)
+      expect(screen.queryByText(/free requests left this month/i)).not.toBeInTheDocument()
+    })
+
+    it('hides the count when the user switches to their own endpoint', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      useAiQuotaMock.mockReturnValue(quotaState({ usage: USAGE }))
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      expect(screen.getByText(/27 of 30 free requests left this month/i)).toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole('radio', { name: /your own endpoint/i }))
+
+      expect(useAiQuotaMock).toHaveBeenLastCalledWith(false)
+      expect(screen.queryByText(/free requests left this month/i)).not.toBeInTheDocument()
+    })
+
+    it('re-reads the counter after a hosted generation', async () => {
+      useOptionalAuthMock.mockReturnValue(authState(true))
+      const refresh = vi.fn()
+      useAiQuotaMock.mockReturnValue(quotaState({ usage: USAGE, refresh }))
+      narrateSeasonHostedMock.mockResolvedValue({ status: 'ok', text: 'A grand year.' })
+      render(<NarrationPanel findings={FINDINGS} year={2024} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /generate narration/i }))
+      await screen.findByText('A grand year.')
+
+      expect(refresh).toHaveBeenCalled()
     })
   })
 })

--- a/src/__tests__/hooks/useAiQuota.test.tsx
+++ b/src/__tests__/hooks/useAiQuota.test.tsx
@@ -121,4 +121,32 @@ describe('useAiQuota', () => {
     )
     expect(getCurrentUsageMock).toHaveBeenCalledTimes(2)
   })
+
+  it('clears a previously shown usage when a refresh fails', async () => {
+    getCurrentUsageMock.mockResolvedValueOnce(USAGE)
+    getCurrentUsageMock.mockRejectedValueOnce(new Error('supabase down'))
+
+    const { result } = renderHook(() => useAiQuota())
+    await waitFor(() => expect(result.current.usage).toEqual(USAGE))
+
+    act(() => result.current.refresh())
+
+    // The failed re-read must not leave the stale count on show.
+    await waitFor(() => expect(result.current.error).toBe('supabase down'))
+    expect(result.current.usage).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('clears a previous error when a later fetch succeeds', async () => {
+    getCurrentUsageMock.mockRejectedValueOnce(new Error('supabase down'))
+    getCurrentUsageMock.mockResolvedValueOnce(USAGE)
+
+    const { result } = renderHook(() => useAiQuota())
+    await waitFor(() => expect(result.current.error).toBe('supabase down'))
+
+    act(() => result.current.refresh())
+
+    await waitFor(() => expect(result.current.usage).toEqual(USAGE))
+    expect(result.current.error).toBeNull()
+  })
 })

--- a/src/__tests__/hooks/useAiQuota.test.tsx
+++ b/src/__tests__/hooks/useAiQuota.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * useAiQuota — the shared client-side lookup of the free-tier AI counter,
+ * reused by Settings (AiQuotaSection) and the Season Review narration panel.
+ */
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAiQuota } from '@/hooks/useAiQuota'
+import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+import { isSupabaseConfigured } from '@/lib/supabase/client'
+import { getCurrentUsage } from '@/lib/supabase/ai-usage'
+
+vi.mock('@/hooks/useOptionalAuth', () => ({
+  useOptionalAuth: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/client', () => ({
+  isSupabaseConfigured: vi.fn(),
+  createAuthClient: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/ai-usage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/supabase/ai-usage')>()),
+  getCurrentUsage: vi.fn(),
+}))
+
+const useOptionalAuthMock = vi.mocked(useOptionalAuth)
+const isSupabaseConfiguredMock = vi.mocked(isSupabaseConfigured)
+const getCurrentUsageMock = vi.mocked(getCurrentUsage)
+
+function authState(isSignedIn: boolean, token: string | null = 'jwt-token') {
+  return {
+    isSignedIn,
+    userId: isSignedIn ? 'user_1' : null,
+    getToken: vi.fn(async () => (isSignedIn ? token : null)),
+    signOut: async () => {},
+    userEmail: undefined,
+  }
+}
+
+const USAGE = { yearMonth: '2026-07', requestCount: 3, remaining: 27 }
+
+describe('useAiQuota', () => {
+  beforeEach(() => {
+    getCurrentUsageMock.mockReset()
+    isSupabaseConfiguredMock.mockReturnValue(true)
+    useOptionalAuthMock.mockReturnValue(authState(true))
+  })
+
+  it('fetches the current usage for a signed-in user', async () => {
+    getCurrentUsageMock.mockResolvedValue(USAGE)
+
+    const { result } = renderHook(() => useAiQuota())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.usage).toEqual(USAGE)
+    expect(result.current.error).toBeNull()
+    expect(getCurrentUsageMock).toHaveBeenCalledWith('jwt-token', 'user_1')
+  })
+
+  it('does not fetch and resolves quietly when signed out', async () => {
+    useOptionalAuthMock.mockReturnValue(authState(false))
+
+    const { result } = renderHook(() => useAiQuota())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.usage).toBeNull()
+    expect(result.current.error).toBeNull()
+    expect(getCurrentUsageMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when disabled, even signed in', async () => {
+    const { result } = renderHook(() => useAiQuota(false))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.usage).toBeNull()
+    expect(getCurrentUsageMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when Supabase is not configured', async () => {
+    isSupabaseConfiguredMock.mockReturnValue(false)
+
+    const { result } = renderHook(() => useAiQuota())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.usage).toBeNull()
+    expect(getCurrentUsageMock).not.toHaveBeenCalled()
+  })
+
+  it('reports an error (usage stays null) when the lookup fails', async () => {
+    getCurrentUsageMock.mockRejectedValue(new Error('supabase down'))
+
+    const { result } = renderHook(() => useAiQuota())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.usage).toBeNull()
+    expect(result.current.error).toBe('supabase down')
+  })
+
+  it('reports an error when the JWT template yields no token', async () => {
+    useOptionalAuthMock.mockReturnValue(authState(true, null))
+
+    const { result } = renderHook(() => useAiQuota())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.usage).toBeNull()
+    expect(result.current.error).toMatch(/JWT template/i)
+    expect(getCurrentUsageMock).not.toHaveBeenCalled()
+  })
+
+  it('re-fetches on refresh()', async () => {
+    getCurrentUsageMock.mockResolvedValueOnce(USAGE)
+    getCurrentUsageMock.mockResolvedValueOnce({ ...USAGE, requestCount: 4, remaining: 26 })
+
+    const { result } = renderHook(() => useAiQuota())
+    await waitFor(() => expect(result.current.usage).toEqual(USAGE))
+
+    act(() => result.current.refresh())
+
+    await waitFor(() =>
+      expect(result.current.usage).toEqual({ ...USAGE, requestCount: 4, remaining: 26 })
+    )
+    expect(getCurrentUsageMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/components/season-review/NarrationPanel.tsx
+++ b/src/components/season-review/NarrationPanel.tsx
@@ -33,6 +33,8 @@ import {
 import { getStorageItem, setStorageItem } from '@/services/generic-storage'
 import { useSessionStorage } from '@/hooks/useSessionStorage'
 import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+import { useAiQuota } from '@/hooks/useAiQuota'
+import { FREE_TIER_MONTHLY_QUOTA } from '@/lib/supabase/ai-usage'
 
 /** Endpoint + model + provider persist across sessions; the optional key is session-only. */
 const NARRATION_CONFIG_KEY = 'bwp-narration-config'
@@ -118,6 +120,14 @@ export default function NarrationPanel({
 
   const effectiveProvider: NarrationProvider =
     isSignedIn && provider === 'hosted' ? 'hosted' : 'custom'
+
+  // The Built-in tier spends the same ai_usage counter as Aitor — surface how
+  // much is left where it's about to be spent. The lookup only runs while the
+  // hosted provider is in play, and the panel degrades silently (no count) when
+  // the user is signed out or the lookup fails.
+  const { usage: quotaUsage, refresh: refreshQuota } = useAiQuota(
+    effectiveProvider === 'hosted'
+  )
 
   const chooseProvider = (next: NarrationProvider) => {
     setProvider(next)
@@ -207,6 +217,11 @@ export default function NarrationPanel({
       } else {
         setStatus({ kind: 'error', message: friendlyRequestError(error, settings.baseUrl) })
       }
+    } finally {
+      // A hosted attempt may have spent a unit of the shared quota (even one
+      // whose result was orphaned) — re-read the counter so the count stays
+      // honest. A refresh is a pure re-read, so firing on failure is harmless.
+      if (effectiveProvider === 'hosted') refreshQuota()
     }
   }
 
@@ -254,6 +269,13 @@ export default function NarrationPanel({
               </label>
             </div>
           </fieldset>
+        )}
+
+        {effectiveProvider === 'hosted' && quotaUsage && (
+          <p className="text-xs text-zen-stone-500" role="status" aria-label="Free AI quota">
+            {quotaUsage.remaining} of {FREE_TIER_MONTHLY_QUOTA} free requests left this month
+            <span className="text-zen-stone-400"> (shared with Aitor)</span>
+          </p>
         )}
 
         {effectiveProvider === 'custom' && (

--- a/src/components/settings/AiQuotaSection.tsx
+++ b/src/components/settings/AiQuotaSection.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { Sparkles } from 'lucide-react'
 import { useOptionalAuth } from '@/hooks/useOptionalAuth'
-import { isSupabaseConfigured } from '@/lib/supabase/client'
-import { FREE_TIER_MONTHLY_QUOTA, getCurrentUsage, type AiUsage } from '@/lib/supabase/ai-usage'
+import { useAiQuota } from '@/hooks/useAiQuota'
+import { FREE_TIER_MONTHLY_QUOTA } from '@/lib/supabase/ai-usage'
 
 interface AiQuotaSectionProps {
   /** Whether the user has a BYO OpenAI token configured. When true, the
@@ -13,48 +12,14 @@ interface AiQuotaSectionProps {
 }
 
 /**
- * Surfaces the user's free-tier monthly Aitor quota when the server-side
- * Gemini fallback is in play. Stays silent when the user has their own
- * OpenAI token (no quota applies) or when Supabase isn't configured.
+ * Surfaces the user's free-tier monthly AI quota (shared between Aitor and
+ * season narration) when the server-side Gemini fallback is in play. Stays
+ * silent when the user has their own OpenAI token (no quota applies) or when
+ * Supabase isn't configured.
  */
 export default function AiQuotaSection({ hasOwnToken }: AiQuotaSectionProps) {
-  const { isSignedIn, userId, getToken } = useOptionalAuth()
-  const [usage, setUsage] = useState<AiUsage | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    if (!isSignedIn || !userId || !isSupabaseConfigured() || hasOwnToken) {
-      setIsLoading(false)
-      return
-    }
-
-    let cancelled = false
-    async function load() {
-      try {
-        const token = await getToken({ template: 'supabase' })
-        if (!token) {
-          if (!cancelled) {
-            setError('Could not check quota — JWT template not configured.')
-            setIsLoading(false)
-          }
-          return
-        }
-        const u = await getCurrentUsage(token, userId!)
-        if (!cancelled) {
-          setUsage(u)
-          setIsLoading(false)
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load quota')
-          setIsLoading(false)
-        }
-      }
-    }
-    load()
-    return () => { cancelled = true }
-  }, [isSignedIn, userId, hasOwnToken, getToken])
+  const { isSignedIn } = useOptionalAuth()
+  const { usage, error, isLoading } = useAiQuota(!hasOwnToken)
 
   if (!isSignedIn || hasOwnToken) return null
   if (isLoading) return null
@@ -77,7 +42,7 @@ export default function AiQuotaSection({ hasOwnToken }: AiQuotaSectionProps) {
           : 'bg-zen-moss-50 border-zen-moss-100'
       }`}
       role="status"
-      aria-label="Free Aitor quota"
+      aria-label="Free AI quota"
     >
       <Sparkles
         className={`w-4 h-4 mt-0.5 flex-shrink-0 ${
@@ -87,12 +52,12 @@ export default function AiQuotaSection({ hasOwnToken }: AiQuotaSectionProps) {
       />
       <div className="text-sm text-zen-ink-700">
         <p className="font-medium">
-          {used} / {FREE_TIER_MONTHLY_QUOTA} free Aitor requests used this month
+          {used} / {FREE_TIER_MONTHLY_QUOTA} free AI requests used this month
         </p>
         <p className="text-xs text-zen-stone-600 mt-1">
           {exhausted
-            ? 'Free quota exhausted. Add your own OpenAI key below for unlimited use, or check back next month.'
-            : 'Add your own OpenAI key below for unlimited use.'}
+            ? 'Free quota exhausted — it is shared between Aitor and season narration. Add your own OpenAI key below for unlimited Aitor use, or check back next month.'
+            : 'This quota is shared between Aitor and season narration. Add your own OpenAI key below for unlimited Aitor use.'}
         </p>
       </div>
     </div>

--- a/src/hooks/useAiQuota.ts
+++ b/src/hooks/useAiQuota.ts
@@ -1,0 +1,72 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useOptionalAuth } from '@/hooks/useOptionalAuth'
+import { isSupabaseConfigured } from '@/lib/supabase/client'
+import { getCurrentUsage, type AiUsage } from '@/lib/supabase/ai-usage'
+
+export interface AiQuotaState {
+  /** Current month's usage, or null while loading / on error / when the lookup doesn't apply. */
+  usage: AiUsage | null
+  error: string | null
+  isLoading: boolean
+  /** Re-fetch the counter (e.g. after a request that spent quota). */
+  refresh: () => void
+}
+
+/**
+ * Client-side lookup of the shared free-tier AI quota (`ai_usage` counter,
+ * spent by both Aitor and season narration). Requires a signed-in user and
+ * configured Supabase; otherwise resolves to no usage without fetching.
+ * Pass `enabled: false` to skip the lookup entirely (e.g. BYO key users,
+ * or a provider selection the quota doesn't apply to).
+ */
+export function useAiQuota(enabled: boolean = true): AiQuotaState {
+  const { isSignedIn, userId, getToken } = useOptionalAuth()
+  const [usage, setUsage] = useState<AiUsage | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [fetchCount, setFetchCount] = useState(0)
+
+  useEffect(() => {
+    if (!enabled || !isSignedIn || !userId || !isSupabaseConfigured()) {
+      setUsage(null)
+      setError(null)
+      setIsLoading(false)
+      return
+    }
+
+    let cancelled = false
+    async function load() {
+      try {
+        const token = await getToken({ template: 'supabase' })
+        if (!token) {
+          if (!cancelled) {
+            setError('Could not check quota — JWT template not configured.')
+            setIsLoading(false)
+          }
+          return
+        }
+        const u = await getCurrentUsage(token, userId!)
+        if (!cancelled) {
+          setUsage(u)
+          setError(null)
+          setIsLoading(false)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load quota')
+          setIsLoading(false)
+        }
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, isSignedIn, userId, getToken, fetchCount])
+
+  const refresh = useCallback(() => setFetchCount((c) => c + 1), [])
+
+  return { usage, error, isLoading, refresh }
+}

--- a/src/hooks/useAiQuota.ts
+++ b/src/hooks/useAiQuota.ts
@@ -25,7 +25,11 @@ export function useAiQuota(enabled: boolean = true): AiQuotaState {
   const { isSignedIn, userId, getToken } = useOptionalAuth()
   const [usage, setUsage] = useState<AiUsage | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  // Start in the loading state only when a fetch will actually happen, so a
+  // disabled/signed-out mount doesn't render a loading frame it never needed.
+  const [isLoading, setIsLoading] = useState(
+    () => enabled && isSignedIn && !!userId && isSupabaseConfigured()
+  )
   const [fetchCount, setFetchCount] = useState(0)
 
   useEffect(() => {
@@ -36,12 +40,19 @@ export function useAiQuota(enabled: boolean = true): AiQuotaState {
       return
     }
 
+    // Every fetch (including enabled-toggles and refresh()) starts a fresh
+    // loading cycle with the previous outcome cleared. A failed lookup below
+    // also clears `usage`, so consumers never show a count the latest read
+    // couldn't vouch for.
+    setIsLoading(true)
+    setError(null)
     let cancelled = false
     async function load() {
       try {
         const token = await getToken({ template: 'supabase' })
         if (!token) {
           if (!cancelled) {
+            setUsage(null)
             setError('Could not check quota — JWT template not configured.')
             setIsLoading(false)
           }
@@ -50,11 +61,11 @@ export function useAiQuota(enabled: boolean = true): AiQuotaState {
         const u = await getCurrentUsage(token, userId!)
         if (!cancelled) {
           setUsage(u)
-          setError(null)
           setIsLoading(false)
         }
       } catch (err) {
         if (!cancelled) {
+          setUsage(null)
           setError(err instanceof Error ? err.message : 'Failed to load quota')
           setIsLoading(false)
         }


### PR DESCRIPTION
## Summary

Season narration and Aitor now draw from one `ai_usage` counter (#484), but only Settings showed the quota. This makes it visible where it's spent, reusing the existing client-side lookup — no new endpoints, no schema changes.

- **New `useAiQuota` hook** (`src/hooks/useAiQuota.ts`): extracts the lookup `AiQuotaSection` did inline (signed-in + Supabase-configured gate, Clerk `supabase` JWT, `getCurrentUsage`), plus a `refresh()` re-read. Takes an `enabled` flag so consumers can skip the fetch when the quota doesn't apply (BYO key, custom provider).
- **NarrationPanel**: while the Built-in provider is selected, shows "X of 30 free requests left this month (shared with Aitor)". Degrades silently — no count, no error — when signed out or the lookup fails, and re-reads the counter after each hosted generation so the number stays honest.
- **Settings › AiQuotaSection**: reuses the hook; copy now says the quota is shared between Aitor and season narration (both the normal and exhausted states).
- `docs/plans/current-plan.md` updated.

## Related issue

Follow-up to #484 (hosted narration via the shared free tier).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Checklist

- [x] I have tested my changes
- [x] I have updated documentation if needed

Tests: `useAiQuota` hook tests (fetch, disabled/signed-out/unconfigured no-fetch, error, JWT-missing, refresh), NarrationPanel quota-visibility tests (shows remaining count, hides on lookup failure / signed out / custom provider, refresh after hosted generation), AiQuotaSection reuse + copy tests. `type-check`, `lint`, `test:unit` (1495 passed), and `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAUymxasKbCK9hcHrzhPtw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAUymxasKbCK9hcHrzhPtw)_