### PR TITLE
Close out the two Aitor/Settings sprint follow-ups

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,34 @@
 # Current Plan
 
-Last updated: 2026-07-19 (shared AI quota made visible)
+Last updated: 2026-07-20 (Aitor/Settings sprint follow-ups closed)
+
+## Aitor/Settings sprint follow-ups closed (2026-07-20)
+
+The two non-blocking leftovers from the #366–#371 sprint are resolved:
+
+**1. `usePersistedStorage` auto-save falsy-check — obsolete, no fix needed.**
+The flagged code path was the auto-save effect's `if (data && !isLoading)`
+truthy check in `src/hooks/usePersistedStorage.ts`. That entire file — and
+the auto-save write path with it — was deleted on main by ADR 027 Step 5
+(PR #462), which retired the legacy storage chain in favour of the Yjs
+engine. The surviving storage hooks don't carry the pattern:
+`usePersistedState`'s auto-save effect writes unconditionally after
+hydration and guards loads with `stored !== null`, and `useSessionStorage`'s
+consumers are all string tokens whose `''` initial value round-trips
+through its intentional clear-on-empty behaviour.
+
+**2. Tour element-existence filter now handles tab-switch targets.**
+The start-time filter in `useTour` can only inspect the active tab (the
+Tabs component unmounts inactive panels), so steps behind a tab switch
+passed through unchecked — e.g. a signed-in user with a BYO key starting
+the tour from the Data tab would land driver.js on the never-rendered
+`ai-quota` section as a detached popover. `moveToStep` now re-checks the
+target after the tab switch renders and walks past missing steps in the
+direction of travel (forward, backward, and at tour start); if nothing
+ahead has a live target the tour completes cleanly. The signed-out
+Data → Help fallback is unchanged. Covered by new `useTour` tests
+(fallback, start-time filter, forward skip, backward skip,
+complete-on-exhausted).
 
 ## Quota visibility for the shared AI free tier (shipped)
 
@@ -600,7 +628,7 @@ First cost-line measurement: on a small fixture (one bed with 2 plantings, one t
 
 ### AI/Settings UX sprint — Shipped (PRs #366–#371, 2026-05-17 → 2026-05-18)
 
-A six-PR sprint focused on the AI advisor and Settings surface. PR #366 (squash `e9c560c`) removed the Reset button from the allotment grid toolbar, dropped the OpenAI token privacy notice, merged the floating Diagnose + Ask Aitor launchers into one, made Settings land on the AI & Location tab for signed-in users via a `key` remount that survives Clerk's async auth resolve, lazy-mounted `AitorChatModal` via `next/dynamic` so its hooks no longer run on every parent re-render (the "extremely slow" report), added a minimize affordance with conversation state preserved via mount-while-minimized, and tightened the Aitor system prompt to favour short chat-style replies. The follow-up PRs landed on top of `main`: #367 (`1428638`) collapsed the BYOK OpenAI key input behind a default-closed disclosure; #369 (`9ada468`) fixed the bug where toggling Aitor off in Settings didn't propagate to the floating launcher in the same tab — `usePersistedStorage` now emits a same-tab `bonnie:storage-update` CustomEvent with a per-instance id and monotonic sequence so sibling hook instances stay in sync; #368 (`57d6ece`) made a planting's name itself clickable to open the species `PlantSummaryDialog`, removing the small `(i)` icon as redundant; #370 (`a085db5`) polished `usePersistedStorage` (unmount-flush symmetry, validate-rejection test, stringify hoist); and #371 (`e0cd829`) extended the Settings tour with the AI & Location section, with a runtime element-existence filter so signed-out users still get the Data → Help fallback. Each PR went through one round of Gemini bot review with a follow-up commit addressing the findings. Two non-blocking notes remain: the auto-save effect in `usePersistedStorage` still has a falsy-T truthy-check (same pattern as the two fixed in PR #370 but a separate code path), and the tour's element-existence filter only catches missing targets when the relevant tab is already active at tour start — both filed as follow-up candidates.
+A six-PR sprint focused on the AI advisor and Settings surface. PR #366 (squash `e9c560c`) removed the Reset button from the allotment grid toolbar, dropped the OpenAI token privacy notice, merged the floating Diagnose + Ask Aitor launchers into one, made Settings land on the AI & Location tab for signed-in users via a `key` remount that survives Clerk's async auth resolve, lazy-mounted `AitorChatModal` via `next/dynamic` so its hooks no longer run on every parent re-render (the "extremely slow" report), added a minimize affordance with conversation state preserved via mount-while-minimized, and tightened the Aitor system prompt to favour short chat-style replies. The follow-up PRs landed on top of `main`: #367 (`1428638`) collapsed the BYOK OpenAI key input behind a default-closed disclosure; #369 (`9ada468`) fixed the bug where toggling Aitor off in Settings didn't propagate to the floating launcher in the same tab — `usePersistedStorage` now emits a same-tab `bonnie:storage-update` CustomEvent with a per-instance id and monotonic sequence so sibling hook instances stay in sync; #368 (`57d6ece`) made a planting's name itself clickable to open the species `PlantSummaryDialog`, removing the small `(i)` icon as redundant; #370 (`a085db5`) polished `usePersistedStorage` (unmount-flush symmetry, validate-rejection test, stringify hoist); and #371 (`e0cd829`) extended the Settings tour with the AI & Location section, with a runtime element-existence filter so signed-out users still get the Data → Help fallback. Each PR went through one round of Gemini bot review with a follow-up commit addressing the findings. The two non-blocking follow-up notes this sprint left behind are now closed — see "Aitor/Settings sprint follow-ups closed" at the top of this plan.
 
 ### ADR 027 Yjs Step 3 — Foundation shipped (PRs #382, #383, 2026-05-18)
 

--- a/src/__tests__/hooks/useTour.test.tsx
+++ b/src/__tests__/hooks/useTour.test.tsx
@@ -1,0 +1,320 @@
+/**
+ * Tests for useTour — settings tour tab handling.
+ *
+ * Focus: the element-existence filter can only inspect the active tab's
+ * content at tour start (inactive tab panels are unmounted), so steps behind
+ * a tab switch must be re-checked at navigation time and skipped gracefully
+ * when their target never renders (e.g. the ai-quota section is hidden for
+ * users with their own API key).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { Config, DriveStep } from 'driver.js'
+
+interface MockDriverInstance {
+  drive: Mock<(index?: number) => void>
+  moveNext: Mock<() => void>
+  movePrevious: Mock<() => void>
+  moveTo: Mock<(index: number) => void>
+  getActiveIndex: Mock<() => number | undefined>
+  destroy: Mock<() => void>
+  refresh: Mock<() => void>
+}
+
+let lastConfig: Config | null = null
+let lastInstance: MockDriverInstance | null = null
+
+vi.mock('driver.js', () => ({
+  driver: (config: Config) => {
+    lastConfig = config
+    let activeIndex: number | undefined
+    const instance: MockDriverInstance = {
+      drive: vi.fn((index = 0) => {
+        activeIndex = index
+      }),
+      moveNext: vi.fn(() => {
+        activeIndex = (activeIndex ?? 0) + 1
+      }),
+      movePrevious: vi.fn(() => {
+        activeIndex = (activeIndex ?? 0) - 1
+      }),
+      moveTo: vi.fn((index: number) => {
+        activeIndex = index
+      }),
+      getActiveIndex: vi.fn(() => activeIndex),
+      destroy: vi.fn(),
+      refresh: vi.fn(),
+    }
+    lastInstance = instance
+    return instance
+  },
+}))
+
+import { useTour } from '@/hooks/useTour'
+
+/**
+ * Build a DOM that mimics the Settings page Tabs component: tab buttons with
+ * aria-selected, and a panel that only contains the active tab's content.
+ * Clicking a tab button synchronously re-renders the panel, like the real
+ * Tabs component does on the next React render.
+ */
+function setupSettingsDom(options: {
+  tabs: string[]
+  activeTab: string
+  /** data-tour attribute values rendered inside each tab's panel */
+  content: Record<string, string[]>
+}) {
+  const { tabs, activeTab, content } = options
+
+  // The tabs bar itself is always present (intro step target).
+  const tabsCard = document.createElement('div')
+  tabsCard.setAttribute('data-tour', 'settings-tabs')
+  document.body.appendChild(tabsCard)
+
+  const panel = document.createElement('div')
+
+  const renderPanel = (tabId: string) => {
+    panel.innerHTML = ''
+    for (const name of content[tabId] ?? []) {
+      const el = document.createElement('div')
+      el.setAttribute('data-tour', name)
+      panel.appendChild(el)
+    }
+  }
+
+  const activate = (tabId: string) => {
+    for (const other of tabs) {
+      document
+        .getElementById(`tab-${other}`)!
+        .setAttribute('aria-selected', other === tabId ? 'true' : 'false')
+    }
+    renderPanel(tabId)
+  }
+
+  for (const tabId of tabs) {
+    const btn = document.createElement('button')
+    btn.id = `tab-${tabId}`
+    btn.setAttribute('aria-selected', tabId === activeTab ? 'true' : 'false')
+    btn.addEventListener('click', () => activate(tabId))
+    tabsCard.appendChild(btn)
+  }
+  tabsCard.appendChild(panel)
+  renderPanel(activeTab)
+}
+
+const stepElements = (config: Config): string[] =>
+  (config.steps ?? []).map((s: DriveStep) => s.element as string)
+
+const activeTabId = (): string | undefined =>
+  document
+    .querySelector('[aria-selected="true"]')
+    ?.id.replace(/^tab-/, '')
+
+/** Start the settings tour and run past the 600ms initial delay. */
+function startSettingsTour(result: { current: ReturnType<typeof useTour> }) {
+  act(() => {
+    result.current.startTour('settings')
+  })
+  act(() => {
+    vi.advanceTimersByTime(600)
+  })
+}
+
+/** Click "next" and run past the 100ms tab-switch render delay. */
+function clickNext() {
+  act(() => {
+    lastConfig!.onNextClick!(undefined, {} as DriveStep, {
+      config: lastConfig!,
+      state: {},
+      driver: lastInstance as never,
+      index: lastInstance!.getActiveIndex(),
+    })
+    vi.advanceTimersByTime(100)
+  })
+}
+
+function clickPrev() {
+  act(() => {
+    lastConfig!.onPrevClick!(undefined, {} as DriveStep, {
+      config: lastConfig!,
+      state: {},
+      driver: lastInstance as never,
+      index: lastInstance!.getActiveIndex(),
+    })
+    vi.advanceTimersByTime(100)
+  })
+}
+
+describe('useTour - settings tour tab handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    document.body.innerHTML = ''
+    localStorage.clear()
+    lastConfig = null
+    lastInstance = null
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps the Data → Help fallback when signed out (no AI tab rendered)', () => {
+    setupSettingsDom({
+      tabs: ['data', 'help'],
+      activeTab: 'data',
+      content: {
+        data: ['data-management'],
+        help: ['tour-management'],
+      },
+    })
+
+    const { result } = renderHook(() => useTour())
+    startSettingsTour(result)
+
+    expect(lastConfig).not.toBeNull()
+    expect(stepElements(lastConfig!)).toEqual([
+      '[data-tour="settings-tabs"]',
+      '[data-tour="data-management"]',
+      '[data-tour="tour-management"]',
+    ])
+    expect(lastInstance!.drive).toHaveBeenCalledWith(0)
+  })
+
+  it('filters a missing target on the already-active tab at tour start', () => {
+    // Signed-in user with a BYO key: ai-quota is not rendered. Starting the
+    // tour while AI & Location is active lets the filter see the gap.
+    setupSettingsDom({
+      tabs: ['ai-location', 'data', 'help'],
+      activeTab: 'ai-location',
+      content: {
+        'ai-location': [
+          'ai-settings',
+          'ai-toggle',
+          'ai-byok-disclosure',
+          'location-settings',
+        ],
+        data: ['data-management'],
+        help: ['tour-management'],
+      },
+    })
+
+    const { result } = renderHook(() => useTour())
+    startSettingsTour(result)
+
+    expect(stepElements(lastConfig!)).not.toContain('[data-tour="ai-quota"]')
+  })
+
+  it('skips a step whose target is missing after its tab switch', () => {
+    // Same BYO-key user, but the tour starts from the Data tab, so the AI
+    // steps cannot be checked up front — ai-quota must be skipped at
+    // navigation time instead of driver.js landing on a missing element.
+    setupSettingsDom({
+      tabs: ['ai-location', 'data', 'help'],
+      activeTab: 'data',
+      content: {
+        'ai-location': [
+          'ai-settings',
+          'ai-toggle',
+          'ai-byok-disclosure',
+          'location-settings',
+        ],
+        data: ['data-management'],
+        help: ['tour-management'],
+      },
+    })
+
+    const { result } = renderHook(() => useTour())
+    startSettingsTour(result)
+
+    // All 8 steps survive the start-time filter: the 5 AI steps sit behind an
+    // inactive tab, so their existence is unknown until the switch.
+    expect(stepElements(lastConfig!)).toHaveLength(8)
+    expect(stepElements(lastConfig!)[3]).toBe('[data-tour="ai-quota"]')
+
+    // Step 0 (settings-tabs intro) → step 1 (ai-settings): switches tab.
+    clickNext()
+    expect(activeTabId()).toBe('ai-location')
+    expect(lastInstance!.moveNext).toHaveBeenCalledTimes(1)
+
+    // Step 1 → step 2 (ai-toggle): same tab.
+    clickNext()
+    expect(lastInstance!.moveNext).toHaveBeenCalledTimes(2)
+
+    // Step 2 → step 3 would be ai-quota, which never rendered: the tour must
+    // jump over it to step 4 (ai-byok-disclosure).
+    clickNext()
+    expect(lastInstance!.moveNext).toHaveBeenCalledTimes(2)
+    expect(lastInstance!.moveTo).toHaveBeenCalledWith(4)
+  })
+
+  it('skips a missing step when navigating backwards too', () => {
+    setupSettingsDom({
+      tabs: ['ai-location', 'data', 'help'],
+      activeTab: 'data',
+      content: {
+        'ai-location': [
+          'ai-settings',
+          'ai-toggle',
+          'ai-byok-disclosure',
+          'location-settings',
+        ],
+        data: ['data-management'],
+        help: ['tour-management'],
+      },
+    })
+
+    const { result } = renderHook(() => useTour())
+    startSettingsTour(result)
+
+    // Walk forward to step 4 (ai-byok-disclosure), skipping ai-quota.
+    clickNext() // → 1
+    clickNext() // → 2
+    clickNext() // → 4 via moveTo
+    expect(lastInstance!.getActiveIndex()).toBe(4)
+
+    // Backwards from 4: step 3 (ai-quota) is missing → jump to step 2.
+    clickPrev()
+    expect(lastInstance!.movePrevious).not.toHaveBeenCalled()
+    expect(lastInstance!.moveTo).toHaveBeenCalledWith(2)
+  })
+
+  it('completes the tour when every remaining target is missing', () => {
+    // The Help tab renders nothing: advancing from the Data step should end
+    // the tour cleanly instead of showing a detached popover.
+    setupSettingsDom({
+      tabs: ['ai-location', 'data', 'help'],
+      activeTab: 'data',
+      content: {
+        'ai-location': [
+          'ai-settings',
+          'ai-toggle',
+          'ai-quota',
+          'ai-byok-disclosure',
+          'location-settings',
+        ],
+        data: ['data-management'],
+        help: [],
+      },
+    })
+
+    const { result } = renderHook(() => useTour())
+    startSettingsTour(result)
+    expect(stepElements(lastConfig!)).toHaveLength(8)
+
+    // Jump straight to step 6 (data-management); index bookkeeping only.
+    act(() => {
+      lastInstance!.moveTo(6)
+    })
+    lastInstance!.moveTo.mockClear()
+
+    // Next would be step 7 (tour-management) on the empty Help tab: no live
+    // target remains, so the tour completes and tears down.
+    clickNext()
+    expect(lastInstance!.moveNext).not.toHaveBeenCalled()
+    expect(lastInstance!.moveTo).not.toHaveBeenCalled()
+    expect(lastInstance!.destroy).toHaveBeenCalled()
+    expect(result.current.isCompleted('settings')).toBe(true)
+  })
+})

--- a/src/hooks/useTour.ts
+++ b/src/hooks/useTour.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from 'react'
-import { driver, type Driver, type Config } from 'driver.js'
+import { driver, type Driver, type Config, type DriveStep } from 'driver.js'
 import { TourId, getTourDefinition, type SettingsTabStep } from '@/lib/tours/tour-definitions'
 
 const TOUR_STORAGE_KEY = 'bonnie-wee-plot-tours'
@@ -179,16 +179,41 @@ export function useTour(): UseTourReturn {
       return
     }
 
-    // Move to a step with tab switching and delay
-    const moveToStep = (targetIndex: number, onComplete?: () => void) => {
+    // The start-time filter can only inspect the active tab — inactive tab
+    // content is unmounted, so steps behind a tab switch pass through
+    // unchecked. This re-check runs once the step's tab has rendered.
+    const stepElementExists = (step: DriveStep): boolean => {
+      if (typeof step.element !== 'string') return true
+      return document.querySelector(step.element) !== null
+    }
+
+    // Move to a step with tab switching and delay. If the step's target is
+    // still missing after its tab renders (e.g. a section conditionally
+    // hidden inside that tab), keep walking in `direction` until a step
+    // with a live target is found. Calls back with the resolved index, or
+    // null when no step in that direction has a target in the DOM.
+    const moveToStep = (
+      targetIndex: number,
+      direction: 1 | -1,
+      onResolved: (resolvedIndex: number | null) => void
+    ) => {
+      if (targetIndex < 0 || targetIndex >= availableSteps.length) {
+        onResolved(null)
+        return
+      }
       const switched = switchToTab(targetIndex)
+      const verify = () => {
+        if (stepElementExists(availableSteps[targetIndex])) {
+          onResolved(targetIndex)
+        } else {
+          moveToStep(targetIndex + direction, direction, onResolved)
+        }
+      }
       if (switched) {
         // Delay to let React render the new tab content
-        setTimeout(() => {
-          onComplete?.()
-        }, 100)
+        setTimeout(verify, 100)
       } else {
-        onComplete?.()
+        verify()
       }
     }
 
@@ -223,8 +248,17 @@ export function useTour(): UseTourReturn {
           markCompleted(tourId)
           driverRef.current.destroy()
         } else if (hasTabSteps) {
-          moveToStep(currentIndex + 1, () => {
-            driverRef.current?.moveNext()
+          moveToStep(currentIndex + 1, 1, (resolvedIndex) => {
+            if (!driverRef.current) return
+            if (resolvedIndex === null) {
+              // Every remaining step's target is missing — the tour is done.
+              markCompleted(tourId)
+              driverRef.current.destroy()
+            } else if (resolvedIndex === currentIndex + 1) {
+              driverRef.current.moveNext()
+            } else {
+              driverRef.current.moveTo(resolvedIndex)
+            }
           })
         } else {
           driverRef.current.moveNext()
@@ -235,8 +269,17 @@ export function useTour(): UseTourReturn {
         if (hasTabSteps) {
           const currentIndex = driverRef.current.getActiveIndex() ?? 0
           if (currentIndex > 0) {
-            moveToStep(currentIndex - 1, () => {
-              driverRef.current?.movePrevious()
+            moveToStep(currentIndex - 1, -1, (resolvedIndex) => {
+              if (!driverRef.current) return
+              if (resolvedIndex === null) {
+                // Nothing behind has a live target; probing may have
+                // switched tabs, so restore the current step's tab and stay.
+                switchToTab(currentIndex)
+              } else if (resolvedIndex === currentIndex - 1) {
+                driverRef.current.movePrevious()
+              } else {
+                driverRef.current.moveTo(resolvedIndex)
+              }
             })
           }
         } else {
@@ -248,11 +291,27 @@ export function useTour(): UseTourReturn {
     // Small delay to ensure DOM is ready (longer if we switched tabs)
     const initialDelay = hasTabSteps ? 600 : 500
     setTimeout(() => {
-      const driverInstance = driver(config)
-      driverRef.current = driverInstance
+      const beginTour = (startIndex: number) => {
+        const driverInstance = driver(config)
+        driverRef.current = driverInstance
 
-      setIsActive(true)
-      driverInstance.drive()
+        setIsActive(true)
+        driverInstance.drive(startIndex)
+      }
+
+      // The first step's tab was switched in before the delay; if its
+      // target still didn't render, start from the next live step instead.
+      if (hasTabSteps && !stepElementExists(availableSteps[0])) {
+        moveToStep(1, 1, (resolvedIndex) => {
+          if (resolvedIndex === null) {
+            console.warn(`No elements found for tour "${tourId}"`)
+            return
+          }
+          beginTour(resolvedIndex)
+        })
+      } else {
+        beginTour(0)
+      }
     }, initialDelay)
   }, [markCompleted, markDismissed])
 


### PR DESCRIPTION
## Summary

Closes out the two non-blocking follow-ups tracked in `docs/plans/current-plan.md` from the AI/Settings UX sprint (#366–#371):

**1. `usePersistedStorage` auto-save falsy truthy-check — obsolete, note retired.** The flagged code path was the auto-save effect's `if (data && !isLoading)` in `src/hooks/usePersistedStorage.ts`. That entire file (and the auto-save write path with it) was deleted on `main` by ADR 027 Step 5 (#462), which retired the legacy storage chain in favour of the Yjs engine. The surviving storage hooks don't carry the pattern — `usePersistedState`'s auto-save effect writes unconditionally after hydration and guards loads with `stored !== null`, and `useSessionStorage`'s consumers are all string tokens whose `''` initial value round-trips through its intentional clear-on-empty behaviour. The stale plan note is deleted rather than "fixed".

**2. Tour element-existence filter — real bug, fixed.** The start-time filter in `useTour` can only inspect the active tab (the Tabs component unmounts inactive panels), so steps behind a tab switch passed through unchecked. Concrete failure: a signed-in user with a BYO OpenAI key (so `[data-tour="ai-quota"]` never renders) starting the settings tour from the Data or Help tab — driver.js landed on the missing target as a popover attached to nothing. `moveToStep` now re-checks the target once the step's tab has rendered and walks past missing steps in the direction of travel (forward, backward, and at tour start); when no remaining step has a live target, the tour completes cleanly instead of showing a detached popover. The signed-out Data → Help fallback is unchanged.

Plan updated with a closeout section; no behaviour changes beyond the tour fix.

## Related issue

Closes # (none — tracked as plan follow-ups, not issues)

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes (five new `useTour` tests: signed-out fallback, start-time filter, forward skip, backward skip, complete-on-exhausted; `type-check`, `lint`, `test:unit` (1502 passed), and `build` all green)
- [x] I have updated documentation if needed (`docs/plans/current-plan.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfcm2ckZ4Fu1Ge23YC1YyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfcm2ckZ4Fu1Ge23YC1YyC)_