### PR TITLE
fix(season-review): allow Open-Meteo Archive/Climate hosts in CSP

### DIFF
--- a/docs/plans/current-plan.md
+++ b/docs/plans/current-plan.md
@@ -1,6 +1,44 @@
 # Current Plan
 
-Last updated: 2026-07-21 (post-#492 cleanups: dead hook + useTour timer race)
+Last updated: 2026-07-22 (Season Review "no data" fix: CSP blocked Open-Meteo Archive)
+
+## Season Review showed no data — CSP `connect-src` omission (2026-07-22)
+
+**Symptom.** A user with several past-year seasons and plantings saw the
+`/season-review` page render nothing useful for 2025: the grey "Weather for
+2025 isn't available right now (offline, or not fetched yet)" note plus an
+empty findings list — persistently, even on good wifi after a reload.
+
+**Diagnosis (three empty states, ruled out one by one).** Not empty-state #1
+(`years.length === 0`) — several reviewable years existed. Not the rules being
+too strict — the engine's silence-on-thin-data discipline is intact. It was
+empty-state #3: `fetchSeasonWeather(coords, year)` returned `null`, so
+`weatherStatus` became `'unavailable'`, which makes **8 of the 10 rules
+early-return `[]`** (every rule guarded by `if (!input.weather) return []`),
+and the two log-only rules stayed silent on sparse logs → zero findings.
+
+**Root cause.** The CSP `connect-src` allowlist in `src/middleware.ts` listed
+`https://api.open-meteo.com` (the forecast host) but **not
+`https://archive-api.open-meteo.com`** — the distinct host the Season Review
+archive service (`src/lib/weather/open-meteo-archive.ts`) calls, nor
+`https://climate-api.open-meteo.com` used by frost-dates
+(`src/lib/weather/frost-dates.ts`, Today page). The browser blocked every
+archive/climate request before it left the page (works from `curl` because
+curl isn't subject to the page CSP; the endpoint itself is healthy — verified
+HTTP 200, CORS `*`, 365 days for 2025). Weather backfill logic was **not** the
+gap: `fetchSeasonWeather` and `getBaseline` already backfill any past year
+on demand and cache correctly — they just never got the chance to run.
+
+**Fix.** Extracted the CSP builder into `src/lib/security/csp.ts` (so it's
+unit-testable without the Clerk middleware wrapper) and added both missing
+Open-Meteo hosts to `connect-src`. A `BROWSER_FETCH_ORIGINS` map plus
+`src/__tests__/lib/security/csp.test.ts` now assert every browser-fetched
+origin is present — the guardrail that would have caught this omission when
+the archive service was added. Rules engine, thresholds, and Yjs persistence
+untouched; nothing new is written to the doc. After the fix, 2025 populates:
+archive + 10-year baseline fetch, the 5 plot-wide weather rules (temp/rain
+anomaly, dry-spell, water-deficit, dull-month) fire from weather alone, and
+the weather table + per-planting soil/GDD figures render.
 
 ## Post-#492 cleanups (2026-07-21)
 

--- a/src/__tests__/lib/security/csp.test.ts
+++ b/src/__tests__/lib/security/csp.test.ts
@@ -37,6 +37,24 @@ describe('buildCspHeader', () => {
     expect(connectSrc).toContain('https://climate-api.open-meteo.com')
   })
 
+  it('allows the auth/sync/telemetry SDK hosts and the local narration preset', () => {
+    // These connect from the browser too, so they belong in the guardrail —
+    // dropping any of them must fail this test, not silently break a feature.
+    const connectSrc = csp['connect-src'] ?? []
+    expect(connectSrc).toContain('https://*.clerk.accounts.dev') // auth
+    expect(connectSrc).toContain('https://*.supabase.co') // cloud sync
+    expect(connectSrc).toContain('https://*.ingest.sentry.io') // telemetry
+    expect(connectSrc).toContain('http://localhost:11434') // Ollama narration
+    expect(connectSrc).toContain('http://127.0.0.1:11434')
+  })
+
+  it('derives connect-src from BROWSER_FETCH_ORIGINS (self + every listed origin)', () => {
+    // Guards the single-source-of-truth wiring: the policy is exactly 'self'
+    // plus the map, so the two cannot drift apart.
+    const connectSrc = csp['connect-src'] ?? []
+    expect(connectSrc).toEqual(["'self'", ...Object.values(BROWSER_FETCH_ORIGINS)])
+  })
+
   it('keeps the security-critical directives locked down', () => {
     expect(csp['default-src']).toEqual(["'self'"])
     expect(csp['frame-ancestors']).toEqual(["'none'"])

--- a/src/__tests__/lib/security/csp.test.ts
+++ b/src/__tests__/lib/security/csp.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { buildCspHeader, BROWSER_FETCH_ORIGINS } from '@/lib/security/csp'
+
+/**
+ * Parse a CSP header string into { directive: [values] }. Mirrors how a
+ * browser reads the policy, so assertions match real enforcement.
+ */
+function parseCsp(header: string): Record<string, string[]> {
+  const out: Record<string, string[]> = {}
+  for (const part of header.split(';')) {
+    const [directive, ...values] = part.trim().split(/\s+/)
+    if (directive) out[directive] = values
+  }
+  return out
+}
+
+describe('buildCspHeader', () => {
+  const csp = parseCsp(buildCspHeader())
+
+  it('lists every browser-fetched origin in connect-src', () => {
+    // The guardrail: any host our client code hits with fetch() must be here,
+    // or the request is blocked before it leaves the page and the feature
+    // silently degrades. This caught the Season Review archive host omission
+    // (weather stuck "unavailable", 8/10 rules silent, page showed no data).
+    const connectSrc = csp['connect-src'] ?? []
+    for (const origin of Object.values(BROWSER_FETCH_ORIGINS)) {
+      expect(connectSrc, `connect-src must allow ${origin}`).toContain(origin)
+    }
+  })
+
+  it('allows all three distinct Open-Meteo hosts the app fetches', () => {
+    // Forecast (Today), Archive (Season Review) and Climate (frost dates) are
+    // separate subdomains — a wildcard is not used, so each must be explicit.
+    const connectSrc = csp['connect-src'] ?? []
+    expect(connectSrc).toContain('https://api.open-meteo.com')
+    expect(connectSrc).toContain('https://archive-api.open-meteo.com')
+    expect(connectSrc).toContain('https://climate-api.open-meteo.com')
+  })
+
+  it('keeps the security-critical directives locked down', () => {
+    expect(csp['default-src']).toEqual(["'self'"])
+    expect(csp['frame-ancestors']).toEqual(["'none'"])
+    expect(csp['base-uri']).toEqual(["'self'"])
+    expect(csp['form-action']).toEqual(["'self'"])
+  })
+
+  it('does not expose server-only AI hosts to the browser', () => {
+    // Gemini is called from the season-narration / ai-advisor API routes
+    // (server-to-server), never the browser, so it must not appear here.
+    expect(buildCspHeader()).not.toContain('generativelanguage.googleapis.com')
+  })
+})

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -1,0 +1,81 @@
+/**
+ * Content-Security-Policy for the app, extracted from the middleware so it can
+ * be unit-tested without pulling in Clerk's middleware wrapper.
+ *
+ * The `connect-src` allowlist is the one that bites silently: every host the
+ * browser reaches with `fetch()` (weather, geocoding, BYO AI narration, Clerk,
+ * Supabase, Sentry) must be listed, or the request is blocked before it leaves
+ * the page — no network error the user can act on, just a failed fetch that
+ * degrades a feature to "unavailable". Server-to-server calls (e.g. the Gemini
+ * proxy in the season-narration / ai-advisor API routes) are NOT subject to
+ * this and must stay out of the list.
+ *
+ * When adding a browser-side fetch to a new host, add it here and to
+ * `csp.test.ts`'s coverage assertion.
+ */
+
+/**
+ * Origins the browser fetches directly. Kept as a named export so the CSP test
+ * can assert every one is present in `connect-src` — the guardrail that caught
+ * the Season Review archive host being omitted (weather stuck "unavailable").
+ */
+export const BROWSER_FETCH_ORIGINS = {
+  /** Open-Meteo forecast API — Today-page current weather (open-meteo.ts). */
+  openMeteoForecast: 'https://api.open-meteo.com',
+  /** Open-Meteo Archive API — Season Review historical weather (open-meteo-archive.ts). */
+  openMeteoArchive: 'https://archive-api.open-meteo.com',
+  /** Open-Meteo Climate API — frost-date normals (frost-dates.ts). */
+  openMeteoClimate: 'https://climate-api.open-meteo.com',
+  /** BigDataCloud reverse geocoding (two endpoints). */
+  bigDataCloud: 'https://api.bigdatacloud.net',
+  bigDataCloudBdc: 'https://api-bdc.io',
+  /** OpenAI — BYO-key narration/advisor when the user picks the OpenAI preset. */
+  openai: 'https://api.openai.com',
+} as const
+
+function buildCspDirectives(): Record<string, string[]> {
+  return {
+    'default-src': ["'self'"],
+    'script-src': [
+      "'self'", "'unsafe-eval'", "'unsafe-inline'",
+      'https://*.clerk.accounts.dev',
+      'https://challenges.cloudflare.com',
+    ],
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'connect-src': [
+      "'self'",
+      // Season-review narration default preset: the user's own local Ollama.
+      // Browsers exempt localhost from mixed-content blocking, but CSP still
+      // needs the origin. Custom remote narration endpoints require adding
+      // their origin here.
+      'http://localhost:11434',
+      'http://127.0.0.1:11434',
+      BROWSER_FETCH_ORIGINS.openai,
+      BROWSER_FETCH_ORIGINS.bigDataCloud,
+      BROWSER_FETCH_ORIGINS.bigDataCloudBdc,
+      BROWSER_FETCH_ORIGINS.openMeteoForecast,
+      // Archive + Climate are distinct Open-Meteo hosts from the forecast API;
+      // each must be listed separately or its weather feature (Season Review,
+      // frost dates) silently degrades to "unavailable".
+      BROWSER_FETCH_ORIGINS.openMeteoArchive,
+      BROWSER_FETCH_ORIGINS.openMeteoClimate,
+      'https://*.clerk.accounts.dev',
+      'https://*.supabase.co',
+      'https://*.ingest.sentry.io',
+    ],
+    'img-src': ["'self'", 'data:', 'blob:', 'https://images.unsplash.com', 'https://img.clerk.com'],
+    'font-src': ["'self'"],
+    'worker-src': ["'self'", 'blob:'], // blob: required by Clerk for CAPTCHA web workers
+    'frame-src': ["'self'", 'https://*.clerk.accounts.dev', 'https://challenges.cloudflare.com'],
+    'frame-ancestors': ["'none'"],
+    'base-uri': ["'self'"],
+    'form-action': ["'self'"],
+  }
+}
+
+/** Serialise the CSP directives into a single header value. */
+export function buildCspHeader(): string {
+  return Object.entries(buildCspDirectives())
+    .map(([directive, values]) => `${directive} ${values.join(' ')}`)
+    .join('; ')
+}

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -3,34 +3,50 @@
  * be unit-tested without pulling in Clerk's middleware wrapper.
  *
  * The `connect-src` allowlist is the one that bites silently: every host the
- * browser reaches with `fetch()` (weather, geocoding, BYO AI narration, Clerk,
- * Supabase, Sentry) must be listed, or the request is blocked before it leaves
- * the page — no network error the user can act on, just a failed fetch that
- * degrades a feature to "unavailable". Server-to-server calls (e.g. the Gemini
- * proxy in the season-narration / ai-advisor API routes) are NOT subject to
- * this and must stay out of the list.
+ * browser reaches with `fetch()` / SDK network calls (weather, geocoding, BYO
+ * AI narration, Clerk, Supabase, Sentry) must be listed, or the request is
+ * blocked before it leaves the page — no network error the user can act on,
+ * just a failed request that degrades a feature to "unavailable". Server-to-
+ * server calls (e.g. the Gemini proxy in the season-narration / ai-advisor API
+ * routes) are NOT subject to this and must stay out of the list.
  *
- * When adding a browser-side fetch to a new host, add it here and to
- * `csp.test.ts`'s coverage assertion.
+ * `connect-src` is derived from `BROWSER_FETCH_ORIGINS` below, so the tested
+ * guardrail list and the enforced policy can never drift: to allow a new
+ * browser-reached host, add it to the map and it lands in the header and the
+ * coverage assertion at once.
  */
 
 /**
- * Origins the browser fetches directly. Kept as a named export so the CSP test
- * can assert every one is present in `connect-src` — the guardrail that caught
- * the Season Review archive host being omitted (weather stuck "unavailable").
+ * Every origin the browser connects to directly (fetch/XHR/WebSocket/SDK).
+ * The single source of truth for `connect-src`: the CSP header is built from
+ * these values, and `csp.test.ts` asserts each one is present — the guardrail
+ * that caught the Season Review archive host being omitted (weather stuck
+ * "unavailable", 8/10 rules silent, the page showed no data).
+ *
+ * Anything reached only from server code (API routes) must NOT be added here.
  */
 export const BROWSER_FETCH_ORIGINS = {
-  /** Open-Meteo forecast API — Today-page current weather (open-meteo.ts). */
-  openMeteoForecast: 'https://api.open-meteo.com',
-  /** Open-Meteo Archive API — Season Review historical weather (open-meteo-archive.ts). */
-  openMeteoArchive: 'https://archive-api.open-meteo.com',
-  /** Open-Meteo Climate API — frost-date normals (frost-dates.ts). */
-  openMeteoClimate: 'https://climate-api.open-meteo.com',
-  /** BigDataCloud reverse geocoding (two endpoints). */
+  // Season-review narration default preset: the user's own local Ollama.
+  // Browsers exempt localhost from mixed-content blocking, but CSP still needs
+  // the origin. Custom remote narration endpoints require adding their origin.
+  ollamaLocalhost: 'http://localhost:11434',
+  ollamaLoopback: 'http://127.0.0.1:11434',
+  // BYO-key narration/advisor when the user picks the OpenAI preset.
+  openai: 'https://api.openai.com',
+  // BigDataCloud reverse geocoding (two endpoints).
   bigDataCloud: 'https://api.bigdatacloud.net',
   bigDataCloudBdc: 'https://api-bdc.io',
-  /** OpenAI — BYO-key narration/advisor when the user picks the OpenAI preset. */
-  openai: 'https://api.openai.com',
+  // Open-Meteo: three DISTINCT hosts (no wildcard), each fetched by the app —
+  // forecast (Today weather), archive (Season Review historical weather),
+  // climate (frost-date normals). Each must be listed separately.
+  openMeteoForecast: 'https://api.open-meteo.com',
+  openMeteoArchive: 'https://archive-api.open-meteo.com',
+  openMeteoClimate: 'https://climate-api.open-meteo.com',
+  // Clerk browser SDK (auth), Supabase browser client (cloud sync), and the
+  // Sentry browser SDK (error/telemetry ingest) all connect from the page.
+  clerk: 'https://*.clerk.accounts.dev',
+  supabase: 'https://*.supabase.co',
+  sentry: 'https://*.ingest.sentry.io',
 } as const
 
 function buildCspDirectives(): Record<string, string[]> {
@@ -42,27 +58,9 @@ function buildCspDirectives(): Record<string, string[]> {
       'https://challenges.cloudflare.com',
     ],
     'style-src': ["'self'", "'unsafe-inline'"],
-    'connect-src': [
-      "'self'",
-      // Season-review narration default preset: the user's own local Ollama.
-      // Browsers exempt localhost from mixed-content blocking, but CSP still
-      // needs the origin. Custom remote narration endpoints require adding
-      // their origin here.
-      'http://localhost:11434',
-      'http://127.0.0.1:11434',
-      BROWSER_FETCH_ORIGINS.openai,
-      BROWSER_FETCH_ORIGINS.bigDataCloud,
-      BROWSER_FETCH_ORIGINS.bigDataCloudBdc,
-      BROWSER_FETCH_ORIGINS.openMeteoForecast,
-      // Archive + Climate are distinct Open-Meteo hosts from the forecast API;
-      // each must be listed separately or its weather feature (Season Review,
-      // frost dates) silently degrades to "unavailable".
-      BROWSER_FETCH_ORIGINS.openMeteoArchive,
-      BROWSER_FETCH_ORIGINS.openMeteoClimate,
-      'https://*.clerk.accounts.dev',
-      'https://*.supabase.co',
-      'https://*.ingest.sentry.io',
-    ],
+    // Built from BROWSER_FETCH_ORIGINS so the policy and the tested guardrail
+    // list stay in lockstep — see the module and BROWSER_FETCH_ORIGINS docs.
+    'connect-src': ["'self'", ...Object.values(BROWSER_FETCH_ORIGINS)],
     'img-src': ["'self'", 'data:', 'blob:', 'https://images.unsplash.com', 'https://img.clerk.com'],
     'font-src': ["'self'"],
     'worker-src': ["'self'", 'blob:'], // blob: required by Clerk for CAPTCHA web workers

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,50 +1,12 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { clerkMiddleware } from '@clerk/nextjs/server'
+import { buildCspHeader } from '@/lib/security/csp'
 
 // Clerk is available via explicit keys or keyless mode (dev only)
 const hasClerkKeys = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 const isKeylessMode = !hasClerkKeys && process.env.NODE_ENV === 'development'
 const clerkAvailable = hasClerkKeys || isKeylessMode
-
-function buildCspHeader(): string {
-  const directives: Record<string, string[]> = {
-    'default-src': ["'self'"],
-    'script-src': [
-      "'self'", "'unsafe-eval'", "'unsafe-inline'",
-      'https://*.clerk.accounts.dev',
-      'https://challenges.cloudflare.com',
-    ],
-    'style-src': ["'self'", "'unsafe-inline'"],
-    'connect-src': [
-      "'self'",
-      // Season-review narration default preset: the user's own local Ollama.
-      // Browsers exempt localhost from mixed-content blocking, but CSP still
-      // needs the origin. Custom remote narration endpoints require adding
-      // their origin here.
-      'http://localhost:11434',
-      'http://127.0.0.1:11434',
-      'https://api.openai.com',
-      'https://api.bigdatacloud.net',
-      'https://api-bdc.io',
-      'https://api.open-meteo.com',
-      'https://*.clerk.accounts.dev',
-      'https://*.supabase.co',
-      'https://*.ingest.sentry.io',
-    ],
-    'img-src': ["'self'", 'data:', 'blob:', 'https://images.unsplash.com', 'https://img.clerk.com'],
-    'font-src': ["'self'"],
-    'worker-src': ["'self'", 'blob:'], // blob: required by Clerk for CAPTCHA web workers
-    'frame-src': ["'self'", 'https://*.clerk.accounts.dev', 'https://challenges.cloudflare.com'],
-    'frame-ancestors': ["'none'"],
-    'base-uri': ["'self'"],
-    'form-action': ["'self'"],
-  }
-
-  return Object.entries(directives)
-    .map(([directive, values]) => `${directive} ${values.join(' ')}`)
-    .join('; ')
-}
 
 function addSecurityHeaders(response: NextResponse) {
   response.headers.set('Content-Security-Policy', buildCspHeader())


### PR DESCRIPTION
## Summary

The `/season-review` page showed **no data** for a plot with several past-year seasons and plantings — a persistent grey *"Weather for 2025 isn't available right now (offline, or not fetched yet)"* note plus an empty findings list, even on good wifi after a reload.

**Root cause:** the CSP `connect-src` allowlist in `src/middleware.ts` listed the Open-Meteo *forecast* host (`https://api.open-meteo.com`) but **not `https://archive-api.open-meteo.com`** — the distinct host the Season Review archive service (`src/lib/weather/open-meteo-archive.ts`) fetches. The browser blocked every archive request before it left the page, so `fetchSeasonWeather` returned `null`, `weatherStatus` became `'unavailable'`, and **8 of the 10 rules** (all guarded by `if (!input.weather) return []`) went silent — with sparse logs, the two log-only rules stayed silent too, giving zero findings. The endpoint itself is healthy (verified HTTP 200, CORS `*`, 365 days for 2025); it works from `curl` precisely because curl isn't subject to the page CSP.

`https://climate-api.open-meteo.com` (frost-dates, Today page — `src/lib/weather/frost-dates.ts`) was missing for the same reason and is added alongside.

**What was *not* the gap:** the weather backfill logic. `fetchSeasonWeather` and `getBaseline` already fetch any past year on demand and cache correctly — they just never got the chance to run. The rules engine's silence-on-thin-data discipline is intact; no thresholds were touched and nothing new is persisted to the Yjs doc.

### Changes
- Extracted the CSP builder into `src/lib/security/csp.ts` so it is unit-testable without the Clerk middleware wrapper.
- Added `https://archive-api.open-meteo.com` and `https://climate-api.open-meteo.com` to `connect-src`.
- Added a `BROWSER_FETCH_ORIGINS` map + `src/__tests__/lib/security/csp.test.ts` asserting every browser-fetched origin appears in `connect-src` — the guardrail that would have caught this when the archive service was added. Also asserts server-only Gemini stays out of the browser policy.
- Updated `docs/plans/current-plan.md`.

After the fix, 2025 populates: the archive fetch + 10-year baseline load, the 5 plot-wide weather rules (temp/rain anomaly, dry-spell, water-deficit, dull-month) fire from weather alone (no logs needed), and the weather-vs-baseline table and per-planting soil/GDD figures render.

## Related issue

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update

## Checklist

- [x] I have tested my changes — `type-check`, `lint`, `test:unit` (1508 passed / 11 skipped), and `build` all pass; new CSP regression test added
- [x] I have updated documentation if needed — `docs/plans/current-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDa9hLE4zF89Eg6DXuz8d1)_