### PR TITLE
fix(deps): bump fast-uri to 3.1.4 (GHSA-4c8g-83qw-93j6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6550,9 +6550,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Two dependency-maintenance jobs were scoped for this branch. The first shipped; the second was investigated and deliberately abandoned because its premise turned out to be false. Only `package-lock.json` changes here — `package.json` is untouched.

### Job 1 — fast-uri high-severity advisory (shipped)

GHSA-4c8g-83qw-93j6, high severity, `fast-uri` vulnerable `>= 3.0.0 < 3.1.3`, first patched 3.1.3.

**Before 3.1.2 → after 3.1.4.**

The package is transitive: `ajv@8.18.0` (vendored under both `ajv-formats` and `schema-utils`) requires it at `^3.0.1`. That caret already admits 3.1.3+, so `npm update fast-uri --package-lock-only` was sufficient on its own. No `package.json` change, no `overrides` entry, no major bump — a three-line lockfile edit.

### Job 2 — the "redundant" postcss override (NOT done, premise disproved)

The plan was to delete `postcss` from `overrides` on the theory that it is redundant with the identical `^8.5.10` direct devDependency, and that the redundancy is what makes Dependabot's own updater error out and retry. Half that premise holds and half does not, so the override stays.

The true half: `postcss` really does appear twice at identical ranges, `devDependencies: "^8.5.10"` and `overrides: "^8.5.10"`.

The false half: a duplicate-looking range does not mean the override is inert. The devDependency governs only the root's own postcss, whereas the override rewrites *transitive consumers'* pins — and one transitive consumer carries an exact pin, `next`, which depends on `postcss` at exactly `8.4.31`.

Controlled experiment, the same `npm install --package-lock-only` re-resolve run with and without the override so that re-resolution drift is held constant:

| | hoisted `postcss` | nested under `next` | total packages |
|---|---|---|---|
| override kept (control) | 8.5.13 | none | 916 |
| override removed | 8.5.23 | **8.4.31** | 917 |

Removing it adds exactly one package: a second, older `node_modules/next/node_modules/postcss@8.4.31`. That is a resolved-version change, so by the pre-agreed gate — if removing it changes the resolved version, it is load-bearing and must stay — Job 2 is aborted. The override is the only thing collapsing next's exact `8.4.31` pin onto the modern hoisted copy, and deleting it would silently reintroduce an older postcss.

For whoever picks up the Dependabot-retry symptom: that diagnosis needs a different root cause. A more plausible candidate is the override's own resolution being stale — `^8.5.10` sits pinned at 8.5.13 in the lockfile while 8.5.23 is published, and 8.5.13 is itself inside the vulnerable range of a separate open high advisory (see below).

## Test plan

Verified locally on Node 26.5.0 / npm 11.17.0. CI pins Node 25, so local-only oddities would warrant suspicion — none arose.

- `npm ci` — clean
- `npm run lint` (`eslint . --max-warnings 0`) — pass, zero warnings
- `npm run type-check` (`tsc --noEmit`) — pass
- `npm run test:unit` (vitest) — 95 files passed / 1 skipped; 1510 tests passed / 11 skipped; 0 failed
- `npm run build` (`next build`) — success, all routes emitted

No baseline re-run on the unmodified base commit was required, because nothing failed. A lockfile-only patch bump of a URI parser has no plausible failure surface here and the suite is fully green.

`npm test` (Playwright e2e) was not run locally as it needs browser downloads; CI's E2E job covers it.

## Remaining npm audit highs

`npm audit --audit-level=high` goes from 6 highs to 5, with `fast-uri` gone. Dependabot has alerted on **none** of these 5 yet, and npm audit leads Dependabot by minutes to hours, so they should be expected to arrive as alerts:

| package | vulnerable range | direct | non-major fix available |
|---|---|---|---|
| `postcss` | `<= 8.5.17` | yes | yes |
| `next` | `>= 9.3.4-canary.0` | yes | yes |
| `sharp` | `< 0.35.0` | no | yes |
| `js-yaml` | `4.0.0 - 4.2.0` | no | yes |
| `brace-expansion` | `<= 5.0.7` | no | yes |

All five report a non-major fix available, so they are plausibly clearable without a breaking bump, but each needs its own verification pass and all are out of scope here. The `postcss` row is the notable one given Job 2: refreshing the override's resolution from 8.5.13 to 8.5.23 would clear it, which is worth doing deliberately as a follow-up rather than as a side effect of this PR.

## Gold tier impact

This clears the only Dependabot-alerted high on the repo, taking the Dependabot high/critical count to zero and unblocking the Gold "Zero critical/high security findings" check as that check reads it. To be precise, though, the check is satisfied via Dependabot's view rather than npm audit's — the five highs above are real and will likely surface as alerts before long, at which point Gold regresses until they are handled.

Untouched as instructed: Dependabot PRs #429 and #436. No Dependabot alert was dismissed or altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
